### PR TITLE
ライバルIDフォームへのスペースの混入を許容する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ matrix:
         - npm install yarn -g
         - yarn
         - yarn build
+        - yarn test

--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -19,7 +19,11 @@ import TablePage from "./pages/TablePage";
 import Monitor from './pages/Monitor';
 
 import NavigationBar from "./components/NavigationBar";
-import { ATCODER_USER_REGEXP, ATCODER_RIVALS_REGEXP } from "./utils";
+import {
+  ATCODER_USER_REGEXP,
+  ATCODER_RIVALS_REGEXP,
+  extractRivalsParam
+} from "./utils";
 type MatchUserId = { match: { params: { user_id?: string } } };
 const extractUserId = ({
   match: {
@@ -83,7 +87,7 @@ class App extends Component {
                   const rivals =
                     rivals_param != null &&
                       rivals_param.match(ATCODER_RIVALS_REGEXP)
-                      ? rivals_param.split(",")
+                      ? extractRivalsParam(rivals_param)
                       : [];
                   const kind =
                     kind_param === "list"

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -16,7 +16,11 @@ import {
   Button,
   FormGroup
 } from "reactstrap";
-import { ATCODER_USER_REGEXP, ATCODER_RIVALS_REGEXP } from "../utils";
+import {
+  ATCODER_USER_REGEXP,
+  ATCODER_RIVALS_REGEXP,
+  extractRivalsParam
+} from "../utils";
 
 enum PageKind {
   TABLE = "table",
@@ -63,10 +67,8 @@ class PrimitiveNavigationBar extends React.Component<
       users.push("");
     }
     if (rival_id.match(ATCODER_RIVALS_REGEXP)) {
-      rival_id
-        .split(",")
-        .filter(user => user.length > 0)
-        .forEach(user => users.push(user));
+      const rivals = extractRivalsParam(rival_id);
+      users.push(...rivals);
     }
 
     const current_pathname = this.props.location.pathname;

--- a/atcoder-problems-frontend/src/utils/index.test.ts
+++ b/atcoder-problems-frontend/src/utils/index.test.ts
@@ -1,4 +1,8 @@
-import {ATCODER_RIVALS_REGEXP, ATCODER_USER_REGEXP} from "./index";
+import {
+  ATCODER_RIVALS_REGEXP,
+  ATCODER_USER_REGEXP,
+  extractRivalsParam
+} from "./index";
 
 describe ("user regex", () => {
   it ("should match", () => {
@@ -26,4 +30,9 @@ describe ("rival regex", () => {
   it ("user names including invalid char should not match", () => {
     expect("user^, user|".match(ATCODER_RIVALS_REGEXP)).toBeFalsy();
   });
+});
+
+it ("extract rival params", () => {
+  expect(extractRivalsParam(" user1 , USER2, user_3 "))
+    .toMatchObject(["user1", "USER2", "user_3"]);
 });

--- a/atcoder-problems-frontend/src/utils/index.test.ts
+++ b/atcoder-problems-frontend/src/utils/index.test.ts
@@ -1,0 +1,29 @@
+import {ATCODER_RIVALS_REGEXP, ATCODER_USER_REGEXP} from "./index";
+
+describe ("user regex", () => {
+  it ("should match", () => {
+    expect("user_1a".match(ATCODER_USER_REGEXP)).toBeTruthy();
+  });
+
+  it ("should not match", () => {
+    expect("user;".match(ATCODER_USER_REGEXP)).toBeFalsy();
+  });
+});
+
+describe ("rival regex", () => {
+  it ("should match", () => {
+    expect(" user1 , USER2, user_3 ".match(ATCODER_RIVALS_REGEXP)).toBeTruthy();
+  });
+
+  it ("empty string should not match", () => {
+    expect("".match(ATCODER_RIVALS_REGEXP)).toBeFalsy();
+  });
+
+  it ("user names separated spaces should not match", () => {
+    expect("user1 user2".match(ATCODER_RIVALS_REGEXP)).toBeFalsy();
+  });
+
+  it ("user names including invalid char should not match", () => {
+    expect("user^, user|".match(ATCODER_RIVALS_REGEXP)).toBeFalsy();
+  });
+});

--- a/atcoder-problems-frontend/src/utils/index.ts
+++ b/atcoder-problems-frontend/src/utils/index.ts
@@ -3,6 +3,13 @@ export const ATCODER_USER_REGEXP = new RegExp(`^${userIdRegex.source}$`);
 export const ATCODER_RIVALS_REGEXP = new RegExp(
   `^\\s*(${userIdRegex.source})\\s*(,\\s*(${userIdRegex.source})\\s*)*$`
 );
+
+export const extractRivalsParam = (rivalsParam: string) : string[] => {
+  return rivalsParam.split(",")
+    .map(rival => rival.trim())
+    .filter(rival => rival.length > 0);
+};
+
 export const isAccepted = (result: string) => result === "AC";
 export const ordinalSuffixOf = (i: number) => {
   const j = i % 10;

--- a/atcoder-problems-frontend/src/utils/index.ts
+++ b/atcoder-problems-frontend/src/utils/index.ts
@@ -1,5 +1,8 @@
-export const ATCODER_USER_REGEXP = /^[0-9a-zA-Z_]+$/;
-export const ATCODER_RIVALS_REGEXP = /^[a-zA-Z0-9_,]+$/;
+const userIdRegex = /[0-9a-zA-Z_]+/;
+export const ATCODER_USER_REGEXP = new RegExp(`^${userIdRegex.source}$`);
+export const ATCODER_RIVALS_REGEXP = new RegExp(
+  `^\\s*(${userIdRegex.source})\\s*(,\\s*(${userIdRegex.source})\\s*)*$`
+);
 export const isAccepted = (result: string) => result === "AC";
 export const ordinalSuffixOf = (i: number) => {
   const j = i % 10;


### PR DESCRIPTION
現在、ナビゲーションバーのライバルIDフォームに空白文字が混入していると、入力されたライバルIDの列がinvalidであるとみなされてしまいます。例えば、`kenkoooo, blue_jam`とライバルIDフォームに入力しても、フォームが空のときと同じ処理がなされてしまいます。

このPRでは、ライバルIDフォームの先頭・末尾およびカンマの前後の空白文字列を許容します。例えば、` kenkoooo   ,    blue_jam   ` と入力した場合と `kenkoooo,blue_jam` と入力した場合で同じ結果が表示されるようにします。

また、次の変更も行っています。

* ユーザID、ライバルID列のvalidity判断用正規表現へのテストの追加
* TravisCIでのユニットテストの実行