### PR TITLE
Make tables responsive

### DIFF
--- a/atcoder-problems-frontend/src/components/CategorySmallBlock.tsx
+++ b/atcoder-problems-frontend/src/components/CategorySmallBlock.tsx
@@ -39,7 +39,7 @@ export class CategorySmallBlock extends React.Component<
                   {contest.title}
                 </a>
               </strong>
-              <Table striped bordered condensed hover>
+              <Table striped bordered condensed hover responsive>
                 <tbody>
                   <tr>
                     {problems.sort((a, b) => a.title > b.title ? 1 : -1).map((problem, i) => (


### PR DESCRIPTION
スマホで開いたときに右側に大きな余白が出るのは嬉しくないので消します