### PR TITLE
Allow spaces in User ID

### DIFF
--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -16,7 +16,7 @@ import {
   Button,
   FormGroup
 } from "reactstrap";
-import { ATCODER_USER_REGEXP, extractRivalsParam } from "../utils";
+import { extractRivalsParam, normalizeUserId } from "../utils";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { List } from "immutable";
@@ -62,16 +62,9 @@ const generatePath = (
   userId: string,
   rivalIdString: string
 ) => {
-  const trimmedUserId = userId.trim();
-  const users = [
-    checkUserId(trimmedUserId),
-    ...extractRivalsParam(rivalIdString)
-  ];
+  const users = [normalizeUserId(userId), ...extractRivalsParam(rivalIdString)];
   return "/" + kind + "/" + users.join("/");
 };
-
-const checkUserId = (inputUserId: string): string =>
-  inputUserId.match(ATCODER_USER_REGEXP) ? inputUserId : "";
 
 class NavigationBar extends React.Component<Props, LocalState> {
   constructor(props: Props) {
@@ -87,7 +80,10 @@ class NavigationBar extends React.Component<Props, LocalState> {
   submit(nextKind: PageKind) {
     const { userId, rivalIdString } = this.state;
     const path = generatePath(nextKind, userId, rivalIdString);
-    this.props.updateUserIds(userId.trim(), List(extractRivalsParam(rivalIdString)));
+    this.props.updateUserIds(
+      normalizeUserId(userId),
+      List(extractRivalsParam(rivalIdString))
+    );
     this.props.history.push({ pathname: path });
     this.setState({ pageKind: nextKind });
   }
@@ -97,7 +93,10 @@ class NavigationBar extends React.Component<Props, LocalState> {
     const pageKind = extractPageKind(pathname);
     const { userId, rivalIdString } = extractUserIds(pathname);
     this.setState({ userId, rivalIdString, pageKind });
-    this.props.updateUserIds(userId.trim(), List(extractRivalsParam(rivalIdString)));
+    this.props.updateUserIds(
+      normalizeUserId(userId),
+      List(extractRivalsParam(rivalIdString))
+    );
   }
 
   render() {

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -62,7 +62,11 @@ const generatePath = (
   userId: string,
   rivalIdString: string
 ) => {
-  const users = [checkUserId(userId), ...extractRivalsParam(rivalIdString)];
+  const trimmedUserId = userId.trim();
+  const users = [
+    checkUserId(trimmedUserId),
+    ...extractRivalsParam(rivalIdString)
+  ];
   return "/" + kind + "/" + users.join("/");
 };
 
@@ -83,7 +87,7 @@ class NavigationBar extends React.Component<Props, LocalState> {
   submit(nextKind: PageKind) {
     const { userId, rivalIdString } = this.state;
     const path = generatePath(nextKind, userId, rivalIdString);
-    this.props.updateUserIds(userId, List(extractRivalsParam(rivalIdString)));
+    this.props.updateUserIds(userId.trim(), List(extractRivalsParam(rivalIdString)));
     this.props.history.push({ pathname: path });
     this.setState({ pageKind: nextKind });
   }
@@ -93,7 +97,7 @@ class NavigationBar extends React.Component<Props, LocalState> {
     const pageKind = extractPageKind(pathname);
     const { userId, rivalIdString } = extractUserIds(pathname);
     this.setState({ userId, rivalIdString, pageKind });
-    this.props.updateUserIds(userId, List(extractRivalsParam(rivalIdString)));
+    this.props.updateUserIds(userId.trim(), List(extractRivalsParam(rivalIdString)));
   }
 
   render() {

--- a/atcoder-problems-frontend/src/utils/index.test.ts
+++ b/atcoder-problems-frontend/src/utils/index.test.ts
@@ -1,7 +1,8 @@
 import {
   ATCODER_RIVALS_REGEXP,
   ATCODER_USER_REGEXP,
-  extractRivalsParam
+  extractRivalsParam,
+  normalizeUserId,
 } from "./index";
 
 describe("user regex", () => {
@@ -38,4 +39,12 @@ it("extract rival params", () => {
     "USER2",
     "user_3"
   ]);
+});
+
+it("should normalize user id", () => {
+  expect(normalizeUserId("   userid")).toBe("userid");
+  expect(normalizeUserId("userid   ")).toBe("userid");
+  expect(normalizeUserId("  userid ")).toBe("userid");
+  expect(normalizeUserId("userid")).toBe("userid");
+  expect(normalizeUserId("user id")).toBe("");
 });

--- a/atcoder-problems-frontend/src/utils/index.ts
+++ b/atcoder-problems-frontend/src/utils/index.ts
@@ -15,6 +15,11 @@ export const extractRivalsParam = (rivalsParam: string): string[] => {
   }
 };
 
+export const normalizeUserId = (userId: string): string => {
+  const trimmedUserId = userId.trim();
+  return trimmedUserId.match(ATCODER_USER_REGEXP) ? trimmedUserId : "";
+};
+
 export const isAccepted = (result: string) => result === "AC";
 export const ordinalSuffixOf = (i: number) => {
   const j = i % 10;


### PR DESCRIPTION
User IDの前後にスペースを入れたとき、ユーザーページにて一貫性のない挙動をしていたので修正しました。#221 ではRival IDの前後にスペースを許容しましたが、このPRではUser IDの前後においてもスペースを許容します。

自分で入力するときにスペースが混入することは少ないと思いますが、コピー&ペーストにより混入することがあります。

#### 修正前
- `"userid"`    (正常)
- `"    userid"` (leading whitespaces) => 何も表示されない
- `"userid    "` (trailing whitespaces) => 'Accepted', 'Rated Point Sum'のみ表示されるが他はデータ無
- `"  userid  "` (leading & trailing) => 何も表示されない

#### 修正後
- 全てにおいて正常に表示されるようになりました