### PR TITLE
added difficulty circle

### DIFF
--- a/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
+++ b/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
@@ -15,7 +15,7 @@ function getColor (difficulty: number): string {
   else if(difficulty < 800) return '#804000'; // brown
   else if(difficulty < 1200) return '#008000'; // green
   else if(difficulty < 1600) return '#00C0C0'; // cyan
-  else if(difficulty < 2000) return '#7F7FFF'; // blue
+  else if(difficulty < 2000) return '#0000FF'; // blue
   else if(difficulty < 2400) return '#C0C000'; // yellow
   else if(difficulty < 2800) return '#FF8000'; // orange
   else return '#FF0000'; // red

--- a/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
+++ b/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {Tooltip} from "reactstrap";
+
+interface Props {
+  id: string;
+  difficulty: number | null;
+}
+
+interface LocalState {
+  tooltipOpen: boolean;
+}
+
+function getColor (difficulty: number): string {
+  if(difficulty < 400) return '#808080'; // grey
+  else if(difficulty < 800) return '#804000'; // brown
+  else if(difficulty < 1200) return '#008000'; // green
+  else if(difficulty < 1600) return '#00C0C0'; // cyan
+  else if(difficulty < 2000) return '#7F7FFF'; // blue
+  else if(difficulty < 2400) return '#C0C000'; // yellow
+  else if(difficulty < 2800) return '#FF8000'; // orange
+  else return '#FF0000'; // red
+}
+
+export class DifficultyCircle extends React.Component<Props, LocalState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      tooltipOpen: false
+    };
+  }
+
+  render (): React.ReactNode {
+    const {id, difficulty} = this.props;
+    if(difficulty === null){
+      return null;
+    }
+    const difficultyClipped = Math.round(difficulty >= 400 ? difficulty : 400 / Math.exp(1.0 - difficulty / 400));
+    const {tooltipOpen} = this.state
+    const fillRatio: number = (difficultyClipped >= 3200 ? 1.0 : (difficultyClipped % 400) / 400);
+    const color: string = getColor(difficultyClipped);
+    const r: number = parseInt(color.slice(1, 3), 16);
+    const g: number = parseInt(color.slice(3, 5), 16);
+    const b: number = parseInt(color.slice(5, 7), 16);
+    const styleOptions = Object({
+      "borderColor": color,
+      "background": `linear-gradient(to top, rgba(${r}, ${g}, ${b}, ${1.0}) 0%, rgba(${r}, ${g}, ${b}, ${1.0}) ${fillRatio*100}%, rgba(${r}, ${g}, ${b}, ${0.0}) ${fillRatio*100}%, rgba(${r}, ${g}, ${b}, ${0.0}) 100%)`,
+    });
+    const title: string = `Difficulty: ${Math.round(difficultyClipped)}`;
+    const circleId = 'DifficultyCircle-' + id;
+    return (<>
+      <span className="difficulty-circle" style={styleOptions} id={circleId}> 
+      </span>
+      <Tooltip
+        placement="top"
+        target={circleId}
+        isOpen={tooltipOpen}
+        toggle={() => this.setState({tooltipOpen: !tooltipOpen})}
+      >
+        {title}
+      </Tooltip>
+    </>);
+  }
+}

--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -21,3 +21,13 @@ code {
     word-break: break-word;
   }
 }
+
+span.difficulty-circle {
+  display: inline-block;
+  border-radius: 50%;
+  border-style: solid;
+  border-width: 1px;
+  margin-right: 5px;
+  height: 12px;
+  width: 12px;
+}

--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -31,3 +31,29 @@ span.difficulty-circle {
   height: 12px;
   width: 12px;
 }
+
+.difficulty-red {
+  color: #FF0000;
+}
+.difficulty-orange {
+  color: #FF8000;
+}
+.difficulty-yellow {
+  color: #C0C000;
+}
+.difficulty-blue {
+  color: #0000FF;
+}
+.difficulty-cyan {
+  color: #00C0C0;
+}
+.difficulty-green {
+  color: #008000;
+}
+.difficulty-brown {
+  color: #804000;
+}
+.difficulty-grey {
+  color: #808080;
+}
+

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -257,7 +257,8 @@ class ListPage extends React.Component<Props, ListPageState> {
           if (difficulty >= INF_POINT) {
             return <p>-</p>;
           } else {
-            return <p>{difficulty}</p>;
+            const difficultyClipped = Math.round(difficulty >= 400 ? difficulty : 400 / Math.exp(1.0 - difficulty / 400));
+            return <p>{difficultyClipped}</p>;
           }
         }
       },

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -25,6 +25,18 @@ interface Props {
   problemModels: Map<string, ProblemModel>;
 }
 
