### PR TITLE
Added Contest and Difficulty columns to Recommendations table

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -78,18 +78,6 @@ const Recommendations = ({
       striped
     >
       <TableHeaderColumn
-        dataField="contest"
-        dataFormat={(
-          {id, title}: {id: string, title: string}
-        ) => (
-          <a href={Url.formatContestUrl(id)} target="_blank">
-            {title}
-          </a>
-        )}
-      >
-        Contest
-      </TableHeaderColumn>
-      <TableHeaderColumn
         dataField="title"
         dataFormat={(
           title: string,
@@ -101,6 +89,18 @@ const Recommendations = ({
         )}
       >
         Title
+      </TableHeaderColumn>
+      <TableHeaderColumn
+        dataField="contest"
+        dataFormat={(
+          {id, title}: {id: string, title: string}
+        ) => (
+          <a href={Url.formatContestUrl(id)} target="_blank">
+            {title}
+          </a>
+        )}
+      >
+        Contest
       </TableHeaderColumn>
       <TableHeaderColumn
         dataField="difficulty"

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -88,7 +88,7 @@ const Recommendations = ({
           </a>
         )}
       >
-        Title
+        Problem
       </TableHeaderColumn>
       <TableHeaderColumn
         dataField="contest"

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { isAccepted } from "../../utils";
 import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
+import Contest from "../../interfaces/Contest";
 import * as Url from "../../utils/Url";
 
 const TOP_PERFORMANCES = 50;
@@ -10,10 +11,12 @@ const RECOMMEND_NUM = 10;
 const Recommendations = ({
   submissions,
   problems,
+  contests,
   performances
 }: {
   submissions: { result: string; problem_id: string; epoch_second: number }[];
   problems: { id: string; title: string; contest_id: string }[];
+  contests: Contest[];
   performances: { problem_id: string; minimum_performance: number }[];
 }) => {
   if (submissions.length == 0) {
@@ -23,6 +26,11 @@ const Recommendations = ({
     (map, { problem_id, minimum_performance }) =>
       map.set(problem_id, minimum_performance),
     new Map<string, number>()
+  );
+
+  const contest_map = contests.reduce(
+    (map, contest) => map.set(contest.id, contest),
+    new Map<string, Contest>()
   );
 
   const accepted_problem_ids = submissions
@@ -54,7 +62,12 @@ const Recommendations = ({
       const db = Math.abs(pb - predicted_performance);
       return da - db;
     })
-    .slice(0, RECOMMEND_NUM);
+    .slice(0, RECOMMEND_NUM)
+    .map(p => Object.assign({
+      difficulty: performance_map.get(p.id) as number,
+      contest: contest_map.get(p.contest_id) as Contest
+    }, p))
+    .sort((a, b) => b.difficulty - a.difficulty);
 
   return (
     <BootstrapTable
@@ -64,6 +77,18 @@ const Recommendations = ({
       hover
       striped
     >
+      <TableHeaderColumn
+        dataField="contest"
+        dataFormat={(
+          {id, title}: {id: string, title: string}
+        ) => (
+          <a href={Url.formatContestUrl(id)} target="_blank">
+            {title}
+          </a>
+        )}
+      >
+        Contest
+      </TableHeaderColumn>
       <TableHeaderColumn
         dataField="title"
         dataFormat={(
@@ -76,6 +101,11 @@ const Recommendations = ({
         )}
       >
         Title
+      </TableHeaderColumn>
+      <TableHeaderColumn
+        dataField="difficulty"
+      >
+        Difficulty
       </TableHeaderColumn>
     </BootstrapTable>
   );

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -5,6 +5,7 @@ import * as Api from "../../utils/Api";
 import Submission from "../../interfaces/Submission";
 import UserInfo from "../../interfaces/UserInfo";
 import MergedProblem from "../../interfaces/MergedProblem";
+import Contest from "../../interfaces/Contest";
 import { ordinalSuffixOf, isAccepted } from "../../utils";
 import { formatDate } from "../../utils/DateFormat";
 
@@ -33,6 +34,7 @@ interface State {
   problems: MergedProblem[];
   submissions: Submission[];
   user_info: UserInfo;
+  contests: Contest[];
 
   problem_performances: { problem_id: string; minimum_performance: number }[];
 
@@ -61,6 +63,7 @@ class UserPage extends React.Component<Props, State> {
         rated_point_sum_rank: 1e9 + 7,
         user_id: ""
       },
+      contests: [],
 
       problem_performances: [],
 
@@ -77,8 +80,9 @@ class UserPage extends React.Component<Props, State> {
     Promise.all([
       Api.fetchMergedProblems(),
       Api.fetchContestProblemPairs(),
-      Api.fetchProblemPerformances()
-    ]).then(([problems, edges, problem_performances]) => {
+      Api.fetchProblemPerformances(),
+      Api.fetchContests()
+    ]).then(([problems, edges, problem_performances, contests]) => {
       const fast_ranking = Api.getFastRanking(problems).sort(
         (a, b) => b.problem_count - a.problem_count
       );
@@ -94,7 +98,8 @@ class UserPage extends React.Component<Props, State> {
         short_ranking,
         problems,
         edges,
-        problem_performances
+        problem_performances,
+        contests
       });
     });
     this.updateState(this.getUserIdFromProps());
@@ -158,7 +163,8 @@ class UserPage extends React.Component<Props, State> {
       last_ac,
       problems,
       edges,
-      problem_performances
+      problem_performances,
+      contests
     } = this.state;
     if (user_id.length == 0 || submissions.length == 0) {
       return null;
@@ -331,6 +337,7 @@ class UserPage extends React.Component<Props, State> {
         <Recommendations
           submissions={submissions}
           problems={problems}
+          contests={contests}
           performances={problem_performances}
         />
       </div>


### PR DESCRIPTION
Recommends のテーブルが寂しい気がしたので以下を追加 / 変更しました。

1. Contest column を追加  
    どのコンテストの問題かわかった方がいい気がします。 元のままでも url 見ればわかりますが
2. Difficulty column を追加  
    難易度の目安の表示があると嬉しい気がするのですが、どう算出された値なのかを別に表記しておいた方がいいかもしれません。
    https://twitter.com/kenkoooo/status/1128844726843654150
    https://twitter.com/kenkoooo/status/1128844814085238785
3. 表示順を difficulty 降順に変更
4. Title column を Problem column に表記変更  
    他のテーブルでは表記が Problem になっていたので合わせました

![fig](https://user-images.githubusercontent.com/11204237/57878781-c2f68580-7855-11e9-8d3a-2a7071ff9ec3.png)
