### PR TITLE
Fix difficulty bugs

### DIFF
--- a/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
+++ b/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Tooltip } from "reactstrap";
-import { clipDifficulty } from "../utils";
 
 interface Props {
   id: string;
@@ -48,18 +47,17 @@ export class DifficultyCircle extends React.Component<Props, LocalState> {
     if (difficulty === null) {
       return null;
     }
-    const difficultyClipped = clipDifficulty(difficulty);
     const { tooltipOpen } = this.state;
     const fillRatio: number =
-      difficultyClipped >= 3200 ? 1.0 : (difficultyClipped % 400) / 400;
-    const color: string = getColor(difficultyClipped);
+      difficulty >= 3200 ? 1.0 : (difficulty % 400) / 400;
+    const color: string = getColor(difficulty);
     const r: number = parseInt(color.slice(1, 3), 16);
     const g: number = parseInt(color.slice(3, 5), 16);
     const b: number = parseInt(color.slice(5, 7), 16);
     const styleOptions = Object({
       borderColor: color,
       background:
-        difficultyClipped < 3200
+        difficulty < 3200
           ? `linear-gradient(to top, rgba(${r}, ${g}, ${b}, ${1.0}) 0%, rgba(${r}, ${g}, ${b}, ${1.0}) ${fillRatio *
               100}%, rgba(${r}, ${g}, ${b}, ${0.0}) ${fillRatio *
               100}%, rgba(${r}, ${g}, ${b}, ${0.0}) 100%)`
@@ -67,7 +65,7 @@ export class DifficultyCircle extends React.Component<Props, LocalState> {
           ? `linear-gradient(to right, ${color}, #ffd10c, ${color})`
           : `linear-gradient(to right, ${color}, white, ${color})`
     });
-    const title: string = `Difficulty: ${Math.round(difficultyClipped)}`;
+    const title: string = `Difficulty: ${difficulty}`;
     const circleId = "DifficultyCircle-" + id;
     return (
       <>

--- a/atcoder-problems-frontend/src/interfaces/ProblemModel.ts
+++ b/atcoder-problems-frontend/src/interfaces/ProblemModel.ts
@@ -2,6 +2,7 @@ export default interface ProblemModel {
   readonly slope: number | undefined;
   readonly intercept: number | undefined;
   readonly difficulty: number | undefined;
+  readonly rawDifficulty: number | undefined;
   readonly discrimination: number | undefined;
 }
 
@@ -9,6 +10,7 @@ export const isProblemModel = (obj: any): obj is ProblemModel =>
   (typeof obj.slope === "number" || typeof obj.slope === "undefined") &&
   (typeof obj.intercept === "number" || typeof obj.intercept === "undefined") &&
   (typeof obj.difficulty === "number" || typeof obj.difficulty === "undefined") &&
+  (typeof obj.rawDifficulty === "number" || typeof obj.rawDifficulty === "undefined") &&
   (typeof obj.discrimination === "number" || typeof obj.discrimination === "undefined");
 
 
@@ -16,6 +18,7 @@ export interface ProblemModelWithDifficultyModel {
   readonly slope: number | undefined;
   readonly intercept: number | undefined;
   readonly difficulty: number;
+  readonly rawDifficulty: number;
   readonly discrimination: number;
 }
 
@@ -23,6 +26,7 @@ export const isProblemModelWithDifficultyModel = (obj: any): obj is ProblemModel
   (typeof obj.slope === "number" || typeof obj.slope === "undefined") &&
   (typeof obj.intercept === "number" || typeof obj.intercept === "undefined") &&
   typeof obj.difficulty === "number" &&
+  typeof obj.rawDifficulty === "number" &&
   typeof obj.discrimination === "number";
 
 
@@ -30,6 +34,7 @@ export interface ProblemModelWithTimeModel {
   readonly slope: number;
   readonly intercept: number;
   readonly difficulty: number | undefined;
+  readonly rawDifficulty: number | undefined;
   readonly discrimination: number | undefined;
 }
 
@@ -37,4 +42,5 @@ export const isProblemModelWithTimeModel = (obj: any): obj is ProblemModelWithTi
   typeof obj.slope === "number" &&
   typeof obj.intercept === "number" &&
   (typeof obj.difficulty === "number" || typeof obj.difficulty === "undefined") &&
+  (typeof obj.rawDifficulty === "number" || typeof obj.rawDifficulty === "undefined") &&
   (typeof obj.discrimination === "number" || typeof obj.discrimination === "undefined");

--- a/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isAccepted, clipDifficulty } from "../../utils";
+import { isAccepted } from "../../utils";
 import Table from "reactstrap/lib/Table";
 import Submission from "../../interfaces/Submission";
 import { List, Map, Range } from "immutable";
@@ -42,14 +42,14 @@ const DifficultyTable = ({ submissions, userIds, mergedProblems, problemModels, 
         .valueSeq()
         .filter((d: number | undefined): d is number => d !== undefined)
         .reduce(
-          (map, difficulty) => map.update(Math.floor(Math.min(4000, clipDifficulty(Math.round(difficulty))) / 400), 0, count => count + 1),
+          (map, difficulty) => map.update(Math.floor(Math.min(4000, difficulty) / 400), 0, count => count + 1),
           Map<number, number>()
         )
     }));
   const totalCount = mergedProblems
     .map(p => problemModels.getIn([p.id, "difficulty"], undefined))
     .filter((d): d is number => d !== undefined)
-    .map(d => Math.floor(Math.min(4000, clipDifficulty(Math.round(d))) / 400))
+    .map(d => Math.floor(Math.min(4000, d) / 400))
     .reduce(
       (map, d) => map.update(d, 0, count => count + 1),
       Map<number, number>()

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -11,7 +11,7 @@ import {
   Button
 } from "reactstrap";
 
-import { clipDifficulty, isAccepted } from "../../utils";
+import { isAccepted } from "../../utils";
 import { formatMoment, parseSecond } from "../../utils/DateUtil";
 import * as Url from "../../utils/Url";
 import MergedProblem from "../../interfaces/MergedProblem";
@@ -125,9 +125,7 @@ class ListPage extends React.Component<Props, ListPageState> {
             : INF_POINT;
           const shortestUserId = p.shortest_user_id ? p.shortest_user_id : "";
           const fastestUserId = p.fastest_user_id ? p.fastest_user_id : "";
-          const difficulty = Math.round(
-            problemModels.getIn([p.id, "difficulty"], INF_POINT)
-          );
+          const difficulty = problemModels.getIn([p.id, "difficulty"], -1);
 
           return {
             id: p.id,
@@ -137,7 +135,7 @@ class ListPage extends React.Component<Props, ListPageState> {
             lastAcceptedDate,
             solverCount: p.solver_count ? p.solver_count : 0,
             point,
-            difficulty: difficulty !== INF_POINT ? clipDifficulty(difficulty) : -1,
+            difficulty,
             firstUserId,
             executionTime,
             codeLength,
@@ -171,7 +169,7 @@ class ListPage extends React.Component<Props, ListPageState> {
         dataFormat: (_, row) => (
           <ProblemLink
             showDifficulty={true}
-            difficulty={row.difficulty !== INF_POINT && row.difficulty !== -1 ? row.difficulty : null}
+            difficulty={row.difficulty !== -1 ? row.difficulty : null}
             problemId={row.mergedProblem.id}
             problemTitle={row.title}
             contestId={row.mergedProblem.contest_id}

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -171,7 +171,7 @@ class ListPage extends React.Component<Props, ListPageState> {
         dataFormat: (_, row) => (
           <ProblemLink
             showDifficulty={true}
-            difficulty={row.difficulty !== INF_POINT ? row.difficulty : null}
+            difficulty={row.difficulty !== INF_POINT && row.difficulty !== -1 ? row.difficulty : null}
             problemId={row.mergedProblem.id}
             problemTitle={row.title}
             contestId={row.mergedProblem.contest_id}

--- a/atcoder-problems-frontend/src/pages/ReviewPage.tsx
+++ b/atcoder-problems-frontend/src/pages/ReviewPage.tsx
@@ -3,7 +3,7 @@ import State, { ProblemId } from "../interfaces/State";
 import { connect } from "react-redux";
 import { List, Map, Range } from "immutable";
 import Submission from "../interfaces/Submission";
-import { clipDifficulty, isAccepted } from "../utils";
+import { isAccepted } from "../utils";
 import { RatingInfo, ratingInfoOf } from "../utils/RatingInfo";
 import ProblemModel, {
   isProblemModelWithDifficultyModel,
@@ -67,7 +67,7 @@ const ReviewPage: React.FC<Props> = props => {
       }
       const { title } = problem;
       const problemModel = problemModels.get(problem_id);
-      const difficulty = problemModel ? problemModel.difficulty : null;
+      const difficulty = problemModel && problemModel.difficulty !== undefined ? problemModel.difficulty : null;
       const predictedSolveTime =
         problemModel &&
         internalRating &&
@@ -82,7 +82,7 @@ const ReviewPage: React.FC<Props> = props => {
           : null;
 
       return {
-        difficulty: difficulty ? clipDifficulty(difficulty) : null,
+        difficulty,
         id,
         problem_id,
         contest_id,

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { clipDifficulty, isAccepted } from "../../utils";
+import { isAccepted } from "../../utils";
 import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
 import * as Url from "../../utils/Url";
 import Submission from "../../interfaces/Submission";
@@ -110,8 +110,9 @@ class Recommendations extends React.Component<Props, LocalState> {
       .filter(p => problemModels.has(p.id))
       .map(p => ({
         ...p,
-        difficulty: Math.round(problemModels.getIn([p.id, "difficulty"], 0))
+        difficulty: problemModels.getIn([p.id, "difficulty"], undefined)
       }))
+      .filter(p => p.difficulty !== undefined)
       .map(p => {
         const internalRating = userRatingInfo.internalRating;
         let predictedSolveTime: number | null;
@@ -123,6 +124,7 @@ class Recommendations extends React.Component<Props, LocalState> {
           const problemModel: ProblemModel = problemModels.get(p.id, {
             slope: undefined,
             difficulty: undefined,
+            rawDifficulty: undefined,
             intercept: undefined,
             discrimination: undefined
           });
@@ -225,8 +227,7 @@ class Recommendations extends React.Component<Props, LocalState> {
               dataField="difficulty"
               dataFormat={(difficulty: number | null) => {
                 if (difficulty === null) return "-";
-                const difficultyClipped = clipDifficulty(difficulty);
-                return String(difficultyClipped);
+                return String(difficulty);
               }}
             >
               <span>Difficulty</span>

--- a/atcoder-problems-frontend/src/reducers.ts
+++ b/atcoder-problems-frontend/src/reducers.ts
@@ -30,7 +30,7 @@ import {
   RankingEntry,
   SumRankingEntry
 } from "./interfaces/RankingEntry";
-import { isAccepted } from "./utils";
+import { isAccepted, clipDifficulty } from "./utils";
 import ProblemModel from "./interfaces/ProblemModel";
 import ContestParticipation from "./interfaces/ContestParticipation";
 
@@ -130,11 +130,20 @@ const dataReducer = (
       const ratedContestIds = atcoderContestIds.concat(othersRated.keySeq());
       const others = contests.filter(c => !ratedContestIds.has(c.id));
 
+      const problemModels = action.problemModels.map((model : ProblemModel) : ProblemModel => {
+        if(model.difficulty === undefined) return model;
+        return {
+          ...model,
+          difficulty: clipDifficulty(model.difficulty),
+          rawDifficulty: model.difficulty
+        };
+      });
+
       return {
         problems,
         contests,
         contestToProblems,
-        problemModels: action.problemModels,
+        problemModels,
         abc,
         arc,
         agc,

--- a/atcoder-problems-frontend/src/utils/ProblemModelUtil.ts
+++ b/atcoder-problems-frontend/src/utils/ProblemModelUtil.ts
@@ -12,7 +12,7 @@ export const predictSolveProbability = (
     (1 +
       Math.exp(
         -problemModel.discrimination *
-          (internalRating - problemModel.difficulty)
+          (internalRating - problemModel.rawDifficulty)
       ))
   );
 };


### PR DESCRIPTION
difficulty 周りのバグを2件発見・修正しました  
* List Page で difficulty 未定義の問題が灰色に表示される  
    - 原因: 未定義の問題の difficulty を フィルタ用に -1 として扱っていて、処理を忘れてた #270 
    - 対応: 適切に処理をしました
* difficulty < 400 の問題の玉と実際の difficulty の値が異なっている場所がある (list, review ページで確認)
    - 原因: difficulty 400 以下のクリッピング処理を多重に行っていた
    - 対応: problemModel を API で読み込んだ時の初期処理段階でクリッピング処理しておき、 他の位置でのクリッピングを行わないようにしました  
      Solve Probability 計算に元の値も必要なので、次のように変更しました
      ```
      problemModel.rawDifficulty : クリッピングしていない difficulty
      problemModel.difficulty : クリッピング済み
      ```