### PR TITLE
Add `extern crate openssl;` to crawl to build on musl

### DIFF
--- a/atcoder-problems-backend/src/bin/crawl.rs
+++ b/atcoder-problems-backend/src/bin/crawl.rs
@@ -1,3 +1,5 @@
+extern crate openssl;
+
 use atcoder_problems_backend::{crawler, scraper};
 use diesel::pg::PgConnection;
 use diesel::Connection;


### PR DESCRIPTION
Crawlerをmuslでビルドしようとしたところ失敗しましたが
https://github.com/emk/rust-musl-builder/issues/64#issuecomment-484209412
を参考に`extern crate openssl;`をつけたらよくわかりませんがビルドできたのでPRを送らせていただきます