### PR TITLE
Add rated contest color balls

### DIFF
--- a/atcoder-problems-frontend/src/components/ContestLink.tsx
+++ b/atcoder-problems-frontend/src/components/ContestLink.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import * as Url from "../utils/Url";
+import Contest from "../interfaces/Contest";
+
+
+interface Props {
+  contest: Contest;
+  title?: string;
+}
+
+enum RatedTargetType {
+  All,
+  Unrated,
+};
+
+type RatedTarget = Number | RatedTargetType;
+
+function getRatedTarget(contest: Contest) : RatedTarget {
+  const agc001date = 1468670400;
+  if(agc001date > contest.start_epoch_second) return RatedTargetType.Unrated;
+  switch (contest.rate_change){
+    case undefined:
+      return RatedTargetType.Unrated;
+    case "-":
+      return RatedTargetType.Unrated;
+    case "All":
+      return RatedTargetType.All;
+    case (/\d+/.test(contest.rate_change) ? contest.rate_change : false):
+      const tmp = /\d+/.exec(contest.rate_change);
+      if(tmp !== null) return parseInt(tmp[0]);
+    default:
+      return RatedTargetType.Unrated;
+  }
+}
+
+function getColorClass(target: RatedTarget): string {
+  if(target === RatedTargetType.All) return "difficulty-red";
+  if(target === RatedTargetType.Unrated) return "";
+
+  if (target < 400) return "difficulty-grey";
+  else if (target < 800) return "difficulty-brown";
+  else if (target < 1200) return "difficulty-green";
+  else if (target < 1600) return "difficulty-cyan";
+  else if (target < 2000) return "difficulty-blue";
+  else if (target < 2400) return "difficulty-yellow";
+  else if (target < 2800) return "difficulty-orange";
+  else return "difficulty-red";
+}
+
+const ContestLink: React.FC<Props> = props => {
+  const {
+    contest,
+    title
+  } = props;
+  const target: RatedTarget = getRatedTarget(contest);
+
+  return (
+    <>
+      <span className={getColorClass(target)}>◉</span>
+      <a target="_blank" href={Url.formatContestUrl(contest.id)}>
+        {title !== undefined ? title : contest.title}
+      </a>
+    </>
+  );
+};
+
+export default ContestLink;

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -3,6 +3,7 @@ import { StatusLabel } from "../../interfaces/State";
 import { Badge } from "reactstrap";
 import React, { ReactElement } from "react";
 import ProblemLink from "../../components/ProblemLink";
+import ContestLink from "../../components/ContestLink";
 import * as Url from "../../utils/Url";
 import { INF_POINT, ProblemRowData } from "./index";
 import { List } from "immutable";
@@ -47,15 +48,18 @@ export const ListTable = (props: Props) => {
     },
     {
       header: "Contest",
-      dataField: "contestTitle",
+      dataField: "contest",
       dataSort: true,
-      dataFormat: (contestTitle, row) => (
-        <a
-          href={Url.formatContestUrl(row.mergedProblem.contest_id)}
-          target="_blank"
-        >
-          {contestTitle}
-        </a>
+      dataFormat: (contest, row) => (
+        contest ? 
+          <ContestLink contest={contest} />
+        :
+          <a
+            href={Url.formatContestUrl(row.mergedProblem.contest_id)}
+            target="_blank"
+          >
+            {row.contestTitle}
+          </a>
       )
     },
     {

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -35,6 +35,7 @@ export const INF_POINT = 1e18;
 export interface ProblemRowData {
   readonly id: string;
   readonly title: string;
+  readonly contest?: Contest;
   readonly contestDate: string;
   readonly contestTitle: string;
   readonly lastAcceptedDate: string;
@@ -126,6 +127,7 @@ class ListPage extends React.Component<Props, ListPageState> {
           return {
             id: p.id,
             title: p.title,
+            contest,
             contestDate,
             contestTitle,
             lastAcceptedDate,

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../interfaces/State";
 import { statusLabelToTableColor } from "./index";
 import ProblemLink from "../../components/ProblemLink";
+import ContestLink from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
 
 interface Props {
@@ -71,9 +72,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
             solvedAll(contest) ? "table-success" : ""
           }
           dataFormat={(_: any, contest: Contest) => (
-            <a href={Url.formatContestUrl(contest.id)} target="_blank">
-              {contest.id.toUpperCase()}
-            </a>
+            <ContestLink contest={contest} title={contest.id.toUpperCase()} />
           )}
         >
           Contest

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { ProblemId, ProblemStatus, StatusLabel } from "../../interfaces/State";
 import { statusLabelToTableColor } from "./index";
 import ProblemLink from "../../components/ProblemLink";
+import ContestLink from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
 
 interface Props {
@@ -52,9 +53,7 @@ const ContestTable: React.FC<Props> = (props: Props) => {
             return (
               <div key={contest.id}>
                 <strong>
-                  <a target="_blank" href={Url.formatContestUrl(contest.id)}>
-                    {contest.title}
-                  </a>
+                  <ContestLink contest={contest} />
                 </strong>
                 <Table striped bordered hover responsive>
                   <tbody>

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -29,6 +29,7 @@ import {
 } from "reactstrap";
 import HelpBadgeTooltip from "../../components/HelpBadgeTooltip";
 import ProblemLink from "../../components/ProblemLink";
+import ContestLink from "../../components/ContestLink";
 
 const RECOMMEND_NUM_OPTIONS = [
   {
@@ -265,12 +266,15 @@ class Recommendations extends React.Component<Props, LocalState> {
               dataFormat={(contest_id: string, problem: Problem) => {
                 const contest = contests.get(contest_id);
                 return (
-                  <a
-                    href={Url.formatContestUrl(problem.contest_id)}
-                    target="_blank"
-                  >
-                    {contest ? contest.title : contest_id}
-                  </a>
+                  contest ? 
+                    <ContestLink contest={contest} />
+                  :
+                    <a
+                      href={Url.formatContestUrl(problem.contest_id)}
+                      target="_blank"
+                    >
+                      {contest_id}
+                    </a>
                 );
               }}
             >


### PR DESCRIPTION
AtCoder 公式のアップデートでコンテストの rated 上限値による玉が表示されるようになりました。 このプルリクエストは同様の機能を AtCoder Problems に追加します。

補足: 公式のアップデートでコンテスト一覧に表示されていた大昔の unrated コンなのに "Rated対象 All" となっていた部分が修正されています。 クローラがコンテスト一覧を更新すれば、このコミットにも含まれる "AGC001 以降のコンテストか否か" のチェックが不要となると思います。