### PR TITLE
Fix ordinary number of rated_point_sum_rank in user page.

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -186,7 +186,7 @@ class UserPage extends React.Component<Props, State> {
 						<h6>Rated Point Sum</h6>
 						<h3>{user_info.rated_point_sum} pt</h3>
 						<h6 className="text-muted">{`${user_info.rated_point_sum_rank + 1}${ordinalSuffixOf(
-							user_info.rated_point_sum + 1
+							user_info.rated_point_sum_rank + 1
 						)}`}</h6>
 					</Col>
 					<Col key="Longest Streak" className="text-center">


### PR DESCRIPTION
In my user page, the rated point sum rank is wrongly shown as 199st. It should be 199th.
https://beta.kenkoooo.com/atcoder/#/user/aajisaka

This issue occurs because `rated_point_sum + 1`, which always becomes X*100+1, is used for calculating the ordinary number. `rated_point_sum_rank` should be used instead.

I like AtCoderProblems beta :+1: