### PR TITLE
Update Mockito to resolve #66

### DIFF
--- a/atcoder-problems-backend/build.sbt
+++ b/atcoder-problems-backend/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
   "com.github.pureconfig" %% "pureconfig" % "0.8.0",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-  "org.mockito" % "mockito-core" % "2.8.47" % "test",
+  "org.mockito" % "mockito-core" % "2.23.4" % "test",
   "com.tumblr" %% "colossus-testkit" % "0.10.1" % "test",
   "com.typesafe.akka" % "akka-http-testkit_2.12" % "10.0.10" % "test"
 )


### PR DESCRIPTION
#66 で話していたテストがこける問題ですが、とりあえず Mockito のバージョンを最新にしてみたらなぜか解決しました。

<details>
<summary>ログ</summary>

``` java
$ sbt assembly
[info] Loading settings for project atcoder-problems-backend-build from assembly.sbt,plugins.sbt ...
[info] Loading project definition from /home/user/GitHub/AtCoderProblems/atcoder-problems-backend/project
[info] Loading settings for project atcoder-problems-backend from build.sbt ...
[info] Set current project to atcoder-problems (in build file:/home/user/GitHub/AtCoderProblems/atcoder-problems-backend/)
[info] Including from cache: joda-convert-1.8.2.jar
[info] Including from cache: scala-parser-combinators_2.12-1.0.6.jar
[info] Including from cache: scalikejdbc-interpolation_2.12-3.1.0.jar
[info] Including from cache: jetty-util-9.4.3.v20170317.jar
[info] Including from cache: jetty-io-9.4.3.v20170317.jar
[info] Including from cache: jetty-client-9.4.3.v20170317.jar
[info] Including from cache: scalikejdbc-interpolation-macro_2.12-3.1.0.jar
[info] Including from cache: postgresql-42.1.4.jar
[info] Including from cache: jetty-http-9.4.3.v20170317.jar
[info] Including from cache: websocket-common-9.4.3.v20170317.jar
[info] Including from cache: websocket-api-9.4.3.v20170317.jar
[info] Including from cache: log4j-api-2.9.1.jar
[info] Including from cache: jsoup-1.10.2.jar
[info] Including from cache: scala-library-2.12.4.jar
[info] Including from cache: log4j-core-2.9.1.jar
[info] Including from cache: scalaz-core_2.12-7.2.12.jar
[info] Including from cache: log4j-api-scala_2.12-11.0.jar
[info] Including from cache: akka-http_2.12-10.0.10.jar
[info] Including from cache: scalikejdbc_2.12-3.1.0.jar
[info] Including from cache: pureconfig_2.12-0.8.0.jar
[info] Including from cache: akka-http-core_2.12-10.0.10.jar
[info] Including from cache: scala-xml_2.12-1.0.6.jar
[info] Including from cache: pureconfig-macros_2.12-0.8.0.jar
[info] Including from cache: scalikejdbc-core_2.12-3.1.0.jar
[info] Including from cache: macro-compat_2.12-1.1.1.jar
[info] Including from cache: akka-parsing_2.12-10.0.10.jar
[info] Including from cache: shapeless_2.12-2.3.2.jar
[info] Including from cache: scala-reflect-2.12.4.jar
[info] Including from cache: commons-dbcp2-2.1.1.jar
[info] Including from cache: commons-pool2-2.4.2.jar
[info] Including from cache: slf4j-api-1.7.25.jar
[info] Including from cache: config-1.3.1.jar
[info] Including from cache: akka-actor_2.12-2.4.19.jar
[info] Including from cache: joda-time-2.9.9.jar
[info] Including from cache: serializer-2.7.2.jar
[info] Including from cache: commons-lang3-3.5.jar
[info] Including from cache: scala-java8-compat_2.12-0.8.0.jar
[info] Including from cache: httpmime-4.5.3.jar
[info] Including from cache: httpclient-4.5.3.jar
[info] Including from cache: akka-stream_2.12-2.4.19.jar
[info] Including from cache: reactive-streams-1.0.0.jar
[info] Including from cache: ssl-config-core_2.12-0.2.1.jar
[info] Including from cache: httpcore-4.4.6.jar
[info] Including from cache: commons-logging-1.2.jar
[info] Including from cache: akka-http-spray-json_2.12-10.0.10.jar
[info] Including from cache: commons-codec-1.9.jar
[info] Including from cache: spray-json_2.12-1.3.3.jar
[info] Including from cache: scala-compiler-2.12.4.jar
[info] Including from cache: htmlunit-core-js-2.26.jar
[info] Including from cache: scala-scraper_2.12-2.0.0.jar
[info] Including from cache: neko-htmlunit-2.25.jar
[info] Including from cache: nscala-time_2.12-2.16.0.jar
[info] Including from cache: xercesImpl-2.11.0.jar
[info] Including from cache: xml-apis-1.4.01.jar
[info] Including from cache: cssparser-0.9.22.jar
[info] Including from cache: htmlunit-2.26.jar
[info] Including from cache: sac-1.3.jar
[info] Including from cache: commons-io-2.5.jar
[info] Including from cache: websocket-client-9.4.3.v20170317.jar
[info] Including from cache: xalan-2.7.2.jar
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.postgresql.jdbc.TimestampUtils (file:/home/user/.ivy2/cache/org.postgresql/postgresql/bundles/postgresql-42.1.4.jar) to field java.util.TimeZone.defaultTimeZone
WARNING: Please consider reporting this to the maintainers of org.postgresql.jdbc.TimestampUtils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2018/12/21 01:46:10.867 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading contests
2018/12/21 01:46:10.892 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading problems
2018/12/21 01:46:10.908 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:10.930 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:10.940 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:10.970 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:10.999 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading merged-problems
2018/12/21 01:46:11.152 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading rated_point_sum
2018/12/21 01:46:11.168 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading language_count
2018/12/21 01:46:11.201 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading predicted_rating
2018/12/21 01:46:11.637 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading contests
2018/12/21 01:46:11.648 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading problems
2018/12/21 01:46:11.659 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:11.664 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:11.671 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:11.695 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:11.704 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading merged-problems
2018/12/21 01:46:11.776 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading rated_point_sum
2018/12/21 01:46:11.786 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading language_count
2018/12/21 01:46:11.794 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading predicted_rating
2018/12/21 01:46:12.632 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating solver
2018/12/21 01:46:12.665 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading solver
2018/12/21 01:46:12.702 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating solver
2018/12/21 01:46:12.731 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading solver
2018/12/21 01:46:13.138 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest
2018/12/21 01:46:13.167 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest
2018/12/21 01:46:13.174 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest_submission_count
2018/12/21 01:46:13.240 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:13.376 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest
2018/12/21 01:46:13.390 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest
2018/12/21 01:46:13.395 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest_submission_count
2018/12/21 01:46:13.403 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:13.797 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest
2018/12/21 01:46:13.815 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest
2018/12/21 01:46:14.250 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest
2018/12/21 01:46:14.294 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest
2018/12/21 01:46:14.328 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest_submission_count
2018/12/21 01:46:14.336 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:14.353 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest
2018/12/21 01:46:14.364 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest
2018/12/21 01:46:14.368 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest_submission_count
2018/12/21 01:46:14.380 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:14.796 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first
2018/12/21 01:46:14.835 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first
2018/12/21 01:46:14.854 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first_submission_count
2018/12/21 01:46:14.896 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:14.923 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first
2018/12/21 01:46:14.933 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first
2018/12/21 01:46:14.937 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first_submission_count
2018/12/21 01:46:14.956 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:15.338 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating accepted_count
2018/12/21 01:46:15.389 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:15.411 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating accepted_count
2018/12/21 01:46:15.416 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:15.772 INFO  - [com.kenkoooo.atcoder.db.SqlClient] start batch table update
2018/12/21 01:46:15.773 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating accepted_count
2018/12/21 01:46:15.789 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating solver
2018/12/21 01:46:15.796 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating user rated point sum
2018/12/21 01:46:15.825 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating language count...
2018/12/21 01:46:15.836 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first
2018/12/21 01:46:15.860 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest
2018/12/21 01:46:15.873 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest
2018/12/21 01:46:15.897 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first_submission_count
2018/12/21 01:46:15.906 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest_submission_count
2018/12/21 01:46:15.929 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest_submission_count
2018/12/21 01:46:15.944 INFO  - [com.kenkoooo.atcoder.db.SqlClient] finished batch table update
2018/12/21 01:46:15.948 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:15.961 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading solver
2018/12/21 01:46:15.964 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first
2018/12/21 01:46:15.967 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest
2018/12/21 01:46:15.971 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest
2018/12/21 01:46:15.984 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:15.992 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:15.995 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:16.414 INFO  - [com.kenkoooo.atcoder.db.SqlClient] start batch table update
2018/12/21 01:46:16.415 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating accepted_count
2018/12/21 01:46:16.423 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating solver
2018/12/21 01:46:16.427 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating user rated point sum
2018/12/21 01:46:16.434 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating language count...
2018/12/21 01:46:16.439 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first
2018/12/21 01:46:16.467 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest
2018/12/21 01:46:16.476 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest
2018/12/21 01:46:16.489 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating first_submission_count
2018/12/21 01:46:16.493 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating fastest_submission_count
2018/12/21 01:46:16.497 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating shortest_submission_count
2018/12/21 01:46:16.501 INFO  - [com.kenkoooo.atcoder.db.SqlClient] finished batch table update
2018/12/21 01:46:16.501 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading merged-problems
2018/12/21 01:46:17.225 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating user rated point sum
2018/12/21 01:46:17.233 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading rated_point_sum
2018/12/21 01:46:17.563 INFO  - [com.kenkoooo.atcoder.db.SqlClient] updating language count...
2018/12/21 01:46:17.570 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading language_count
2018/12/21 01:46:17.918 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading contests
2018/12/21 01:46:17.927 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading problems
2018/12/21 01:46:17.934 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading accepted_count
2018/12/21 01:46:17.940 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading first_submission_count
2018/12/21 01:46:17.944 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading shortest_submission_count
2018/12/21 01:46:17.950 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading fastest_submission_count
2018/12/21 01:46:17.954 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading merged-problems
2018/12/21 01:46:17.980 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading rated_point_sum
2018/12/21 01:46:17.987 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading language_count
2018/12/21 01:46:17.991 INFO  - [com.kenkoooo.atcoder.db.SqlClient] loading predicted_rating
[info] SqlClientTest:
[info] - insert and reload submissions
[info] - insert and reload contests
[info] - insert and reload problems
[info] - load user submissions
[info] - update solver counts
[info] - extract shortest submissions
[info] - extract shortest contest
[info] - extract fastest submissions
[info] - extract first submissions
[info] - update accepted count ranking
[info] - batch execution of statistics functions
[info] - load merged problem info
[info] - extract contests which don't have any problems
[info] - update rated point sum table
[info] - update language count table
[info] - load predicted ratings
2018/12/21 01:46:18.210 INFO  - [com.kenkoooo.atcoder.scraper.ProblemScraper] scraping problems of arc084
[info] ProblemScraperTest:
[info] - scrape problems of ARC 084
[info] ConfigureTest:
[info] - parse JSON Configure
[info] ApiJsonSupportTest:
[info] - convert contest to json
[info] - convert submission to json
[info] - convert submission with a blank field to json
[info] - convert problem to json
[info] - convert user-count pairs to json
[info] - convert merged problems
2018/12/21 01:46:20.713 INFO  - [com.kenkoooo.atcoder.runner.NewerSubmissionScrapingRunner] 1 submissions overlapped in rco-contest-2017-final-open
2018/12/21 01:46:20.727 INFO  - [com.kenkoooo.atcoder.runner.NewerSubmissionScrapingRunner] 0 submissions overlapped in rco-contest-2017-final-open
2018/12/21 01:46:20.731 INFO  - [com.kenkoooo.atcoder.runner.NewerSubmissionScrapingRunner] 9 submissions overlapped in rco-contest-2017-final-open
2018/12/21 01:46:20.734 INFO  - [com.kenkoooo.atcoder.runner.NewerSubmissionScrapingRunner] 0 submissions overlapped in rco-contest-2017-final-open
[info] NewerSubmissionScrapingRunnerTest:
[info] - scrape and create next runner with the next page number
[info] - scrape and create next runner with the next contest when the page is the last page
[info] - scrape and create next runner with the next contest when many submissions were overlapped
[info] - scrape and return None when all the contests are scraped
[info] AllSubmissionScrapingRunnerTest:
[info] - scrape and create next runner with the next page number
[info] - scrape and create next runner with the next contest
[info] - scrape and return None when all the contests are scraped
2018/12/21 01:46:20.902 INFO  - [com.kenkoooo.atcoder.scraper.SubmissionScraper] scraping https://beta.atcoder.jp/contests/arc001/submissions?page=10...
[info] SubmissionScraperTest:
[info] - scrape submissions
[info] JsonApiTest:
[info] - return 200 to new request
[info] - check CORS header
[info] - return 304 to cached request
[info] - return 200 to requests with invalid tags
[info] - return 200 to problems request
[info] - user-count APIs
[info] - user submission result api
[info] - submission api with user
[info] - submission api with user and a rival
[info] - submission api with user and rivals
[info] - filter invalid parameters
[info] - merged problems api
[info] - rated point sums api
[info] - language count api
[info] - predicted rating api
2018/12/21 01:46:23.584 ERROR - [com.kenkoooo.atcoder.common.ScheduledExecutorServiceExtension$TryAndDieScheduledExecutorService$$anonfun$$nestedInanonfun$tryAtFixedDelay$1$1] Catching
java.lang.IllegalArgumentException: requirement failed
	at scala.Predef$.require(Predef.scala:264) ~[scala-library-2.12.4.jar:?]
	at com.kenkoooo.atcoder.common.ScheduledExecutorServiceExtensionTest.$anonfun$new$2(ScheduledExecutorServiceExtensionTest.scala:16) ~[test-classes/:?]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12) ~[scala-library-2.12.4.jar:?]
	at scala.util.Try$.apply(Try.scala:209) ~[scala-library-2.12.4.jar:?]
	at com.kenkoooo.atcoder.common.ScheduledExecutorServiceExtension$TryAndDieScheduledExecutorService$.$anonfun$tryAtFixedDelay$1(ScheduledExecutorServiceExtension.scala:30) [classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514) [?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:844) [?:?]
[info] ScheduledExecutorServiceExtensionTest:
[info] - log crashed command
2018/12/21 01:46:25.629 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=1
2018/12/21 01:46:25.832 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=2
2018/12/21 01:46:26.039 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=3
2018/12/21 01:46:26.296 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=4
2018/12/21 01:46:26.560 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=5
2018/12/21 01:46:26.831 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=6
2018/12/21 01:46:27.011 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=7
2018/12/21 01:46:27.186 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=8
2018/12/21 01:46:27.362 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=9
2018/12/21 01:46:27.532 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=10
2018/12/21 01:46:27.737 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=11
2018/12/21 01:46:27.940 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=12
2018/12/21 01:46:28.239 INFO  - [com.kenkoooo.atcoder.scraper.ContestScraper] scraping https://beta.atcoder.jp/contests/archive?lang=ja&page=1
2018/12/21 01:46:28.240 ERROR - [com.kenkoooo.atcoder.scraper.ContestScraper] Catching
java.net.SocketTimeoutException: null
	at com.kenkoooo.atcoder.scraper.ContestScraperTest.$anonfun$new$6(ContestScraperTest.scala:32) ~[test-classes/:?]
	at org.mockito.internal.stubbing.StubbedInvocationMatcher.answer(StubbedInvocationMatcher.java:39) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:96) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:35) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:63) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:49) ~[mockito-core-2.23.4.jar:?]
	at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$DispatcherDefaultingToRealMethod.interceptAbstract(MockMethodInterceptor.java:128) ~[mockito-core-2.23.4.jar:?]
	at net.ruippeixotog.scalascraper.browser.Browser$MockitoMock$1125514534.get(Unknown Source) ~[?:?]
	at com.kenkoooo.atcoder.scraper.ContestScraper.$anonfun$scrape$1(ContestScraper.scala:26) ~[classes/:?]
	at scala.util.Try$.apply(Try.scala:209) ~[scala-library-2.12.4.jar:?]
	at com.kenkoooo.atcoder.scraper.ContestScraper.scrape(ContestScraper.scala:26) [classes/:?]
	at com.kenkoooo.atcoder.scraper.ContestScraper.$anonfun$scrapeAllContests$1(ContestScraper.scala:62) [classes/:?]
	at scala.collection.Iterator$$anon$7.next(Iterator.scala:128) [scala-library-2.12.4.jar:?]
	at scala.collection.Iterator$$anon$15.hasNext(Iterator.scala:637) [scala-library-2.12.4.jar:?]
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:447) [scala-library-2.12.4.jar:?]
	at scala.collection.Iterator.foreach(Iterator.scala:929) [scala-library-2.12.4.jar:?]
	at scala.collection.Iterator.foreach$(Iterator.scala:929) [scala-library-2.12.4.jar:?]
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1417) [scala-library-2.12.4.jar:?]
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:59) [scala-library-2.12.4.jar:?]
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:50) [scala-library-2.12.4.jar:?]
	at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:104) [scala-library-2.12.4.jar:?]
	at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:48) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.to(TraversableOnce.scala:310) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.to$(TraversableOnce.scala:308) [scala-library-2.12.4.jar:?]
	at scala.collection.AbstractIterator.to(Iterator.scala:1417) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.toBuffer(TraversableOnce.scala:302) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.toBuffer$(TraversableOnce.scala:302) [scala-library-2.12.4.jar:?]
	at scala.collection.AbstractIterator.toBuffer(Iterator.scala:1417) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.toArray(TraversableOnce.scala:289) [scala-library-2.12.4.jar:?]
	at scala.collection.TraversableOnce.toArray$(TraversableOnce.scala:283) [scala-library-2.12.4.jar:?]
	at scala.collection.AbstractIterator.toArray(Iterator.scala:1417) [scala-library-2.12.4.jar:?]
	at com.kenkoooo.atcoder.scraper.ContestScraper.scrapeAllContests(ContestScraper.scala:65) [classes/:?]
	at com.kenkoooo.atcoder.scraper.ContestScraperTest.$anonfun$new$5(ContestScraperTest.scala:35) [test-classes/:?]
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.Transformer.apply(Transformer.scala:22) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.Transformer.apply(Transformer.scala:20) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.TestSuite.withFixture(TestSuite.scala:196) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuite.runTest(FunSuite.scala:1560) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:396) [scalatest_2.12-3.0.4.jar:?]
	at scala.collection.immutable.List.foreach(List.scala:389) [scala-library-2.12.4.jar:?]
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:379) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuite.runTests(FunSuite.scala:1560) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.Suite.run(Suite.scala:1147) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.Suite.run$(Suite.scala:1129) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.FunSuite.run(FunSuite.scala:1560) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314) [scalatest_2.12-3.0.4.jar:?]
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:507) [scalatest_2.12-3.0.4.jar:?]
	at sbt.TestRunner.runTest$1(TestFramework.scala:113) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestRunner.run(TestFramework.scala:124) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:282) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:246) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:282) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:282) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.TestFunction.apply(TestFramework.scala:294) [testing_2.12-1.2.7.jar:1.2.7]
	at sbt.Tests$.processRunnable$1(Tests.scala:347) [actions_2.12-1.2.7.jar:1.2.7]
	at sbt.Tests$.$anonfun$makeSerial$1(Tests.scala:353) [actions_2.12-1.2.7.jar:1.2.7]
	at sbt.std.Transform$$anon$3.$anonfun$apply$2(System.scala:46) [task-system_2.12-1.2.7.jar:1.2.7]
	at sbt.std.Transform$$anon$4.work(System.scala:67) [task-system_2.12-1.2.7.jar:1.2.7]
	at sbt.Execute.$anonfun$submit$2(Execute.scala:269) [tasks_2.12-1.2.7.jar:1.2.7]
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16) [util-control_2.12-1.2.4.jar:1.2.4]
	at sbt.Execute.work(Execute.scala:278) [tasks_2.12-1.2.7.jar:1.2.7]
	at sbt.Execute.$anonfun$submit$1(Execute.scala:269) [tasks_2.12-1.2.7.jar:1.2.7]
	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178) [tasks_2.12-1.2.7.jar:1.2.7]
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37) [tasks_2.12-1.2.7.jar:1.2.7]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:844) [?:?]
[info] ContestScraperTest:
[info] - scrape contest list
[info] - timed out when scraping
[info] Run completed in 20 seconds, 130 milliseconds.
[info] Total number of tests run: 50
[info] Suites: completed 10, aborted 0
[info] Tests: succeeded 50, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Checking every *.class/*.jar file's SHA-1.
[info] Merging files...
[warn] Merging 'com/gargoylesoftware/htmlunit/protocol/about' with strategy 'rename'
[warn] Merging 'license_xml-apis-1.4.01/LICENSE' with strategy 'rename'
[warn] Merging 'META-INF/DEPENDENCIES' with strategy 'discard'
[warn] Merging 'META-INF/MANIFEST.MF' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-codec/commons-codec/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-codec/commons-codec/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-io/commons-io/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-io/commons-io/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-logging/commons-logging/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/commons-logging/commons-logging/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/jline/jline/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/jline/jline/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/joda-time/joda-time/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/joda-time/joda-time/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.cssparser/cssparser/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.cssparser/cssparser/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.htmlunit/neko-htmlunit/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/net.sourceforge.htmlunit/neko-htmlunit/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-dbcp2/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-dbcp2/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-lang3/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-lang3/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-pool2/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.commons/commons-pool2/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpclient/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpclient/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpcore/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpcore/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpmime/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.httpcomponents/httpmime/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-api-scala_2.12/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-api-scala_2.12/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-api/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-api/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.apache.logging.log4j/log4j-core/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-api/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-api/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-client/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-client/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-common/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty.websocket/websocket-common/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-client/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-client/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-http/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-http/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-io/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-io/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-util/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.eclipse.jetty/jetty-util/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.joda/joda-convert/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.joda/joda-convert/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.jsoup/jsoup/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.jsoup/jsoup/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.postgresql/postgresql/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.postgresql/postgresql/pom.xml' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.slf4j/slf4j-api/pom.properties' with strategy 'discard'
[warn] Merging 'META-INF/maven/org.slf4j/slf4j-api/pom.xml' with strategy 'discard'
[warn] Merging 'reference.conf' with strategy 'concat'
[warn] Merging 'rootdoc.txt' with strategy 'concat'
[warn] Strategy 'concat' was applied to 2 files
[info] Strategy 'deduplicate' was applied to 29 files (Run the task at debug level to see details)
[warn] Strategy 'discard' was applied to 58 files
[warn] Strategy 'rename' was applied to 2 files
[info] SHA-1: 1bf5934d28d4068433b3f3ad15668ab419852b3d
[info] Packaging /home/user/GitHub/AtCoderProblems/atcoder-problems-backend/target/scala-2.12/atcoder-problems-assembly-0.1.jar ...
[info] Done packaging.
[success] Total time: 33 s, completed Dec 21, 2018, 1:46:37 AM
```

</details>