+function getColorClass (difficulty: number | null): string {
+  if(difficulty === null) return "";
+  if(difficulty < 400) return 'difficulty-grey'; // grey
+  else if(difficulty < 800) return 'difficulty-brown'; // brown
+  else if(difficulty < 1200) return 'difficulty-green'; // green
+  else if(difficulty < 1600) return 'difficulty-cyan'; // cyan
+  else if(difficulty < 2000) return 'difficulty-blue'; // blue
+  else if(difficulty < 2400) return 'difficulty-yellow'; // yellow
+  else if(difficulty < 2800) return 'difficulty-orange'; // orange
+  else return 'difficulty-red'; // red
+}
+
 export const AtCoderRegularTable: React.FC<Props> = props => {
   const { contestToProblems, showSolved, showDifficulty, statusLabelMap, problemModels } = props;
   const solvedAll = (contest: Contest) => {
@@ -87,25 +99,35 @@ export const AtCoderRegularTable: React.FC<Props> = props => {
             }}
             dataFormat={(_: any, contest: Contest) => {
               const problem = ithProblem(contest, i);
-              return problem ? (
-                <>
-                  {showDifficulty ? (
+              if(problem){
+                if(showDifficulty){
+                  const difficulty = problemModels.getIn([problem.id, "difficulty"], null);
+                  return (<>
                     <DifficultyCircle
-                      difficulty={problemModels.getIn([problem.id, "difficulty"], null)}
+                      difficulty={difficulty}
                       id={problem.id + '-' + contest.id}
-                    />) :
-                    null
-                  }
-                  <a
-                    href={Url.formatProblemUrl(problem.id, contest.id)}
-                    target="_blank"
-                  >
-                    {problem.title}
-                  </a>
-                </>
-              ) : (
-                ""
-              );
+                    />
+                    <a
+                      href={Url.formatProblemUrl(problem.id, contest.id)}
+                      target="_blank"
+                      className={getColorClass(difficulty)}
+                    >
+                      {problem.title}
+                    </a>
+                  </>);
+                } else {
+                  return (
+                    <a
+                      href={Url.formatProblemUrl(problem.id, contest.id)}
+                      target="_blank"
+                    >
+                      {problem.title}
+                    </a>
+                  );
+                }
+              } else {
+                return "";
+              }
             }}
           >
             {c}

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -12,17 +12,21 @@ import {
   StatusLabel
 } from "../../interfaces/State";
 import { statusLabelToTableColor } from "./index";
+import ProblemModel from "../../interfaces/ProblemModel";
+import {DifficultyCircle} from "../../components/DifficultyCircle";
 
 interface Props {
   contests: Map<string, Contest>;
   contestToProblems: Map<string, List<Problem>>;
   showSolved: boolean;
+  showDifficulty: boolean;
   title: string;
   statusLabelMap: Map<ProblemId, ProblemStatus>;
+  problemModels: Map<string, ProblemModel>;
 }
 
 export const AtCoderRegularTable: React.FC<Props> = props => {
-  const { contestToProblems, showSolved, statusLabelMap } = props;
+  const { contestToProblems, showSolved, showDifficulty, statusLabelMap, problemModels } = props;
   const solvedAll = (contest: Contest) => {
     return contestToProblems
       .get(contest.id, List<Problem>())
@@ -84,12 +88,21 @@ export const AtCoderRegularTable: React.FC<Props> = props => {
             dataFormat={(_: any, contest: Contest) => {
               const problem = ithProblem(contest, i);
               return problem ? (
-                <a
-                  href={Url.formatProblemUrl(problem.id, contest.id)}
-                  target="_blank"
-                >
-                  {problem.title}
-                </a>
+                <>
+                  {showDifficulty ? (
+                    <DifficultyCircle
+                      difficulty={problemModels.getIn([problem.id, "difficulty"], null)}
+                      id={problem.id + '-' + contest.id}
+                    />) :
+                    null
+                  }
+                  <a
+                    href={Url.formatProblemUrl(problem.id, contest.id)}
+                    target="_blank"
+                  >
+                    {problem.title}
+                  </a>
+                </>
               ) : (
                 ""
               );

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -82,7 +82,7 @@ class TablePage extends React.Component<Props, LocalState> {
     return (
       <div>
         <Row className="my-4">
-          <FormGroup check>
+          <FormGroup check inline>
             <Label check>
               <Input
                 type="checkbox"
@@ -92,7 +92,7 @@ class TablePage extends React.Component<Props, LocalState> {
               Show Accepted
             </Label>
           </FormGroup>
-          <FormGroup check>
+          <FormGroup check inline>
             <Label check>
               <Input
                 type="checkbox"

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormGroup, Input, Label, Row } from "reactstrap";
 import { connect } from "react-redux";
+import {Dispatch} from "redux";
 import Contest from "../../interfaces/Contest";
 import Problem from "../../interfaces/Problem";
 import State, {
@@ -11,8 +12,10 @@ import State, {
 } from "../../interfaces/State";
 import { List, Map } from "immutable";
 import Submission from "../../interfaces/Submission";
+import ProblemModel from "../../interfaces/ProblemModel";
 import ContestTable from "./ContestTable";
 import { AtCoderRegularTable } from "./AtCoderRegularTable";
+import {requestProblemModels} from "../../actions";
 
 export const statusLabelToTableColor = (label: StatusLabel) => {
   switch (label) {
@@ -36,29 +39,39 @@ interface Props {
   contests: Map<ContestId, Contest>;
   contestToProblems: Map<ContestId, List<Problem>>;
   statusLabelMap: Map<ProblemId, ProblemStatus>;
+  problemModels: Map<string, ProblemModel>;
+
+  requestData: () => void;
 }
 
 interface LocalState {
   showSolved: boolean;
+  showDifficulty: boolean;
 }
 
 class TablePage extends React.Component<Props, LocalState> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      showSolved: true
+      showSolved: true,
+      showDifficulty: false
     };
   }
 
+  componentDidMount() {
+    this.props.requestData();
+  }
+
   render() {
-    const { showSolved } = this.state;
+    const { showSolved, showDifficulty } = this.state;
     const {
       userId,
       rivals,
       contests,
       contestToProblems,
       submissions,
-      statusLabelMap
+      statusLabelMap,
+      problemModels
     } = this.props;
 
     const abc = contests.filter((v, k) => k.match(/^abc\d{3}$/));
@@ -79,27 +92,43 @@ class TablePage extends React.Component<Props, LocalState> {
               Show Accepted
             </Label>
           </FormGroup>
+          <FormGroup check>
+            <Label check>
+              <Input
+                type="checkbox"
+                checked={showDifficulty}
+                onChange={() => this.setState({ showDifficulty: !showDifficulty })}
+              />
+              Show Difficulty
+            </Label>
+          </FormGroup>
         </Row>
         <AtCoderRegularTable
           showSolved={showSolved}
+          showDifficulty={showDifficulty}
           contests={abc}
           title="AtCoder Beginner Contest"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
+          problemModels={problemModels}
         />
         <AtCoderRegularTable
           showSolved={showSolved}
+          showDifficulty={showDifficulty}
           contests={arc}
           title="AtCoder Regular Contest"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
+          problemModels={problemModels}
         />
         <AtCoderRegularTable
           showSolved={showSolved}
+          showDifficulty={showDifficulty}
           contests={agc}
           title="AtCoder Grand Contest"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
+          problemModels={problemModels}
         />
         <Row className="my-4">
           <h2>Other Contests</h2>
@@ -131,7 +160,17 @@ const stateToProps = (state: State) => ({
   ),
   contests: state.contests,
   submissions: state.submissions,
-  statusLabelMap: state.cache.statusLabelMap
+  statusLabelMap: state.cache.statusLabelMap,
+  problemModels: state.problemModels
 });
 
-export default connect(stateToProps)(TablePage);
+const dispatchToProps = (dispatch: Dispatch) => ({
+  requestData: () => {
+    dispatch(requestProblemModels());
+  }
+});
+
+export default connect(
+  stateToProps,
+  dispatchToProps
+)(TablePage);

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -158,7 +158,14 @@ class Recommendations extends React.Component<Props, LocalState> {
             >
               Contest
             </TableHeaderColumn>
-            <TableHeaderColumn dataField="difficulty">
+            <TableHeaderColumn
+              dataField="difficulty"
+              dataFormat={(difficulty: number | null) => {
+                if(difficulty === null) return "-";
+                const difficultyClipped = Math.round(difficulty >= 400 ? difficulty : 400 / Math.exp(1.0 - difficulty / 400));
+                return String(difficultyClipped);
+              }}
+            >
               <span>
                 Difficulty
               </span>


### PR DESCRIPTION
* Table ページの問題名の横に difficulty の玉を表示、問題名に色を付けるようにしました  
difficulty はユーザの rating と同じ水準で計算されているため、目安として有用だと思います。 ネタバレ防止のためデフォルトでオフ、ページ上部の Show Difficulty にチェックを入れると有効化されます。
![ball](https://user-images.githubusercontent.com/11204237/64371961-cf992680-d05c-11e9-82ee-a758dcf994f3.png)
問題名の色は視認性を落としているかもしれません。 利用者の反応によっては玉のみにした方がいいかも。

* List / User ページで表示される difficulty の値を次のリンク先の計算式に基づき正規化しました
[AtCoderのレート計算式#性質4-初心者への慈悲](https://qiita.com/anqooqie/items/92005e337a0d2569bdbd#%E6%80%A7%E8%B3%AA4-%E5%88%9D%E5%BF%83%E8%80%85%E3%81%B8%E3%81%AE%E6%85%88%E6%82%B2)
   ```
   f(x) = x > 400 ? x : 400 / exp(1 - x / 400)
   ```
   [補足] AtCoder のユーザページ に表示されるパフォーマンス値も負の値を避けるため同様に正規化されています


redux / redux-saga をイマイチ理解できていないので適当にやっつけてます