### PR TITLE
#369 added predicted solve time to list page.

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -7,8 +7,14 @@ import ContestLink from "../../components/ContestLink";
 import * as Url from "../../utils/Url";
 import { INF_POINT, ProblemRowData } from "./index";
 import { List } from "immutable";
-import {formatPredictedSolveTime, predictSolveTime} from "../../utils/ProblemModelUtil";
-import ProblemModel, {isProblemModelWithDifficultyModel, isProblemModelWithTimeModel} from "../../interfaces/ProblemModel";
+import {
+  formatPredictedSolveTime,
+  predictSolveTime
+} from "../../utils/ProblemModelUtil";
+import ProblemModel, {
+  isProblemModelWithDifficultyModel,
+  isProblemModelWithTimeModel
+} from "../../interfaces/ProblemModel";
 
 interface Props {
   fromPoint: number;
@@ -42,7 +48,11 @@ export const ListTable = (props: Props) => {
       dataFormat: (_, row) => (
         <ProblemLink
           showDifficulty={true}
-          difficulty={isProblemModelWithDifficultyModel(row.problemModel) ? row.problemModel.difficulty : null}
+          difficulty={
+            isProblemModelWithDifficultyModel(row.problemModel)
+              ? row.problemModel.difficulty
+              : null
+          }
           isExperimentalDifficulty={row.problemModel?.is_experimental}
           problemId={row.mergedProblem.id}
           problemTitle={row.title}
@@ -161,7 +171,10 @@ export const ListTable = (props: Props) => {
         if (!isProblemModelWithTimeModel(problemModel)) {
           return <p>-</p>;
         }
-        const solveTime = predictSolveTime(problemModel, props.userInternalRating);
+        const solveTime = predictSolveTime(
+          problemModel,
+          props.userInternalRating
+        );
         const solveTimeString = formatPredictedSolveTime(solveTime);
         return <p>{solveTimeString}</p>;
       }
@@ -312,14 +325,15 @@ export const ListTable = (props: Props) => {
               return !isRated;
           }
         })
-        .filter(
-          row => {
-            const difficulty = isProblemModelWithDifficultyModel(row.problemModel) ?
-              row.problemModel.difficulty : -1;
-            return props.fromDifficulty <= difficulty &&
-              difficulty <= props.toDifficulty
-          }
-        )
+        .filter(row => {
+          const difficulty = isProblemModelWithDifficultyModel(row.problemModel)
+            ? row.problemModel.difficulty
+            : -1;
+          return (
+            props.fromDifficulty <= difficulty &&
+            difficulty <= props.toDifficulty
+          );
+        })
         .toArray()}
       options={{
         paginationPosition: "top",

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -7,6 +7,8 @@ import ContestLink from "../../components/ContestLink";
 import * as Url from "../../utils/Url";
 import { INF_POINT, ProblemRowData } from "./index";
 import { List } from "immutable";
+import {formatPredictedSolveTime, predictSolveTime} from "../../utils/ProblemModelUtil";
+import ProblemModel, {isProblemModelWithDifficultyModel, isProblemModelWithTimeModel} from "../../interfaces/ProblemModel";
 
 interface Props {
   fromPoint: number;
@@ -16,6 +18,7 @@ interface Props {
   fromDifficulty: number;
   toDifficulty: number;
   rowData: List<ProblemRowData>;
+  userInternalRating: number | null;
 }
 
 export const ListTable = (props: Props) => {
@@ -39,8 +42,8 @@ export const ListTable = (props: Props) => {
       dataFormat: (_, row) => (
         <ProblemLink
           showDifficulty={true}
-          difficulty={row.difficulty !== -1 ? row.difficulty : null}
-          isExperimentalDifficulty={row.isExperimentalDifficulty}
+          difficulty={isProblemModelWithDifficultyModel(row.problemModel) ? row.problemModel.difficulty : null}
+          isExperimentalDifficulty={row.problemModel?.is_experimental}
           problemId={row.mergedProblem.id}
           problemTitle={row.title}
           contestId={row.mergedProblem.contest_id}
@@ -134,14 +137,33 @@ export const ListTable = (props: Props) => {
     },
     {
       header: "Difficulty",
-      dataField: "difficulty",
+      dataField: "problemModel",
       dataSort: true,
-      dataFormat: (difficulty: number) => {
-        if (difficulty === -1) {
+      dataFormat: (problemModel: ProblemModel) => {
+        if (!isProblemModelWithDifficultyModel(problemModel)) {
           return <p>-</p>;
         } else {
-          return <p>{difficulty}</p>;
+          return <p>{problemModel.difficulty}</p>;
         }
+      }
+    },
+    {
+      header: "Time",
+      dataField: "a",
+      dataFormat: (_: string, row) => {
+        if (props.userInternalRating === null) {
+          return <p>-</p>;
+        }
+        const problemModel = row.problemModel;
+        if (problemModel === undefined) {
+          return <p>-</p>;
+        }
+        if (!isProblemModelWithTimeModel(problemModel)) {
+          return <p>-</p>;
+        }
+        const solveTime = predictSolveTime(problemModel, props.userInternalRating);
+        const solveTimeString = formatPredictedSolveTime(solveTime);
+        return <p>{solveTimeString}</p>;
       }
     },
     {
@@ -291,9 +313,12 @@ export const ListTable = (props: Props) => {
           }
         })
         .filter(
-          row =>
-            props.fromDifficulty <= row.difficulty &&
-            row.difficulty <= props.toDifficulty
+          row => {
+            const difficulty = isProblemModelWithDifficultyModel(row.problemModel) ?
+              row.problemModel.difficulty : -1;
+            return props.fromDifficulty <= difficulty &&
+              difficulty <= props.toDifficulty
+          }
         )
         .toArray()}
       options={{

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -24,7 +24,7 @@ import { DifficultyCircle } from "../../components/DifficultyCircle";
 import { ListTable } from "./ListTable";
 import { connect, PromiseState } from "react-refetch";
 import * as CachedApiClient from "../../utils/CachedApiClient";
-import {RatingInfo} from "../../utils/RatingInfo";
+import { RatingInfo } from "../../utils/RatingInfo";
 
 export const INF_POINT = 1e18;
 
@@ -372,5 +372,5 @@ export default connect<OuterProps, InnerProps>(props => ({
   userRatingInfoFetch: {
     comparison: props.userId,
     value: () => CachedApiClient.cachedRatingInfo(props.userId)
-  },
+  }
 }))(ListPage);


### PR DESCRIPTION
#369 を実装しました。
動作例:
<img width="1344" alt="スクリーンショット 2020-01-06 23 53 42" src="https://user-images.githubusercontent.com/967121/71825848-10bf4700-30e0-11ea-9107-0777c9193b04.png">
