### PR TITLE
Fix a bug of computing ETag

### DIFF
--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/EntityTagger.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/EntityTagger.scala
@@ -16,7 +16,7 @@ object EntityTagger {
   def calculateDateTimeTag(dateTime: DateTime): EntityTag = {
     EntityTag(md5Sum(dateTime.toIsoDateTimeString()), weak = true)
   }
-  def calculateLatestSubmissionIdTag(latestSubmissionId: Long): EntityTag = {
-    EntityTag(md5Sum(latestSubmissionId.toString()), weak = true)
+  def calculateIntegerTag(value: Long): EntityTag = {
+    EntityTag(md5Sum(value.toString()), weak = true)
   }
 }

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/api/JsonApi.scala
@@ -47,8 +47,8 @@ class JsonApi(sqlClient: SqlClient) extends ApiJsonSupport {
             val rivalList = rivals.split(",").map(_.trim).toList
             val users = (user :: rivalList).filter(_.length > 0).filter(_.matches(UserNameRegex))
 
-            val latestSubmissionId: Long = sqlClient.loadUserLatestSubmissionId(users: _*);
-            conditional(EntityTagger.calculateLatestSubmissionIdTag(latestSubmissionId)) {
+            val submissionCount: Long = sqlClient.loadUserSubmissionCount(users: _*);
+            conditional(EntityTagger.calculateIntegerTag(submissionCount)) {
               respondWithHeaders(`Cache-Control`(`max-age`(0))) {
                 complete(sqlClient.loadUserSubmissions(users: _*).toList)
               }

--- a/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
+++ b/atcoder-problems-backend/src/main/scala/com/kenkoooo/atcoder/db/SqlClient.scala
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.scala.Logging
 import scalikejdbc._
 import SQLSyntax.min
 import scalikejdbc.interpolation.SQLSyntax
-import sqls.{count, distinct, max}
+import sqls.{count, distinct}
 
 import scala.util.Try
 
@@ -83,15 +83,15 @@ class SqlClient(url: String, user: String, password: String) extends Logging {
   }
 
   /**
-    * load the id of the latest submission which is submitted by anyone in the given list
+    * load the number of submissions which are submitted by anyone in the given list
     *
     * @param userId [[UserId]] to search submissions
-    * @return the id of the latest submission
+    * @return the number of submissions
     */
-  def loadUserLatestSubmissionId(userIds: UserId*): Long = {
+  def loadUserSubmissionCount(userIds: UserId*): Long = {
     DB.readOnly { implicit session =>
       withSQL {
-        select(max(SubmissionSyntax.id)).from(Submission as SubmissionSyntax).where.in(SubmissionSyntax.userId, userIds)
+        select(count).from(Submission as SubmissionSyntax).where.in(SubmissionSyntax.userId, userIds)
       }.map(_.long(1)).single().apply().getOrElse(0L)
     }
   }

--- a/atcoder-problems-backend/src/test/resources/test-db.sql
+++ b/atcoder-problems-backend/src/test/resources/test-db.sql
@@ -14,7 +14,7 @@ CREATE TABLE submissions (
   execution_time  INT,
   PRIMARY KEY (id)
 );
-CREATE INDEX ON submissions (user_id, id);
+CREATE INDEX ON submissions (user_id);
 
 DROP TABLE IF EXISTS problems;
 CREATE TABLE problems (

--- a/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
+++ b/atcoder-problems-backend/src/test/scala/com/kenkoooo/atcoder/api/JsonApiTest.scala
@@ -35,8 +35,8 @@ class JsonApiTest
     when(sql.fastestSubmissionCounts).thenReturn(List(FastestSubmissionCount("kenkoooo", 114)))
     when(sql.firstSubmissionCounts).thenReturn(List(FirstSubmissionCount("kenkoooo", 114)))
     when(sql.acceptedCounts).thenReturn(List(AcceptedCount("kenkoooo", 114)))
-    when(sql.loadUserLatestSubmissionId(ArgumentMatchers.any())).thenReturn(
-      114
+    when(sql.loadUserSubmissionCount(ArgumentMatchers.any())).thenReturn(
+      1
     )
     when(sql.loadUserSubmissions(ArgumentMatchers.any())).thenReturn(
       Iterator(


### PR DESCRIPTION
https://github.com/kenkoooo/AtCoderProblems/pull/90 で入れたETagでのキャッシュに微妙なバグがあることに突然気付きました。
滅多に再現しないのですが、運が悪いとキャッシュのせいで提出が見えなくなります。
バグなので直しました。でもちょっと遅くなります。

indexを貼り替えているのでmergeするなら次を実行してください。

``` sql
DROP INDEX submissions_user_id_id_idx;
CREATE INDEX ON submissions (user_id);
```

---

バグの原因は、現状では提出のidの最大値を比較して以前と同じならキャッシュを返す仕様になっていて、これが嘘であることです。
このidを自動採番だと勘違いしていたのですが実際はAtCoder側で生成されるidを用いていました。
このため、運悪くクロール順がこのidと逆転した場合、新しいデータを返すべきところでキャッシュが返されてしまいます。

修正方法は `max(id)` のかわりに `count(*)` をすればよいです。
ただしPostgreSQLではこれが遅いことが知られています。その設計思想により `table.size()` が O(1) でなく O(n) かかるためです。 (参考: https://wiki.postgresql.org/wiki/Slow_Counting/ja)
0.2ms ぐらいだった処理が 100ms ぐらいまで増えるので50倍遅くなってかなしいのですが、それでもキャッシュしないよりかははるかに速いので大丈夫だと思います。

なおこの速度低下を回避したい場合は、下のようなテーブルを作ってあげればよいです。

``` sql
CREATE TABLE submission_count (
  user_id          VARCHAR(255)  NOT NULL,
  submission_count INT           NOT NULL,
  PRIMARY KEY (user_id)
);
```