### PR TITLE
Perl6 is not Perl

### DIFF
--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
@@ -178,7 +178,7 @@ class SqlClient(url: String, user: String, password: String) extends Logging {
         insertInto(LanguageCount)
           .columns(columns.userId, columns.simplifiedLanguage, columns.problemCount)
           .select(userId, language, count(distinct(problemId)))(_.from {
-            select(sqls"regexp_replace(language, '\d* \(.*\)', '') AS $language", userId, problemId)
+            select(sqls"regexp_replace(language, '((?<!Perl)\d*|) \(.*\)', '') AS $language", userId, problemId)
               .from(Submission as submissions)
               .where
               .eq(submissions.c("result"), SubmissionStatus.Accepted)


### PR DESCRIPTION
Perl6をPerlと区別するため、数字一般にマッチしていた箇所を「Perlという文字列が前にない数字」または「長さ0の文字列」にマッチするようにしました。
Java準拠の正規表現のようですので、Javaではすべての言語名が正しく置換されることを確認しました。