### PR TITLE
Call the results API user by user

### DIFF
--- a/atcoder-problems-frontend/src/components/Application.tsx
+++ b/atcoder-problems-frontend/src/components/Application.tsx
@@ -68,7 +68,7 @@ export class Application extends React.Component<{}, ApplicationState> {
     users.push(this.state.args.userId);
     Promise.all(
         users.filter(user => user.length > 0)
-          .map(user => ApiCall.getSubmissions([user])))
+          .map(user => ApiCall.getSubmissions(user)))
       .then(submissions => this.setState({ submissions: Array.prototype.concat.apply([], submissions) }))
       .catch(err => console.error(err));
   }

--- a/atcoder-problems-frontend/src/components/Application.tsx
+++ b/atcoder-problems-frontend/src/components/Application.tsx
@@ -66,8 +66,10 @@ export class Application extends React.Component<{}, ApplicationState> {
   setSubmissions() {
     let users = this.state.args.rivals.slice(0);
     users.push(this.state.args.userId);
-    ApiCall.getSubmissions(users.filter(user => user.length > 0))
-      .then(submissions => this.setState({ submissions: submissions }))
+    Promise.all(
+        users.filter(user => user.length > 0)
+          .map(user => ApiCall.getSubmissions([user])))
+      .then(submissions => this.setState({ submissions: Array.prototype.concat.apply([], submissions) }))
       .catch(err => console.error(err));
   }
 

--- a/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.test.tsx
@@ -136,7 +136,7 @@ test("get and parse submissions", () => {
     return new MockRequest(response);
   });
   require("./ApiCall")
-    .ApiCall.getSubmissions(["iwiwi", "chokudai"])
+    .ApiCall.getSubmissions("iwiwi")
     .then((submissions: Submission[]) => {
       expect(submissions[0].id).toEqual(74283);
       expect(submissions[1].id).toEqual(74285);

--- a/atcoder-problems-frontend/src/utils/ApiCall.tsx
+++ b/atcoder-problems-frontend/src/utils/ApiCall.tsx
@@ -89,9 +89,9 @@ export class ApiCall {
     return contests;
   }
 
-  static async getSubmissions(users: Array<string>): Promise<Array<Submission>> {
+  static async getSubmissions(user: string): Promise<Array<Submission>> {
     let url = `${this.BaseUrl}/results`;
-    let query = { rivals: users.join(",") };
+    let query = { user: user };
     const obj = await this.getJson(url, query);
     let submissions: Submission[] = obj.map((o: Submission) => o as Submission);
     return submissions;


### PR DESCRIPTION
APIを `results?rivals=hoge,fuga` と呼んでいたのを `results?user=hoge` `results?user=fuga` と分けて呼びます。接続回数は増えますがキャッシュの効きがよくなるので総合的には速くなるでしょう