### PR TITLE
Add EntityTag to results API

### DIFF
--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/EntityTagger.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/EntityTagger.scala
@@ -16,4 +16,7 @@ object EntityTagger {
   def calculateDateTimeTag(dateTime: DateTime): EntityTag = {
     EntityTag(md5Sum(dateTime.toIsoDateTimeString()), weak = true)
   }
+  def calculateLatestSubmissionIdTag(latestSubmissionId: Long): EntityTag = {
+    EntityTag(md5Sum(latestSubmissionId.toString()), weak = true)
+  }
 }

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
@@ -46,7 +46,10 @@ class JsonApi(sqlClient: SqlClient) extends ApiJsonSupport {
             val rivalList = rivals.split(",").map(_.trim).toList
             val users = (user :: rivalList).filter(_.length > 0).filter(_.matches(UserNameRegex))
 
-            complete(sqlClient.loadUserSubmissions(users: _*).toList)
+            val lastSubmitted: DateTime = sqlClient.loadUserLastSubmitted(users: _*);
+            conditional(EntityTagger.calculateDateTimeTag(lastSubmitted), lastSubmitted) {
+              complete(sqlClient.loadUserSubmissions(users: _*).toList)
+            }
           }
         } ~ pathPrefix("v2") {
           path("user_info") {

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
@@ -1,7 +1,8 @@
 package com.kenkoooo.atcoder.api
 
 import akka.http.scaladsl.model.DateTime
-import akka.http.scaladsl.model.headers.`Access-Control-Allow-Origin`
+import akka.http.scaladsl.model.headers.{`Access-Control-Allow-Origin`, `Cache-Control`}
+import akka.http.scaladsl.model.headers.CacheDirectives.`max-age`
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.kenkoooo.atcoder.db.SqlClient
@@ -48,7 +49,9 @@ class JsonApi(sqlClient: SqlClient) extends ApiJsonSupport {
 
             val lastSubmitted: DateTime = sqlClient.loadUserLastSubmitted(users: _*);
             conditional(EntityTagger.calculateDateTimeTag(lastSubmitted), lastSubmitted) {
-              complete(sqlClient.loadUserSubmissions(users: _*).toList)
+              respondWithHeaders(`Cache-Control`(`max-age`(0))) {
+                complete(sqlClient.loadUserSubmissions(users: _*).toList)
+              }
             }
           }
         } ~ pathPrefix("v2") {

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
@@ -47,8 +47,8 @@ class JsonApi(sqlClient: SqlClient) extends ApiJsonSupport {
             val rivalList = rivals.split(",").map(_.trim).toList
             val users = (user :: rivalList).filter(_.length > 0).filter(_.matches(UserNameRegex))
 
-            val lastSubmitted: DateTime = sqlClient.loadUserLastSubmitted(users: _*);
-            conditional(EntityTagger.calculateDateTimeTag(lastSubmitted), lastSubmitted) {
+            val latestSubmissionId: Long = sqlClient.loadUserLatestSubmissionId(users: _*);
+            conditional(EntityTagger.calculateLatestSubmissionIdTag(latestSubmissionId)) {
               respondWithHeaders(`Cache-Control`(`max-age`(0))) {
                 complete(sqlClient.loadUserSubmissions(users: _*).toList)
               }

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
@@ -83,17 +83,16 @@ class SqlClient(url: String, user: String, password: String) extends Logging {
   }
 
   /**
-    * load the time of the last submission which is submitted by anyone in the given list
+    * load the id of the latest submission which is submitted by anyone in the given list
     *
-    * @param userId [[UserId]] to get the epoch of their last submission
-    * @return [[DateTime]] of the last submission
+    * @param userId [[UserId]] to search submissions
+    * @return the id of the latest submission
     */
-  def loadUserLastSubmitted(userIds: UserId*): DateTime = {
+  def loadUserLatestSubmissionId(userIds: UserId*): Long = {
     DB.readOnly { implicit session =>
-      val epochSecond: Long = withSQL {
-        select(max(SubmissionSyntax.epochSecond)).from(Submission as SubmissionSyntax).where.in(SubmissionSyntax.userId, userIds)
+      withSQL {
+        select(max(SubmissionSyntax.id)).from(Submission as SubmissionSyntax).where.in(SubmissionSyntax.userId, userIds)
       }.map(_.long(1)).single().apply().getOrElse(0L)
-      DateTime(1000 * epochSecond)
     }
   }
 

--- a/atcoder-problems-backend/src/test/resources/test-db.sql
+++ b/atcoder-problems-backend/src/test/resources/test-db.sql
@@ -14,7 +14,7 @@ CREATE TABLE submissions (
   execution_time  INT,
   PRIMARY KEY (id)
 );
-CREATE INDEX ON submissions (user_id, epoch_second);
+CREATE INDEX ON submissions (user_id);
 
 DROP TABLE IF EXISTS problems;
 CREATE TABLE problems (

--- a/atcoder-problems-backend/src/test/resources/test-db.sql
+++ b/atcoder-problems-backend/src/test/resources/test-db.sql
@@ -14,7 +14,7 @@ CREATE TABLE submissions (
   execution_time  INT,
   PRIMARY KEY (id)
 );
-CREATE INDEX ON submissions (user_id);
+CREATE INDEX ON submissions (user_id, epoch_second);
 
 DROP TABLE IF EXISTS problems;
 CREATE TABLE problems (

--- a/atcoder-problems-backend/src/test/resources/test-db.sql
+++ b/atcoder-problems-backend/src/test/resources/test-db.sql
@@ -14,7 +14,7 @@ CREATE TABLE submissions (
   execution_time  INT,
   PRIMARY KEY (id)
 );
-CREATE INDEX ON submissions (user_id);
+CREATE INDEX ON submissions (user_id, id);
 
 DROP TABLE IF EXISTS problems;
 CREATE TABLE problems (

--- a/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
+++ b/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
@@ -35,8 +35,8 @@ class JsonApiTest
     when(sql.fastestSubmissionCounts).thenReturn(List(FastestSubmissionCount("kenkoooo", 114)))
     when(sql.firstSubmissionCounts).thenReturn(List(FirstSubmissionCount("kenkoooo", 114)))
     when(sql.acceptedCounts).thenReturn(List(AcceptedCount("kenkoooo", 114)))
-    when(sql.loadUserLastSubmitted(ArgumentMatchers.any())).thenReturn(
-      DateTime(currentTime)
+    when(sql.loadUserLatestSubmissionId(ArgumentMatchers.any())).thenReturn(
+      114
     )
     when(sql.loadUserSubmissions(ArgumentMatchers.any())).thenReturn(
       Iterator(

--- a/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
+++ b/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
@@ -35,6 +35,9 @@ class JsonApiTest
     when(sql.fastestSubmissionCounts).thenReturn(List(FastestSubmissionCount("kenkoooo", 114)))
     when(sql.firstSubmissionCounts).thenReturn(List(FirstSubmissionCount("kenkoooo", 114)))
     when(sql.acceptedCounts).thenReturn(List(AcceptedCount("kenkoooo", 114)))
+    when(sql.loadUserLastSubmitted(ArgumentMatchers.any())).thenReturn(
+      DateTime(currentTime)
+    )
     when(sql.loadUserSubmissions(ArgumentMatchers.any())).thenReturn(
       Iterator(
         Submission(


### PR DESCRIPTION
もともとあったETagをresultsでも使ってキャッシュさせる形で #84 を実現しました。
これまでは更新を5回押されると5倍負荷がかかっていましたが、これからは実質1倍です。
indexの貼り替えをしているので次の実行もお願いします。

``` sql
DROP INDEX submissions_user_id_idx;
CREATE INDEX ON submissions (user_id, id);
```

実装としては、ユーザの提出で最も新しいもののIDとブラウザのキャッシュに残っているIDとを比べて、変化がなければ処理を丸ごと省略するというものです。最新のIDは O(log n) で取れ、処理が走ると O(n) なので速いです。最新であることの確認にはDB内のIDを使っています。確実に単調増加してかつ `count(1)` などよりも速いためです。