### PR TITLE
Fixed CalendarHeatmap

### DIFF
--- a/atcoder-problems-frontend/src/components/CalendarHeatmap.tsx
+++ b/atcoder-problems-frontend/src/components/CalendarHeatmap.tsx
@@ -16,6 +16,7 @@ const formatDate = (date: Date) => {
 
 const CalendarHeatmap = (props: { data: Date[]; formatTooltip?: (date: string, count: number) => string }) => {
   const next_sunday = new Date();
+  next_sunday.setDate(next_sunday.getDate() + 1);
   while (next_sunday.getDay() != 0) {
     next_sunday.setDate(next_sunday.getDate() + 1);
   }

--- a/atcoder-problems-frontend/src/components/CalendarHeatmap.tsx
+++ b/atcoder-problems-frontend/src/components/CalendarHeatmap.tsx
@@ -16,10 +16,7 @@ const formatDate = (date: Date) => {
 
 const CalendarHeatmap = (props: { data: Date[]; formatTooltip?: (date: string, count: number) => string }) => {
   const next_sunday = new Date();
-  next_sunday.setDate(next_sunday.getDate() + 1);
-  while (next_sunday.getDay() != 0) {
-    next_sunday.setDate(next_sunday.getDate() + 1);
-  }
+  next_sunday.setDate(next_sunday.getDate() + (WEEKDAY - next_sunday.getDay()));
 
   const current_date = new Date(next_sunday);
   current_date.setDate(current_date.getDate() - WEEKS * WEEKDAY);


### PR DESCRIPTION
#161 です。
[一年前，次の日曜日)の半開区間のヒートマップで、日曜日に対する次の日曜日を取得できていなかったので直しました。

日、月、火、...、土に対してnext_sunday.getDay()は
0、1、2、...、6を返し、最終的に
7、6、5、...、1を足したいので
``` ts
const next_sunday = new Date();
next_sunday.setDate(next_sunday.getDate() + (WEEKDAY - next_sunday.getDay()));
```
でも動くのですが、
他の人とコードを共有する際にどちらが見やすいコードか分からないので教えていただけないでしょうか...？

resolves #161 