### PR TITLE
Add problem solving status table based on difficulties (List Page)

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { isAccepted, clipDifficulty } from "../../utils";
+import Table from "reactstrap/lib/Table";
+import Submission from "../../interfaces/Submission";
+import { List, Map, Range } from "immutable";
+import MergedProblem from "../../interfaces/MergedProblem";
+import ProblemModel from "../../interfaces/ProblemModel";
+import { DifficultyCircle } from "../../components/DifficultyCircle";
+
+interface Props {
+  mergedProblems: Map<string, MergedProblem>;
+  submissions: Map<string, List<Submission>>;
+  userIds: List<string>;
+  problemModels: Map<string, ProblemModel>;
+  setFilterFunc: (from: number, to: number) => any;
+}
+
+const INF_POINT = 1e18;
+
+const DifficultyTable = ({ submissions, userIds, mergedProblems, problemModels, setFilterFunc }: Props) => {
+  const difficulties: List<{from:number, to:number}> = Range(0, 4400, 400)
+    .map(from => ({
+      from,
+      to: from === 4000 ? INF_POINT : from + 399
+    }))
+    .toList();
+  const userPointCount = userIds
+    .filter(userId => userId.length > 0)
+    .map(userId => ({
+      userId,
+      difficultyLevelCounts: submissions
+        .map(list =>
+          list
+            .filter(s => s.user_id === userId)
+            .filter(s => isAccepted(s.result))
+            .map(s => mergedProblems.get(s.problem_id))
+            .filter(p => p && problemModels.has(p.id))
+            .filter((p): p is MergedProblem => p !== undefined)
+            .map(p => problemModels.getIn([p.id, "difficulty"], undefined))
+            .first(undefined)
+        )
+        .valueSeq()
+        .filter((d: number | undefined): d is number => d !== undefined)
+        .reduce(
+          (map, difficulty) => map.update(Math.floor(Math.min(4000, clipDifficulty(Math.round(difficulty))) / 400), 0, count => count + 1),
+          Map<number, number>()
+        )
+    }));
+  const totalCount = mergedProblems
+    .map(p => problemModels.getIn([p.id, "difficulty"], undefined))
+    .filter((d): d is number => d !== undefined)
+    .map(d => Math.floor(Math.min(4000, clipDifficulty(Math.round(d))) / 400))
+    .reduce(
+      (map, d) => map.update(d, 0, count => count + 1),
+      Map<number, number>()
+    )
+    .entrySeq()
+    .map(([difficultyLevel, count]) => ({ difficultyLevel, count }))
+    .sort((a, b) => a.difficultyLevel - b.difficultyLevel);
+
+  return (
+    <Table striped bordered hover responsive>
+      <thead>
+        <tr>
+          <th>Difficulty</th>
+          {totalCount.map(({ difficultyLevel }) => (
+            <th key={difficultyLevel} style={{whiteSpace: "nowrap"}}>
+              <a
+                href={window.location.hash}
+                onClick={()=>setFilterFunc(
+                  difficulties.get(difficultyLevel, {from: 0}).from,
+                  difficulties.get(difficultyLevel, {to: INF_POINT}).to)}>
+                <DifficultyCircle
+                  difficulty={difficulties.get(difficultyLevel, {from: INF_POINT}).from + 399}
+                  id={`difficulty-table-level-${difficultyLevel}`}
+                />{difficulties.get(difficultyLevel, {from: 0}).from}-
+              </a>
+            </th>
+          ))}
+        </tr>
+        <tr>
+          <th>Total</th>
+          {totalCount.map(({ difficultyLevel, count }) => (
+            <th key={difficultyLevel}>{count}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {userPointCount.map(({ userId, difficultyLevelCounts }) => (
+          <tr key={userId}>
+            <td>{userId}</td>
+            {totalCount.map(({ difficultyLevel }) => (
+              <td key={difficultyLevel}>{difficultyLevelCounts.get(difficultyLevel, 0)}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default DifficultyTable;

--- a/atcoder-problems-frontend/src/pages/ListPage/SmallTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/SmallTable.tsx
@@ -9,9 +9,10 @@ interface Props {
   mergedProblems: Map<string, MergedProblem>;
   submissions: Map<string, List<Submission>>;
   userIds: List<string>;
+  setFilterFunc: (point: number) => any;
 }
 
-const SmallTable = ({ submissions, userIds, mergedProblems }: Props) => {
+const SmallTable = ({ submissions, userIds, mergedProblems, setFilterFunc }: Props) => {
   const userPointCount = userIds
     .filter(userId => userId.length > 0)
     .map(userId => ({
@@ -48,7 +49,11 @@ const SmallTable = ({ submissions, userIds, mergedProblems }: Props) => {
         <tr>
           <th>Point</th>
           {totalCount.map(({ point }) => (
-            <th key={point}>{point}</th>
+            <th key={point}>
+              <a href={window.location.hash} onClick={()=>setFilterFunc(point)}>
+                {point}
+              </a>
+            </th>
           ))}
         </tr>
         <tr>

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -7,7 +7,8 @@ import {
   DropdownToggle,
   Row,
   UncontrolledButtonDropdown,
-  UncontrolledDropdown
+  UncontrolledDropdown,
+  Button
 } from "reactstrap";
 
 import { clipDifficulty, isAccepted } from "../../utils";
@@ -17,6 +18,7 @@ import MergedProblem from "../../interfaces/MergedProblem";
 import Contest from "../../interfaces/Contest";
 import Submission from "../../interfaces/Submission";
 import SmallTable from "./SmallTable";
+import DifficultyTable from "./DifficultyTable";
 import ButtonGroup from "reactstrap/lib/ButtonGroup";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
@@ -126,7 +128,6 @@ class ListPage extends React.Component<Props, ListPageState> {
           const difficulty = Math.round(
             problemModels.getIn([p.id, "difficulty"], INF_POINT)
           );
-          const difficultyClipped = clipDifficulty(difficulty);
 
           return {
             id: p.id,
@@ -136,7 +137,7 @@ class ListPage extends React.Component<Props, ListPageState> {
             lastAcceptedDate,
             solverCount: p.solver_count ? p.solver_count : 0,
             point,
-            difficulty: difficultyClipped,
+            difficulty: difficulty !== INF_POINT ? clipDifficulty(difficulty) : -1,
             firstUserId,
             executionTime,
             codeLength,
@@ -262,7 +263,7 @@ class ListPage extends React.Component<Props, ListPageState> {
         dataField: "difficulty",
         dataSort: true,
         dataFormat: (difficulty: number) => {
-          if (difficulty >= INF_POINT) {
+          if (difficulty === -1) {
             return <p>-</p>;
           } else {
             return <p>{difficulty}</p>;
@@ -389,6 +390,20 @@ class ListPage extends React.Component<Props, ListPageState> {
             mergedProblems={mergedProblems}
             submissions={submissions}
             userIds={rivals.insert(0, userId)}
+            setFilterFunc={(point: number)=>this.setState({ fromPoint: point, toPoint: point })}
+          />
+        </Row>
+
+        <Row className="my-2 border-bottom">
+          <h1>Difficulty Status</h1>
+        </Row>
+        <Row>
+          <DifficultyTable
+            mergedProblems={mergedProblems}
+            submissions={submissions}
+            userIds={rivals.insert(0, userId)}
+            problemModels={problemModels}
+            setFilterFunc={(from: number, to: number)=>this.setState({ fromDifficulty: from, toDifficulty: to })}
           />
         </Row>
 
@@ -527,7 +542,7 @@ class ListPage extends React.Component<Props, ListPageState> {
                 {difficulties.map(({ to }) => (
                   <DropdownItem
                     key={to}
-                    onClick={() => this.setState({ toDifficulty: to })}
+                    onClick={() => this.setState({ fromDifficulty: fromDifficulty !== -1 ? fromDifficulty : 0, toDifficulty: to })}
                   >
                     <DifficultyCircle
                       difficulty={to}
@@ -539,6 +554,17 @@ class ListPage extends React.Component<Props, ListPageState> {
               </DropdownMenu>
             </UncontrolledButtonDropdown>
           </ButtonGroup>
+
+          <Button outline color="danger" onClick={()=>this.setState({
+            fromPoint: 0,
+            toPoint: INF_POINT,
+            statusFilterState: "All",
+            ratedFilterState: "All",
+            fromDifficulty: -1,
+            toDifficulty: INF_POINT
+          })}>
+            Reset
+          </Button>
         </Row>
         <Row>
           <BootstrapTable

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -39,6 +39,31 @@ const getRecommendProbability = (option: RecommendOption): number => {
   }
 };
 
+const getRecommendProbabilityRange = (option: RecommendOption): {lowerBound: number, upperBound: number} => {
+  switch (option) {
+    case "Easy":
+      return {
+        lowerBound: 0.5,
+        upperBound: Number.POSITIVE_INFINITY,
+      };
+    case "Moderate":
+      return {
+        lowerBound: 0.2,
+        upperBound: 0.8,
+      };
+    case "Difficult":
+      return {
+        lowerBound: Number.NEGATIVE_INFINITY,
+        upperBound: 0.5,
+      };
+    default:
+      return {
+        lowerBound: Number.NEGATIVE_INFINITY,
+        upperBound: Number.POSITIVE_INFINITY,
+      };
+  }
+};
+
 interface Props {
   readonly userSubmissions: List<Submission>;
   readonly problems: List<Problem>;
@@ -78,6 +103,7 @@ class Recommendations extends React.Component<Props, LocalState> {
       .map(s => s.problem_id)
       .toSet();
     const recommendingProbability = getRecommendProbability(recommendOption);
+    const recommendingRange = getRecommendProbabilityRange(recommendOption);
 
     const recommendedProblems = problems
       .filter(p => !acProblemIdSet.has(p.id))
@@ -125,6 +151,7 @@ class Recommendations extends React.Component<Props, LocalState> {
         );
         return da - db;
       })
+      .filter(p => recommendingRange.lowerBound <= p.predictedSolveProbability && p.predictedSolveProbability < recommendingRange.upperBound)
       .slice(0, RECOMMEND_NUM)
       .sort((a, b) => b.difficulty - a.difficulty)
       .toArray();


### PR DESCRIPTION
1. List Page に Difficulty 区分の進捗状況を表示するテーブルを実装しました (これを Difficulty Status と呼称します)
2. List Page の Point Status と Difficulty Status にワンクリックでフィルタを設定できるリンクを追加しました
3. List Page の {from / to} Difficulty filter の挙動を変更しました  
    フィルタを未設定の場合は全ての問題を表示しますが、 {from / to} いずれかが有効になっている場合には difficulty が設定されている問題のみを表示します
4. List Page のフィルタを一括でリセットするボタンを設置しました
5. User Page の Recommends の {Easy, Moderate, Difficult} それぞれで表示する問題を Solve Probability の値で限定しました  
    * Easy: 50 - 100 %
    * Moderate: 20 - 80 %
    * Difficult: 0 - 50 %

これにより重複表示をある程度抑制できますが、 #267 を直接解決はしません。 上記の List Page のフィルタ機能の改善により、高難度の問題をより簡単に一覧表示できるようになったため、 問題を解きすぎてしまった方の要望にはある程度応えられていると思います。(そういう人は上級者なので difficulty や点数を見て自分で解く問題決めればいいと思う)