### PR TITLE
Resolved #252 and others

### DIFF
--- a/atcoder-problems-frontend/src/actions.ts
+++ b/atcoder-problems-frontend/src/actions.ts
@@ -34,18 +34,19 @@ export const RECEIVE_SUM_RANKING = "RECEIVE_SUM_RANKING";
 export const REQUEST_LANG_RANKING = "REQUEST_LANG_RANKING";
 export const RECEIVE_LANG_RANKING = "RECEIVE_LANG_RANKING";
 
-export const REQUEST_PROBLEM_MODELS = "REQUEST_PROBLEM_MODELS";
-export const RECEIVE_PROBLEM_MODELS = "RECEIVE_PROBLEM_MODELS";
+export const UPDATE_SHOW_DIFFICULTY = "UPDATE_SHOW_DIFFICULTY";
 
 export const receiveInitialData = (
   contests: List<Contest>,
   problems: List<Problem>,
-  pairs: List<{ contest_id: string; problem_id: string }>
+  pairs: List<{ contest_id: string; problem_id: string }>,
+  problemModels: Map<string, ProblemModel>
 ) => ({
   type: RECEIVE_INITIAL_DATA as typeof RECEIVE_INITIAL_DATA,
   contests,
   problems,
-  pairs
+  pairs,
+  problemModels
 });
 
 export const updateUserIds = (userId: string, rivals: List<string>) => ({
@@ -105,13 +106,9 @@ export const receiveLangRanking = (ranking: List<LangRankingEntry>) => ({
   ranking
 });
 
-export const requestProblemModels = () => ({
-  type: REQUEST_PROBLEM_MODELS as typeof REQUEST_PROBLEM_MODELS
-});
-
-export const receiveProblemModels = (problemModels: Map<string, ProblemModel>) => ({
-  type: RECEIVE_PROBLEM_MODELS as typeof RECEIVE_PROBLEM_MODELS,
-  problemModels: problemModels
+export const updateShowDifficulty = (showDifficulty: boolean) => ({
+  type: UPDATE_SHOW_DIFFICULTY as typeof UPDATE_SHOW_DIFFICULTY,
+  showDifficulty
 });
 
 type Action =
@@ -128,7 +125,6 @@ type Action =
   | ReturnType<typeof receiveSumRanking>
   | ReturnType<typeof requestLangRanking>
   | ReturnType<typeof receiveLangRanking>
-  | ReturnType<typeof requestProblemModels>
-  | ReturnType<typeof receiveProblemModels>;
+  | ReturnType<typeof updateShowDifficulty>;
 
 export default Action;

--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import {connect} from "react-redux";
+import {Map} from "immutable";
+import State from "../interfaces/State";
+import ProblemModel from "../interfaces/ProblemModel";
+import * as Url from "../utils/Url";
+import {DifficultyCircle} from "./DifficultyCircle";
+
+interface Props {
+  problemId: string;
+  contestId: string;
+  problemTitle: string;
+  problemModels: Map<string, ProblemModel>;
+  showDifficulty: boolean;
+}
+
+function getColorClass (difficulty: number | null): string {
+  if(difficulty === null) return "";
+  if(difficulty < 400) return 'difficulty-grey'; // grey
+  else if(difficulty < 800) return 'difficulty-brown'; // brown
+  else if(difficulty < 1200) return 'difficulty-green'; // green
+  else if(difficulty < 1600) return 'difficulty-cyan'; // cyan
+  else if(difficulty < 2000) return 'difficulty-blue'; // blue
+  else if(difficulty < 2400) return 'difficulty-yellow'; // yellow
+  else if(difficulty < 2800) return 'difficulty-orange'; // orange
+  else return 'difficulty-red'; // red
+}
+
+const ProblemLink: React.FC<Props> = props => {
+  const {contestId, problemId, problemTitle, problemModels, showDifficulty} = props;
+  const link = (
+    <a
+      href={Url.formatProblemUrl(problemId, contestId)}
+      target="_blank"
+    >
+      {problemTitle}
+    </a>
+  );
+  if(!showDifficulty) return link;
+
+  const difficulty: number | null = problemModels.getIn([problemId, 'difficulty'], null);
+  if(difficulty === null) return link;
+  return (
+    <>
+      <DifficultyCircle
+        id={problemId + '-' + contestId}
+        difficulty={difficulty} />
+      <a
+        href={Url.formatProblemUrl(problemId, contestId)}
+        target="_blank"
+        className={getColorClass(difficulty)}
+      >
+        {problemTitle}
+      </a>
+    </>
+  );
+};
+
+const mapStateToProps = (state: State) => ({
+  problemModels: state.problemModels,
+  showDifficulty: state.showDifficulty
+});
+
+export default connect(
+  mapStateToProps
+)(ProblemLink);
+

--- a/atcoder-problems-frontend/src/interfaces/State.ts
+++ b/atcoder-problems-frontend/src/interfaces/State.ts
@@ -31,6 +31,7 @@ export default interface State {
   readonly langRanking: List<LangRankingEntry>;
   readonly contestHistory: List<ContestParticipation>;
   readonly problemModels: Map<ProblemId, ProblemModel>;
+  readonly showDifficulty: boolean;
 
   readonly cache: {
     readonly statusLabelMap: Map<ProblemId, ProblemStatus>;

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -27,8 +27,9 @@ import State, {
   StatusLabel
 } from "../../interfaces/State";
 import { List, Map, Set } from "immutable";
-import { requestMergedProblems, requestProblemModels } from "../../actions";
+import { requestMergedProblems } from "../../actions";
 import ProblemModel from "../../interfaces/ProblemModel";
+import ProblemLink from "../../components/ProblemLink";
 
 const INF_POINT = 1e18;
 
@@ -158,15 +159,11 @@ class ListPage extends React.Component<Props, ListPageState> {
         dataField: "title",
         dataSort: true,
         dataFormat: (_, row) => (
-          <a
-            href={Url.formatProblemUrl(
-              row.mergedProblem.id,
-              row.mergedProblem.contest_id
-            )}
-            target="_blank"
-          >
-            {row.title}
-          </a>
+          <ProblemLink
+            problemId={row.mergedProblem.id}
+            problemTitle={row.title}
+            contestId={row.mergedProblem.contest_id}
+          />
         )
       },
       {
@@ -591,7 +588,6 @@ const stateToProps = (state: State) => ({
 const dispatchToProps = (dispatch: Dispatch) => ({
   requestData: () => {
     dispatch(requestMergedProblems());
-    dispatch(requestProblemModels());
   }
 });
 

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -12,33 +12,18 @@ import {
   StatusLabel
 } from "../../interfaces/State";
 import { statusLabelToTableColor } from "./index";
-import ProblemModel from "../../interfaces/ProblemModel";
-import {DifficultyCircle} from "../../components/DifficultyCircle";
+import ProblemLink from "../../components/ProblemLink";
 
 interface Props {
   contests: Map<string, Contest>;
   contestToProblems: Map<string, List<Problem>>;
   showSolved: boolean;
-  showDifficulty: boolean;
   title: string;
   statusLabelMap: Map<ProblemId, ProblemStatus>;
-  problemModels: Map<string, ProblemModel>;
-}
-
-function getColorClass (difficulty: number | null): string {
-  if(difficulty === null) return "";
-  if(difficulty < 400) return 'difficulty-grey'; // grey
-  else if(difficulty < 800) return 'difficulty-brown'; // brown
-  else if(difficulty < 1200) return 'difficulty-green'; // green
-  else if(difficulty < 1600) return 'difficulty-cyan'; // cyan
-  else if(difficulty < 2000) return 'difficulty-blue'; // blue
-  else if(difficulty < 2400) return 'difficulty-yellow'; // yellow
-  else if(difficulty < 2800) return 'difficulty-orange'; // orange
-  else return 'difficulty-red'; // red
 }
 
 export const AtCoderRegularTable: React.FC<Props> = props => {
-  const { contestToProblems, showSolved, showDifficulty, statusLabelMap, problemModels } = props;
+  const { contestToProblems, showSolved, statusLabelMap } = props;
   const solvedAll = (contest: Contest) => {
     return contestToProblems
       .get(contest.id, List<Problem>())
@@ -100,31 +85,13 @@ export const AtCoderRegularTable: React.FC<Props> = props => {
             dataFormat={(_: any, contest: Contest) => {
               const problem = ithProblem(contest, i);
               if(problem){
-                if(showDifficulty){
-                  const difficulty = problemModels.getIn([problem.id, "difficulty"], null);
-                  return (<>
-                    <DifficultyCircle
-                      difficulty={difficulty}
-                      id={problem.id + '-' + contest.id}
-                    />
-                    <a
-                      href={Url.formatProblemUrl(problem.id, contest.id)}
-                      target="_blank"
-                      className={getColorClass(difficulty)}
-                    >
-                      {problem.title}
-                    </a>
-                  </>);
-                } else {
-                  return (
-                    <a
-                      href={Url.formatProblemUrl(problem.id, contest.id)}
-                      target="_blank"
-                    >
-                      {problem.title}
-                    </a>
-                  );
-                }
+                return (
+                  <ProblemLink
+                    contestId={contest.id}
+                    problemId={problem.id}
+                    problemTitle={problem.title}
+                  />
+                );
               } else {
                 return "";
               }

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -7,6 +7,7 @@ import { Table } from "reactstrap";
 import React from "react";
 import { ProblemId, ProblemStatus, StatusLabel } from "../../interfaces/State";
 import { statusLabelToTableColor } from "./index";
+import ProblemLink from "../../components/ProblemLink";
 
 interface Props {
   contests: Map<string, Contest>;
@@ -54,12 +55,11 @@ const ContestTable = (props: Props) => (
                       : "";
                     return (
                       <td key={p.id} className={color}>
-                        <a
-                          target="_blank"
-                          href={Url.formatProblemUrl(p.id, p.contest_id)}
-                        >
-                          {p.title}
-                        </a>
+                        <ProblemLink
+                          problemId={p.id}
+                          problemTitle={p.title}
+                          contestId={p.contest_id}
+                        />
                       </td>
                     );
                   })}

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -15,6 +15,7 @@ import {RatingInfo} from "../../utils/RatingInfo";
 import {predictSolveProbability, predictSolveTime} from "../../utils/ProblemModelUtil";
 import {Button, ButtonGroup, Row} from "reactstrap";
 import HelpBadgeTooltip from "../../components/HelpBadgeTooltip";
+import ProblemLink from "../../components/ProblemLink";
 
 const RECOMMEND_NUM = 10;
 
@@ -138,9 +139,11 @@ class Recommendations extends React.Component<Props, LocalState> {
                 title: string,
                 {id, contest_id}: { id: string; contest_id: string; }
               ) => (
-                <a target="_blank" href={Url.formatProblemUrl(id, contest_id)}>
-                  {title}
-                </a>
+                <ProblemLink
+                  problemId={id}
+                  problemTitle={title}
+                  contestId={contest_id}
+                />
               )}
             >
               Problem

--- a/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
@@ -6,6 +6,7 @@ import { formatMoment, parseSecond } from "../../utils/DateUtil";
 import * as Url from "../../utils/Url";
 import { isAccepted } from "../../utils";
 import { Badge } from "reactstrap";
+import ProblemLink from "../../components/ProblemLink";
 
 const SubmissionList = ({
   submissions,
@@ -75,12 +76,11 @@ const SubmissionList = ({
         dataSort
         dataField="problem_id"
         dataFormat={(_: string, { problem_id, contest_id }: Submission) => (
-          <a
-            target="_blank"
-            href={Url.formatProblemUrl(problem_id, contest_id)}
-          >
-            {title_map.get(problem_id)}
-          </a>
+          <ProblemLink
+            problemId={problem_id}
+            problemTitle={title_map.get(problem_id) || ""}
+            contestId={contest_id}
+          />
         )}
       >
         Problem

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -17,7 +17,7 @@ import LanguageCount from "./LanguageCount";
 import Recommendations from "./Recommendations";
 import State from "../../interfaces/State";
 import {Dispatch} from "redux";
-import {requestMergedProblems, requestProblemModels} from "../../actions";
+import {requestMergedProblems} from "../../actions";
 import {List, Map} from "immutable";
 import {connect} from "react-redux";
 import {getFastRanking, getFirstRanking, getShortRanking} from "../../utils/Api";
@@ -397,7 +397,6 @@ const stateToProps = (state: State) => ({
 const dispatchToProps = (dispatch: Dispatch) => ({
   requestData: () => {
     dispatch(requestMergedProblems());
-    dispatch(requestProblemModels());
   }
 });
 

--- a/atcoder-problems-frontend/src/reducers.ts
+++ b/atcoder-problems-frontend/src/reducers.ts
@@ -15,12 +15,12 @@ import Action, {
   RECEIVE_LANG_RANKING,
   RECEIVE_MERGED_PROBLEMS,
   RECEIVE_PERF,
-  RECEIVE_PROBLEM_MODELS,
   RECEIVE_SUBMISSIONS,
   RECEIVE_SUM_RANKING,
   RECEIVE_USER_CONTEST_HISTORY,
   RECEIVE_USER_INFO,
-  UPDATE_USER_IDS
+  UPDATE_USER_IDS,
+  UPDATE_SHOW_DIFFICULTY
 } from "./actions";
 import MergedProblem from "./interfaces/MergedProblem";
 import Problem from "./interfaces/Problem";
@@ -51,6 +51,7 @@ const initialState: State = {
   langRanking: List(),
   contestHistory: List(),
   problemModels: Map(),
+  showDifficulty: true,
   cache: {
     statusLabelMap: Map()
   }
@@ -77,6 +78,7 @@ const dataReducer = (
   problems: Map<string, Problem>,
   contests: Map<string, Contest>,
   contestToProblems: Map<string, List<string>>,
+  problemModels: Map<string, ProblemModel>,
   action: Action
 ) => {
   switch (action.type) {
@@ -97,14 +99,16 @@ const dataReducer = (
       return {
         problems: newProblems,
         contests: newContests,
-        contestToProblems: newContestToProblems
+        contestToProblems: newContestToProblems,
+        problemModels: action.problemModels
       };
     }
     default: {
       return {
         problems,
         contests,
-        contestToProblems
+        contestToProblems,
+        problemModels
       };
     }
   }
@@ -183,6 +187,14 @@ const sumRankingReducer = (
   }
 };
 
+const showDifficultyReducer = (showDifficulty: boolean, action: Action) => {
+  if(action.type === UPDATE_SHOW_DIFFICULTY){
+    return action.showDifficulty;
+  }else{
+    return showDifficulty;
+  }
+}
+
 const langRankingReducer = (
   langRanking: List<LangRankingEntry>,
   action: Action
@@ -191,17 +203,6 @@ const langRankingReducer = (
     return action.ranking;
   } else {
     return langRanking;
-  }
-};
-
-const problemModelReducer = (
-  problemModels: Map<string, ProblemModel>,
-  action: Action
-): Map<string, ProblemModel> => {
-  if (action.type === RECEIVE_PROBLEM_MODELS) {
-    return action.problemModels;
-  } else {
-    return problemModels;
   }
 };
 
@@ -239,10 +240,11 @@ const statusLabelMapReducer = (
 
 const rootReducer = (state: State = initialState, action: Action): State => {
   performance.mark("reducer_start");
-  const { contests, problems, contestToProblems } = dataReducer(
+  const { contests, problems, contestToProblems, problemModels } = dataReducer(
     state.problems,
     state.contests,
     state.contestToProblems,
+    state.problemModels,
     action
   );
   const submissions = submissionReducer(state.submissions, action);
@@ -252,8 +254,8 @@ const rootReducer = (state: State = initialState, action: Action): State => {
   const sumRanking = sumRankingReducer(state.sumRanking, action);
   const acRanking = acRankingReducer(state.acRanking, action);
   const langRanking = langRankingReducer(state.langRanking, action);
-  const problemModels = problemModelReducer(state.problemModels, action);
   const contestHistory = userContestHistoryReducer(state.contestHistory, action);
+  const showDifficulty = showDifficultyReducer(state.showDifficulty, action);
 
   const statusLabelMap = statusLabelMapReducer(
     state.cache.statusLabelMap,
@@ -278,6 +280,7 @@ const rootReducer = (state: State = initialState, action: Action): State => {
     langRanking,
     contestHistory,
     problemModels,
+    showDifficulty,
     cache: {
       statusLabelMap
     }

--- a/atcoder-problems-frontend/src/sagas.ts
+++ b/atcoder-problems-frontend/src/sagas.ts
@@ -4,7 +4,6 @@ import Action, {
   receiveInitialData,
   receiveLangRanking,
   receiveMergedProblems,
-  receiveProblemModels,
   receiveSubmissions,
   receiveSumRanking,
   receiveUserContestHistory,
@@ -12,7 +11,6 @@ import Action, {
   REQUEST_AC_RANKING,
   REQUEST_LANG_RANKING,
   REQUEST_MERGED_PROBLEMS,
-  REQUEST_PROBLEM_MODELS,
   REQUEST_SUM_RANKING,
   UPDATE_USER_IDS
 } from "./actions";
@@ -50,12 +48,13 @@ function* requestAndReceiveSubmissions(action: Action) {
 }
 
 function* initialFetchData() {
-  const { pairs, contests, problems } = yield all({
+  const { pairs, contests, problems, problemModels } = yield all({
     pairs: call(fetchContestProblemPairs),
     contests: call(fetchContests),
-    problems: call(fetchProblems)
+    problems: call(fetchProblems),
+    problemModels: call(fetchProblemModels)
   });
-  yield put(receiveInitialData(contests, problems, pairs));
+  yield put(receiveInitialData(contests, problems, pairs, problemModels));
 }
 
 function* fetchMergedProblemsOnce() {
@@ -80,12 +79,6 @@ function* fetchLangRankingOnce() {
   yield take(REQUEST_LANG_RANKING);
   const ranking = yield call(fetchLangRanking);
   yield put(receiveLangRanking(ranking));
-}
-
-function* fetchProblemModelOnce() {
-  yield take(REQUEST_PROBLEM_MODELS);
-  const problemModels = yield call(fetchProblemModels);
-  yield put(receiveProblemModels(problemModels));
 }
 
 function* requestAndReceiveUserInfo(action: Action) {
@@ -114,8 +107,7 @@ function* rootSaga() {
     call(fetchMergedProblemsOnce),
     call(fetchAcRankingOnce),
     call(fetchSumRankingOnce),
-    call(fetchLangRankingOnce),
-    call(fetchProblemModelOnce)
+    call(fetchLangRankingOnce)
   ]);
 }
 


### PR DESCRIPTION
1. #255 で追加した difficulty 表示を Table ページのみではなく、 List / User ページでも表示するようにしました
2. 1 に伴って、必要になってから呼んでいた fetchProblemModelOnce を取りやめ、 initialFetchData で取得するよう変更しました
3. 1 を簡単に実現できるように、問題へのリンクを React コンポーネントとして分離しました
4. showDifficulty の初期値を true にしました  
    #255 でネタバレ防止のためと言いましたが、ユーザの反応を見る限り歓迎されているようなので、初期値で有効化しておいた方がいいと思いました。 Table ページで off にしておくと List / User ページでの表示も無効化されます
5. ☑️Show Difficulty の隣にヒントを表示するようにしました  
    表示内容は recommends の difficulty のヒントと同じものです
6. A*C 以外の rated コンテストをまとめて Other Rated Contests として一所に表示するようにしました。 これは #252 を解決します  
    ```
    AGC001 以降 && A*C でない && rate_change !== "-"
    ```
    でフィルターを掛けています。 ここにひっかからなかったものは以前と同じように Other Contests に表示します
7. 6 及び A*C にすぐ移動できるように Table ページ上部に移動用のボタンを設置しました