### PR TITLE
Renamed typescript model to match API data structure

### DIFF
--- a/atcoder-problems-frontend/src/components/Category.tsx
+++ b/atcoder-problems-frontend/src/components/Category.tsx
@@ -40,8 +40,8 @@ export class Category extends React.Component<CategoryProps, {}> {
     let problemMap = new Map<string, Array<Problem>>();
     this.props.contests.forEach(contest => problemMap.set(contest.id, []));
     this.props.problems
-      .filter(problem => problemMap.has(problem.contestId))
-      .forEach(problem => problemMap.get(problem.contestId).push(problem));
+      .filter(problem => problemMap.has(problem.contest_id))
+      .forEach(problem => problemMap.get(problem.contest_id).push(problem));
 
     // filter problems of AtCoder official contests
     let agc = this.filterProblems(problemMap, /^agc\d{3}$/);

--- a/atcoder-problems-frontend/src/components/LanguageOwners.tsx
+++ b/atcoder-problems-frontend/src/components/LanguageOwners.tsx
@@ -42,9 +42,9 @@ export class LanguageOwners extends React.Component<
               .sort((a, b) => b.count - a.count)
               .slice(0, 3)
               .map((count, rank) => (
-                <Col key={count.userId} xs={4} sm={4}>
+                <Col key={count.user_id} xs={4} sm={4}>
                   <h4>{rankLabels[rank]}</h4>
-                  <h3>{count.userId}</h3>
+                  <h3>{count.user_id}</h3>
                   <span className="text-muted">{count.count} AC</span>
                 </Col>
               ))}

--- a/atcoder-problems-frontend/src/components/List.tsx
+++ b/atcoder-problems-frontend/src/components/List.tsx
@@ -155,7 +155,7 @@ export class List extends React.Component<ListProps, ListState> {
       });
 
     let data: Array<ProblemRow> = this.props.problems
