### PR TITLE
fixed sorting if the epochtimes are the same

### DIFF
--- a/atcoder-problems-frontend/src/components/List.tsx
+++ b/atcoder-problems-frontend/src/components/List.tsx
@@ -96,6 +96,34 @@ function formatShortestSubmission(problem: MergedProblem, row: ProblemRow) {
   return HtmlFormatter.createLink(submissionUrl, title);
 }
 
+function sortStartEpoch(a: ProblemRow, b: ProblemRow, order: string) {
+  if (order === 'desc') {
+    let c = a;
+    a = b;
+    b = c;
+  }
+  if(a.startEpochSecond < b.startEpochSecond)return -1;
+  if(a.startEpochSecond > b.startEpochSecond)return 1;
+  if(a.contest.title < b.contest.title)return -1;
+  if(a.contest.title > b.contest.title)return 1;
+  if(a.problem.title < b.problem.title)return -1;
+  if(a.problem.title > b.problem.title)return 1;
+  return 0;
+}
+
+function sortContest(a: ProblemRow, b: ProblemRow, order: string) {
+  if (order === 'desc') {
+    let c = a;
+    a = b;
+    b = c;
+  }
+  if(a.contest.title < b.contest.title)return -1;
+  if(a.contest.title > b.contest.title)return 1;
+  if(a.problem.title < b.problem.title)return -1;
+  if(a.problem.title > b.problem.title)return 1;
+  return 0;
+}
+
 /**
  * format first submission link
  */
@@ -210,8 +238,7 @@ export class List extends React.Component<ListProps, ListState> {
           lastAcceptedDate: lastAcceptedDate ? lastAcceptedDate : ""
         };
       })
-      .sort((a, b) => a.startEpochSecond - b.startEpochSecond)
-      .reverse();
+      .sort((a, b) => sortStartEpoch(a,b,'desc'));
 
     return (
       <Row>
@@ -324,6 +351,7 @@ export class List extends React.Component<ListProps, ListState> {
               TimeFormatter.getDateString(second * 1000)
             }
             dataSort
+            sortFunc={sortStartEpoch}
             isKey
           >
             Date
@@ -337,6 +365,8 @@ export class List extends React.Component<ListProps, ListState> {
           <TableHeaderColumn
             dataField="contest"
             dataFormat={formatContestTitle}
+            dataSort
+            sortFunc={sortContest}
           >
             Contest
           </TableHeaderColumn>


### PR DESCRIPTION
確かに開始日ではなく開始時間をキーにすれば時間がずれている場合はうまくいきますが、ARCのエントリとABCのエントリが交じることはないでしょうか。
開始時間が同じならコンテスト名順でソートするという実装が最も安定していると(気づいた当初から)思っています。
また、コンテスト内では問題順にソートしたほうが精神的に良いと考えられます。

追伸　本件についてはtwitter上で度重なる改善要求を出してしまい大変申し訳ありませんでした。