### PR TITLE
Added css for small screen

### DIFF
--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -12,3 +12,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+
+@media only screen and (max-width: 1024px){
+  .react-bs-table table td,
+  .react-bs-table table th {
+    white-space: unset;
+    word-break: break-word;
+  }
+}

--- a/atcoder-problems-frontend/src/index.tsx
+++ b/atcoder-problems-frontend/src/index.tsx
@@ -1,10 +1,10 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 


### PR DESCRIPTION
#158 です。
画面の横幅が小さいときにAGCの問題名に含まれる長い英単語を折り返すことができず問題名をほとんど見ることができません。`react-bs-table`クラスをもつtable tdとthに`overflow: hidden`、`white-space: nowrap`、`text-overflow: ellipsis`があたっています。

画面幅が1024px以下の時は折返すようにしてみました。基準はPC以外で最も大きい画面幅のiPad Proです。
PCでも1024px以下の時は折り返すのでもう少し画面幅が小さいときに限定しても良いかとも思います。

ただしこの変更で小さい画面幅のときは問題名のテキストを折り返すことで各行ごとの高さが変わってキレイではなくなります。
それは良くないと @kenkoooo さんが思われる場合はこの変更は撤回してください。
よろしくおねがいします！

- resolves #158 