-      .filter(p => contestMap.has(p.contestId))
+      .filter(p => contestMap.has(p.contest_id))
       .filter(p => {
         if (this.state.onlyRated && !p.point) {
           return false;
@@ -168,7 +168,7 @@ export class List extends React.Component<ListProps, ListState> {
         }
       })
       .map(problem => {
-        let contest = contestMap.get(problem.contestId);
+        let contest = contestMap.get(problem.contest_id);
         let point = problem.point
           ? problem.point
           : problem.predict ? problem.predict : INF;

--- a/atcoder-problems-frontend/src/components/UserPage.tsx
+++ b/atcoder-problems-frontend/src/components/UserPage.tsx
@@ -43,7 +43,7 @@ export class UserPage extends React.Component<UserPageProps, {}> {
       .map(s => s.epoch_second);
 
     this.props.problems
-      .filter(problem => problem.contestId.match(/^a[rgb]c\d{3}$/))
+      .filter(problem => problem.contest_id.match(/^a[rgb]c\d{3}$/))
       .forEach(problem => {
         // get problem id
         let c = problem.id.slice(-1);

--- a/atcoder-problems-frontend/src/components/UserPageAchievements.tsx
+++ b/atcoder-problems-frontend/src/components/UserPageAchievements.tsx
@@ -100,7 +100,7 @@ export class UserPageAchievements extends React.Component<
           var rank = 0;
           var count = 0;
           a.ranking.forEach(r => {
-            if (r.userId === this.props.userId) {
+            if (r.user_id === this.props.userId) {
               rank = r.rank;
               count = r.count;
             }

--- a/atcoder-problems-frontend/src/components/UserPageLanguages.tsx
+++ b/atcoder-problems-frontend/src/components/UserPageLanguages.tsx
@@ -27,7 +27,7 @@ export class UserPageLanguages extends React.Component<
   }
 
   render() {
-    let counts = this.state.counts.filter(c => c.userId === this.props.userId);
+    let counts = this.state.counts.filter(c => c.user_id === this.props.userId);
 
     let languageCountMap = new Map<string, number>();
     let languageRankMap = new Map<string, number>();

--- a/atcoder-problems-frontend/src/components/UserPageTable.tsx
+++ b/atcoder-problems-frontend/src/components/UserPageTable.tsx
@@ -66,7 +66,7 @@ export class UserPageTable extends React.Component<UserPageTableProps, {}> {
           dataField="problem_id"
           dataFormat={(problemId: string, submission: Submission) => {
             let url = UrlFormatter.problemUrl(
-              submission.contestId,
+              submission.contest_id,
               submission.problem_id
             );
             let problem = problemMap.get(problemId);
@@ -105,7 +105,7 @@ export class UserPageTable extends React.Component<UserPageTableProps, {}> {
           dataField="id"
           dataFormat={(id: number, submission: Submission) => {
             let url = UrlFormatter.submissionUrl(
-              submission.contestId,
+              submission.contest_id,
               submission.id
             );
             return HtmlFormatter.createLink(url, "details");

--- a/atcoder-problems-frontend/src/model/LangCount.tsx
+++ b/atcoder-problems-frontend/src/model/LangCount.tsx
@@ -1,5 +1,5 @@
 export interface LangCount {
-  userId: string;
+  user_id: string;
   count: number;
   language: string;
 }

--- a/atcoder-problems-frontend/src/model/MergedProblem.tsx
+++ b/atcoder-problems-frontend/src/model/MergedProblem.tsx
@@ -2,7 +2,7 @@ import { Problem } from "./Problem";
 
 export interface MergedProblem extends Problem {
   id: string;
-  contestId: string;
+  contest_id: string;
   solver_count: number;
   title: string;
 

--- a/atcoder-problems-frontend/src/model/Problem.tsx
+++ b/atcoder-problems-frontend/src/model/Problem.tsx
@@ -1,5 +1,5 @@
 export interface Problem {
-  contestId: string;
+  contest_id: string;
   id: string;
   title: string;
 }

--- a/atcoder-problems-frontend/src/model/RankPair.tsx
+++ b/atcoder-problems-frontend/src/model/RankPair.tsx
@@ -1,5 +1,5 @@
 export interface RankPair {
   rank: number;
-  userId: string;
+  user_id: string;
   count: number;
 }

--- a/atcoder-problems-frontend/src/model/Submission.tsx
+++ b/atcoder-problems-frontend/src/model/Submission.tsx
@@ -8,5 +8,5 @@ export interface Submission {
   language: string;
   length: number;
   execution_time: number;
-  contestId: string;
+  contest_id: string;
 }

--- a/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
@@ -184,7 +184,7 @@ test("parse language count", () => {
     .ApiCall.getLanguageCounts()
     .then((counts: LangCount[]) => {
       expect(counts[0]).toEqual({
-        userId: "AGE",
+        user_id: "AGE",
         count: 3,
         language: "Rust"
       });

--- a/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
@@ -156,12 +156,12 @@ test("parse ranking", () => {
     .ApiCall.getRanking()
     .then((ranks: RankPair[]) => {
       expect(ranks[0]).toEqual({
-        userId: "AGE",
+        user_id: "AGE",
         count: 3,
         rank: 1
       });
       expect(ranks[1]).toEqual({
-        userId: "Abcdefgprogrammi",
+        user_id: "Abcdefgprogrammi",
         count: 1,
         rank: 2
       });

--- a/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
@@ -21,7 +21,7 @@ test("get and parse problems", () => {
         {
           id: "problem-id",
           title: "problem title",
-          contestId: "contest-id"
+          contest_id: "contest-id"
         }
       ]);
     });
@@ -58,7 +58,7 @@ test("get and parse merged problems", () => {
     .then((problems: MergedProblem[]) => {
       expect(problems).toEqual([
         {
-          contestId: "arc057",
+          contest_id: "arc057",
           execution_time: 19,
           fastest_contest_id: "arc057",
           fastest_submission_id: 1002161,

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -101,13 +101,7 @@ export class ApiCall {
   static getLanguageCounts(): Promise<Array<LangCount>> {
     let url = `${this.BaseUrl}/info/lang`;
     return this.getJson(url).then((obj: Array<any>) => {
-      let counts: LangCount[] = obj.map(o => {
-        return {
-          count: o["count"],
-          language: o["language"],
-          userId: o["user_id"]
-        };
-      });
+      let counts: LangCount[] = obj.map(o => o as LangCount);
       return counts;
     });
   }

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -85,20 +85,7 @@ export class ApiCall {
     query?: { user: string; rivals: string }
   ): Promise<Array<Submission>> {
     return this.getJson(url, query).then((obj: Array<any>) => {
-      let submissions: Submission[] = obj.map(o => {
-        return {
-          point: o["point"],
-          result: o["result"],
-          problem_id: o["problem_id"],
-          user_id: o["user_id"],
-          epoch_second: o["epoch_second"],
-          id: o["id"],
-          language: o["language"],
-          length: o["length"],
-          contestId: o["contest_id"],
-          execution_time: o["execution_time"]
-        };
-      });
+      let submissions: Submission[] = obj.map(o => o as Submission);
       return submissions;
     });
   }

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -29,10 +29,7 @@ export class ApiCall {
   static getProblems(): Promise<Array<Problem>> {
     let url = `${this.BaseUrl}/info/problems`;
     return this.getJson(url).then((obj: Array<any>) => {
-      let problems: Problem[] = obj.map(o => {
-        let p = { id: o["id"], title: o["title"], contestId: o["contest_id"] };
-        return p;
-      });
+      let problems: Problem[] = obj.map(o => o as Problem);
       return problems;
     });
   }
@@ -109,27 +106,7 @@ export class ApiCall {
   static getMergedProblems(): Promise<Array<MergedProblem>> {
     let url = `${this.BaseUrl}/info/merged-problems`;
     return this.getJson(url).then((obj: Array<any>) => {
-      let problems: MergedProblem[] = obj.map(o => {
-        return {
-          first_submission_id: o["first_submission_id"],
-          solver_count: o["solver_count"],
-          fastest_user_id: o["fastest_user_id"],
-          execution_time: o["execution_time"],
-          shortest_user_id: o["shortest_user_id"],
-          shortest_submission_id: o["shortest_submission_id"],
-          contestId: o["contest_id"],
-          id: o["id"],
-          fastest_submission_id: o["fastest_submission_id"],
-          first_user_id: o["first_user_id"],
-          title: o["title"],
-          source_code_length: o["source_code_length"],
-          fastest_contest_id: o["fastest_contest_id"],
-          shortest_contest_id: o["shortest_contest_id"],
-          first_contest_id: o["first_contest_id"],
-          point: o["point"],
-          predict: o["predict"]
-        };
-      });
+      let problems: MergedProblem[] = obj.map(o => o as MergedProblem);
       return problems;
     });
   }

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -78,13 +78,7 @@ export class ApiCall {
   static getContests(): Promise<Array<Contest>> {
     let url = `${this.BaseUrl}/info/contests`;
     return this.getJson(url).then((obj: Array<any>) => {
-      let contests: Contest[] = obj.map(o => {
-        return {
-          id: o["id"],
-          title: o["title"],
-          start_epoch_second: o["start_epoch_second"]
-        };
-      });
+      let contests: Contest[] = obj.map(o => o as Contest);
       return contests;
     });
   }

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -38,7 +38,7 @@ export class ApiCall {
     let url = `${this.BaseUrl}/info/${kind}`;
     return this.getJson(url).then((obj: Array<any>) => {
       let ranks = obj.map(o => {
-        let p = { rank: 1, userId: o["user_id"], count: o["problem_count"] };
+        let p = { rank: 1, user_id: o["user_id"], count: o["problem_count"] };
         return p;
       });
 
@@ -50,7 +50,7 @@ export class ApiCall {
     let url = `${this.BaseUrl}/info/sums`;
     return this.getJson(url).then((obj: Array<any>) => {
       let ranks = obj.map(o => {
-        let p = { rank: 1, userId: o["user_id"], count: o["point_sum"] };
+        let p = { rank: 1, user_id: o["user_id"], count: o["point_sum"] };
         return p;
       });
 

--- a/atcoder-problems-frontend/src/utils/HtmlFormatter.test.tsx
+++ b/atcoder-problems-frontend/src/utils/HtmlFormatter.test.tsx
@@ -23,7 +23,7 @@ test("get cell color", () => {
   let wrong = new Map([[wrongProblemId, "WA"], [wrongAndRival, "RE"]]);
   expect(
     HtmlFormatter.getCellColor(
-      option({ contestId: "", id: acceptedProblemId, title: "" }),
+      option({ contest_id: "", id: acceptedProblemId, title: "" }),
       accepted,
       rival,
       wrong
@@ -31,7 +31,7 @@ test("get cell color", () => {
   ).toEqual("success");
   expect(
     HtmlFormatter.getCellColor(
-      option({ contestId: "", id: rivalProblemId, title: "" }),
+      option({ contest_id: "", id: rivalProblemId, title: "" }),
       accepted,
       rival,
       wrong
@@ -39,7 +39,7 @@ test("get cell color", () => {
   ).toEqual("danger");
   expect(
     HtmlFormatter.getCellColor(
-      option({ contestId: "", id: wrongProblemId, title: "" }),
+      option({ contest_id: "", id: wrongProblemId, title: "" }),
       accepted,
       rival,
       wrong
@@ -47,7 +47,7 @@ test("get cell color", () => {
   ).toEqual("warning");
   expect(
     HtmlFormatter.getCellColor(
-      option({ contestId: "", id: bothSolved, title: "" }),
+      option({ contest_id: "", id: bothSolved, title: "" }),
       accepted,
       rival,
       wrong
@@ -55,7 +55,7 @@ test("get cell color", () => {
   ).toEqual("success");
   expect(
     HtmlFormatter.getCellColor(
-      option({ contestId: "", id: wrongAndRival, title: "" }),
+      option({ contest_id: "", id: wrongAndRival, title: "" }),
       accepted,
       rival,
       wrong

--- a/atcoder-problems-frontend/src/utils/SubmissionUtils.test.tsx
+++ b/atcoder-problems-frontend/src/utils/SubmissionUtils.test.tsx
@@ -10,7 +10,7 @@ test("extract problems and results", () => {
       problem_id: "ac_problem",
       user_id: "kenkoooo",
       language: "lang",
-      contestId: "contest-id",
+      contest_id: "contest-id",
       execution_time: 10,
       epoch_second: 1,
       length: 2
@@ -22,7 +22,7 @@ test("extract problems and results", () => {
       problem_id: "wa_problem",
       user_id: "kenkoooo",
       language: "lang",
-      contestId: "contest-id",
+      contest_id: "contest-id",
       execution_time: 10,
       epoch_second: 1,
       length: 2
@@ -34,7 +34,7 @@ test("extract problems and results", () => {
       problem_id: "tle_problem",
       user_id: "kenkoooo",
       language: "lang",
-      contestId: "contest-id",
+      contest_id: "contest-id",
       execution_time: 10,
       epoch_second: 1,
       length: 2
@@ -46,7 +46,7 @@ test("extract problems and results", () => {
       problem_id: "iwi_problem",
       user_id: "iwiwi",
       language: "lang",
-      contestId: "contest-id",
+      contest_id: "contest-id",
       execution_time: 10,
       epoch_second: 1,
       length: 2


### PR DESCRIPTION
Changes:
* Renamed `Problem.contestId` to `Problem.contest_id`
* Renamed `MergedProblem.contestId` to `MergedProblem.contest_id`
* Renamed `Submission.contestId` to `Submission.contest_id`
* Renamed `LangCount.userId` to `LangCount.user_id`
* Renamed `RankPair.userId` to `RankPair.user_id`

Why?
By matching typescript model to API data structure, we do not have to convert API data to Typescript's model manually. Check how we can utilize typescript `as` operator [here](https://github.com/kenkoooo/AtCoderProblems/compare/master...1kohei1:master#diff-98dba814d8acfb30e88bfa6070c666a2R96)

Before I started editing, the test result was 
```
Test Suites: 9 passed, 9 total
Tests:       22 passed, 22 total
Snapshots:   8 passed, 8 total
```
After my change, the test result did not change. Also, I checked locally. Let me know if my code breaks the project. I will fix it. 

Thanks!

# Issues
- Resolve #41 