### PR TITLE
BACHA-GACHA UI Improvement

### DIFF
--- a/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
@@ -27,6 +27,8 @@ interface Props {
   problemModels: Map<string, ProblemModel>;
   selectProblem: (...problems: Problem[]) => void;
   expectedParticipantUserIds: string[];
+  addButtonDisabled: boolean;
+  feedbackForDisabledAddButton: string;
 }
 
 interface ProblemSelectionParams {
@@ -241,10 +243,12 @@ export default (props: Props) => {
       </div>
 
       <FormGroup row>
-        <Col>
+        <Col sm={12}>
           <Button
             color="success"
-            disabled={problemSelectionParamsList.length === 0}
+            disabled={
+              problemSelectionParamsList.length === 0 || props.addButtonDisabled
+            }
             onClick={async () => {
               const nProblems = problemSelectionParamsList.length;
 
@@ -334,6 +338,11 @@ export default (props: Props) => {
           >
             Add
           </Button>
+        </Col>
+        <Col>
+          {props.addButtonDisabled && (
+            <span>{props.feedbackForDisabledAddButton}</span>
+          )}
         </Col>
       </FormGroup>
     </Form>

--- a/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
@@ -9,7 +9,8 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupText,
-  Label
+  Label,
+  Row
 } from "reactstrap";
 import React, { useState } from "react";
 import { isAccepted, shuffleList } from "../utils";
@@ -37,82 +38,90 @@ export default (props: Props) => {
   return (
     <Form className={"w-100"}>
       <FormGroup row>
-        <InputGroup>
-          <InputGroupAddon addonType="prepend">
-            <InputGroupText>
-              <Input
-                addon
-                type="checkbox"
-                aria-label="Enable filter by difficulty lower bound"
-                checked={excludeLowDifficulty}
-                onChange={event =>
-                  setExcludeLowDifficulty(event.target.checked)
-                }
-              />
-            </InputGroupText>
-            <InputGroupText>Difficulty Lower Bound</InputGroupText>
-          </InputGroupAddon>
-          <Input
-            placeholder="difficulty lower bound"
-            min={0}
-            max={10000}
-            type="number"
-            value={difficultyLowerBound}
-            step={100}
-            disabled={!excludeLowDifficulty}
-            onChange={event =>
-              setDifficultyLowerBound(parseInt(event.target.value, 10))
-            }
-          />
-        </InputGroup>
+        <Col>
+          <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText>
+                <Input
+                  addon
+                  type="checkbox"
+                  aria-label="Enable filter by difficulty lower bound"
+                  checked={excludeLowDifficulty}
+                  onChange={event =>
+                    setExcludeLowDifficulty(event.target.checked)
+                  }
+                />
+              </InputGroupText>
+              <InputGroupText>Difficulty Lower Bound</InputGroupText>
+            </InputGroupAddon>
+            <Input
+              placeholder="difficulty lower bound"
+              min={0}
+              max={10000}
+              type="number"
+              value={difficultyLowerBound}
+              step={100}
+              disabled={!excludeLowDifficulty}
+              onChange={event =>
+                setDifficultyLowerBound(parseInt(event.target.value, 10))
+              }
+            />
+          </InputGroup>
+        </Col>
       </FormGroup>
 
       <FormGroup row>
-        <InputGroup>
-          <InputGroupAddon addonType="prepend">
-            <InputGroupText>
-              <Input
-                addon
-                type="checkbox"
-                aria-label="Enable filter by difficulty upper bound"
-                checked={excludeHighDifficulty}
-                onChange={event =>
-                  setExcludeHighDifficulty(event.target.checked)
-                }
-              />
-            </InputGroupText>
-            <InputGroupText>Difficulty Upper Bound</InputGroupText>
-          </InputGroupAddon>
-          <Input
-            placeholder="difficulty upper bound"
-            min={0}
-            max={10000}
-            type="number"
-            value={difficultyUpperBound}
-            step={100}
-            disabled={!excludeHighDifficulty}
-            onChange={event =>
-              setDifficultyUpperBound(parseInt(event.target.value, 10))
-            }
-          />
-        </InputGroup>
+        <Col>
+          <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText>
+                <Input
+                  addon
+                  type="checkbox"
+                  aria-label="Enable filter by difficulty upper bound"
+                  checked={excludeHighDifficulty}
+                  onChange={event =>
+                    setExcludeHighDifficulty(event.target.checked)
+                  }
+                />
+              </InputGroupText>
+              <InputGroupText>Difficulty Upper Bound</InputGroupText>
+            </InputGroupAddon>
+            <Input
+              placeholder="difficulty upper bound"
+              min={0}
+              max={10000}
+              type="number"
+              value={difficultyUpperBound}
+              step={100}
+              disabled={!excludeHighDifficulty}
+              onChange={event =>
+                setDifficultyUpperBound(parseInt(event.target.value, 10))
+              }
+            />
+          </InputGroup>
+        </Col>
       </FormGroup>
 
       <FormGroup row>
-        <InputGroup>
-          <InputGroupAddon addonType="prepend">
-            <InputGroupText>
-              <Input
-                addon
-                type="checkbox"
-                aria-label="Exclude experimental difficulty"
-                checked={excludeExperimental}
-                onChange={event => setExcludeExperimental(event.target.checked)}
-              />
-            </InputGroupText>
-          </InputGroupAddon>
-          <InputGroupText>Exclude experimental difficulty</InputGroupText>
-        </InputGroup>
+        <Col>
+          <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText>
+                <Input
+                  addon
+                  type="checkbox"
+                  aria-label="Exclude experimental difficulty"
+                  checked={excludeExperimental}
+                  onChange={event =>
+                    setExcludeExperimental(event.target.checked)
+                  }
+                />
+              </InputGroupText>
+            </InputGroupAddon>
+            <InputGroupText>Exclude experimental difficulty</InputGroupText>
+          </InputGroup>
+        </Col>
       </FormGroup>
 
       <FormGroup row>
@@ -147,70 +156,72 @@ export default (props: Props) => {
       </FormGroup>
 
       <FormGroup row>
-        <Button
-          color="success"
-          onClick={() => {
-            let candidateProblems = props.problems.map(problem => ({
-              problem,
-              model: props.problemModels.get(problem.id)
-            }));
+        <Col>
+          <Button
+            color="success"
+            onClick={() => {
+              let candidateProblems = props.problems.map(problem => ({
+                problem,
+                model: props.problemModels.get(problem.id)
+              }));
 
-            if (excludeExperimental) {
-              candidateProblems = candidateProblems.filter(problem => {
-                return (
-                  problem.model !== undefined && !problem.model.is_experimental
-                );
-              });
-            }
+              if (excludeExperimental) {
+                candidateProblems = candidateProblems.filter(problem => {
+                  return (
+                    problem.model !== undefined && !problem.model.is_experimental
+                  );
+                });
+              }
 
-            if (excludeLowDifficulty) {
-              candidateProblems = candidateProblems.filter(problem => {
-                return (
-                  isProblemModelWithDifficultyModel(problem.model) &&
-                  problem.model.difficulty >= difficultyLowerBound
-                );
-              });
-            }
+              if (excludeLowDifficulty) {
+                candidateProblems = candidateProblems.filter(problem => {
+                  return (
+                    isProblemModelWithDifficultyModel(problem.model) &&
+                    problem.model.difficulty >= difficultyLowerBound
+                  );
+                });
+              }
 
-            if (excludeHighDifficulty) {
-              candidateProblems = candidateProblems.filter(problem => {
-                return (
-                  isProblemModelWithDifficultyModel(problem.model) &&
-                  problem.model.difficulty <= difficultyUpperBound
-                );
-              });
-            }
+              if (excludeHighDifficulty) {
+                candidateProblems = candidateProblems.filter(problem => {
+                  return (
+                    isProblemModelWithDifficultyModel(problem.model) &&
+                    problem.model.difficulty <= difficultyUpperBound
+                  );
+                });
+              }
 
-            const tokenizedUserIds = List.of(...excludeUserIds.split(" "));
-            Promise.all(tokenizedUserIds.map(cachedSubmissions)).then(
-              userSubmissions => {
-                const solvedProblemIds = List(userSubmissions)
-                  .flatten(true)
-                  .filter(submission => isAccepted(submission.result))
-                  .map(submission => submission.problem_id)
-                  .toSet();
+              const tokenizedUserIds = List.of(...excludeUserIds.split(" "));
+              Promise.all(tokenizedUserIds.map(cachedSubmissions)).then(
+                userSubmissions => {
+                  const solvedProblemIds = List(userSubmissions)
+                    .flatten(true)
+                    .filter(submission => isAccepted(submission.result))
+                    .map(submission => submission.problem_id)
+                    .toSet();
 
-                const filteredProblem = candidateProblems
-                  .map(problem => problem.problem)
-                  .filter(problem => !solvedProblemIds.contains(problem.id));
-                if (filteredProblem.size < nProblems) {
-                  alert(
-                    "Only " +
-                      filteredProblem.size +
-                      " problems matched, while " +
-                      nProblems +
-                      " problems requested."
+                  const filteredProblem = candidateProblems
+                    .map(problem => problem.problem)
+                    .filter(problem => !solvedProblemIds.contains(problem.id));
+                  if (filteredProblem.size < nProblems) {
+                    alert(
+                      "Only " +
+                        filteredProblem.size +
+                        " problems matched, while " +
+                        nProblems +
+                        " problems requested."
+                    );
+                  }
+                  props.selectProblem(
+                    ...shuffleList(filteredProblem, nProblems).toArray()
                   );
                 }
-                props.selectProblem(
-                  ...shuffleList(filteredProblem, nProblems).toArray()
-                );
-              }
-            );
-          }}
-        >
-          Add
-        </Button>
+              );
+            }}
+          >
+            Add
+          </Button>
+        </Col>
       </FormGroup>
     </Form>
   );

--- a/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
@@ -3,6 +3,9 @@ import { List, Map } from "immutable";
 import {
   Button,
   Col,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
   Form,
   FormGroup,
   Input,
@@ -10,7 +13,7 @@ import {
   InputGroupAddon,
   InputGroupText,
   Label,
-  Row
+  UncontrolledDropdown
 } from "reactstrap";
 import React, { useState } from "react";
 import { isAccepted, shuffleList } from "../utils";
@@ -18,91 +21,70 @@ import ProblemModel, {
   isProblemModelWithDifficultyModel
 } from "../interfaces/ProblemModel";
 import { cachedSubmissions } from "../utils/CachedApiClient";
-import HelpBadgeTooltip from "./HelpBadgeTooltip";
 
 interface Props {
   problems: List<Problem>;
   problemModels: Map<string, ProblemModel>;
   selectProblem: (...problems: Problem[]) => void;
+  expectedParticipantUserIds: string[];
 }
 
+interface ProblemSelectionParams {
+  minDifficulty: number;
+  maxDifficulty: number;
+}
+
+interface ProblemSetSelectionPreset {
+  displayName: string;
+  problemSelectionParams: ProblemSelectionParams[];
+}
+
+const ABC_PRESET: ProblemSetSelectionPreset = {
+  displayName: "Preset 1",
+  problemSelectionParams: [
+    { minDifficulty: 0, maxDifficulty: 50 },
+    { minDifficulty: 10, maxDifficulty: 100 },
+    { minDifficulty: 50, maxDifficulty: 800 },
+    { minDifficulty: 800, maxDifficulty: 1200 },
+    { minDifficulty: 1200, maxDifficulty: 1600 },
+    { minDifficulty: 2000, maxDifficulty: 2400 }
+  ]
+};
+
+const ARC_PRESET: ProblemSetSelectionPreset = {
+  displayName: "Preset 2",
+  problemSelectionParams: [
+    { minDifficulty: 800, maxDifficulty: 1200 },
+    { minDifficulty: 1200, maxDifficulty: 1800 },
+    { minDifficulty: 2000, maxDifficulty: 2800 },
+    { minDifficulty: 2800, maxDifficulty: 4000 }
+  ]
+};
+
+const AGC_PRESET: ProblemSetSelectionPreset = {
+  displayName: "Preset 3",
+  problemSelectionParams: [
+    { minDifficulty: 400, maxDifficulty: 1200 },
+    { minDifficulty: 1200, maxDifficulty: 2400 },
+    { minDifficulty: 1600, maxDifficulty: 3200 },
+    { minDifficulty: 2400, maxDifficulty: 9999 },
+    { minDifficulty: 2800, maxDifficulty: 9999 },
+    { minDifficulty: 2800, maxDifficulty: 9999 }
+  ]
+};
 export default (props: Props) => {
-  const [nProblems, setNProblems] = useState(1);
-  const [difficultyLowerBound, setDifficultyLowerBound] = useState(0);
-  const [excludeLowDifficulty, setExcludeLowDifficulty] = useState(false);
-  const [difficultyUpperBound, setDifficultyUpperBound] = useState(10000);
-  const [excludeHighDifficulty, setExcludeHighDifficulty] = useState(false);
+  const [problemSelectionParamsList, setProblemSelectionParamsList] = useState(
+    ABC_PRESET.problemSelectionParams
+  );
   const [excludeExperimental, setExcludeExperimental] = useState(false);
-  const [excludeUserIds, setExcludeUserIds] = useState("");
+  const [
+    excludeAlreadySolvedProblems,
+    setExcludeAlreadySolvedProblems
+  ] = useState(true);
+  const [selectedPreset, setSelectedPreset] = useState(ABC_PRESET);
 
   return (
     <Form className={"w-100"}>
-      <FormGroup row>
-        <Col>
-          <InputGroup>
-            <InputGroupAddon addonType="prepend">
-              <InputGroupText>
-                <Input
-                  addon
-                  type="checkbox"
-                  aria-label="Enable filter by difficulty lower bound"
-                  checked={excludeLowDifficulty}
-                  onChange={event =>
-                    setExcludeLowDifficulty(event.target.checked)
-                  }
-                />
-              </InputGroupText>
-              <InputGroupText>Difficulty Lower Bound</InputGroupText>
-            </InputGroupAddon>
-            <Input
-              placeholder="difficulty lower bound"
-              min={0}
-              max={10000}
-              type="number"
-              value={difficultyLowerBound}
-              step={100}
-              disabled={!excludeLowDifficulty}
-              onChange={event =>
-                setDifficultyLowerBound(parseInt(event.target.value, 10))
-              }
-            />
-          </InputGroup>
-        </Col>
-      </FormGroup>
-
-      <FormGroup row>
-        <Col>
-          <InputGroup>
-            <InputGroupAddon addonType="prepend">
-              <InputGroupText>
-                <Input
-                  addon
-                  type="checkbox"
-                  aria-label="Enable filter by difficulty upper bound"
-                  checked={excludeHighDifficulty}
-                  onChange={event =>
-                    setExcludeHighDifficulty(event.target.checked)
-                  }
-                />
-              </InputGroupText>
-              <InputGroupText>Difficulty Upper Bound</InputGroupText>
-            </InputGroupAddon>
-            <Input
-              placeholder="difficulty upper bound"
-              min={0}
-              max={10000}
-              type="number"
-              value={difficultyUpperBound}
-              step={100}
-              disabled={!excludeHighDifficulty}
-              onChange={event =>
-                setDifficultyUpperBound(parseInt(event.target.value, 10))
-              }
-            />
-          </InputGroup>
-        </Col>
-      </FormGroup>
-
       <FormGroup row>
         <Col>
           <InputGroup>
@@ -123,43 +105,148 @@ export default (props: Props) => {
           </InputGroup>
         </Col>
       </FormGroup>
-
       <FormGroup row>
-        <Label sm={2}>
-          New to
-          <HelpBadgeTooltip id={"help-newto"}>
-            Exclude problems solved by at least one AtCoder account listed here.
-          </HelpBadgeTooltip>
-        </Label>
-        <Col sm={10}>
-          <Input
-            placeholder="a list of AtCoder ID separated by space"
-            value={excludeUserIds}
-            onChange={event => setExcludeUserIds(event.target.value)}
-          />
+        <Col>
+          <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText>
+                <Input
+                  addon
+                  type="checkbox"
+                  aria-label="Exclude already solved problems by expected participants"
+                  checked={excludeAlreadySolvedProblems}
+                  onChange={event =>
+                    setExcludeAlreadySolvedProblems(event.target.checked)
+                  }
+                />
+              </InputGroupText>
+            </InputGroupAddon>
+            <InputGroupText>
+              Exclude already solved problems by expected participants
+            </InputGroupText>
+          </InputGroup>
+        </Col>
+      </FormGroup>
+      <FormGroup row>
+        <Col sm={6}>
+          <Label>Difficulty Adjustment Preset</Label>
+          <InputGroup>
+            <UncontrolledDropdown>
+              <DropdownToggle caret>
+                {selectedPreset.displayName}
+              </DropdownToggle>
+              <DropdownMenu>
+                {[ABC_PRESET, ARC_PRESET, AGC_PRESET].map(preset => {
+                  return (
+                    <DropdownItem
+                      onClick={() => {
+                        setSelectedPreset(preset);
+                        setProblemSelectionParamsList(
+                          preset.problemSelectionParams
+                        );
+                      }}
+                      key={preset.displayName}
+                    >
+                      {preset.displayName}
+                    </DropdownItem>
+                  );
+                })}
+              </DropdownMenu>
+            </UncontrolledDropdown>
+          </InputGroup>
         </Col>
       </FormGroup>
 
-      <FormGroup row>
-        <Label sm={2}>Size</Label>
-        <Col sm={10}>
-          <Input
-            placeholder="The number of problems"
-            min={1}
-            max={100}
-            type="number"
-            value={nProblems}
-            step={100}
-            onChange={event => setNProblems(parseInt(event.target.value, 10))}
-          />
-        </Col>
-      </FormGroup>
+      {problemSelectionParamsList.map((problemSelectionParams, idx) => (
+        <FormGroup row key={idx}>
+          <Col sm={6}>
+            <Label> Problem {idx + 1}</Label>
+            <Button
+              close
+              onClick={() => {
+                const newParamsList = [...problemSelectionParamsList];
+                newParamsList.splice(idx, 1);
+                setProblemSelectionParamsList(newParamsList);
+              }}
+            />
+            <InputGroup>
+              <InputGroupAddon addonType="prepend">
+                <InputGroupText>Min Difficulty</InputGroupText>
+              </InputGroupAddon>
+              <Input
+                placeholder="Min Difficulty"
+                min={0}
+                max={10000}
+                type="number"
+                value={problemSelectionParams.minDifficulty}
+                step={50}
+                onChange={event => {
+                  const newParamsList = [...problemSelectionParamsList];
+                  newParamsList[idx] = {
+                    ...problemSelectionParams,
+                    minDifficulty: parseInt(event.target.value, 10)
+                  };
+                  setProblemSelectionParamsList(newParamsList);
+                }}
+              />
+              <InputGroupAddon addonType="prepend">
+                <InputGroupText>Max Difficulty</InputGroupText>
+              </InputGroupAddon>
+              <Input
+                placeholder="Max Difficulty"
+                min={0}
+                max={10000}
+                type="number"
+                value={problemSelectionParams.maxDifficulty}
+                step={50}
+                onChange={event => {
+                  const newParamsList = [...problemSelectionParamsList];
+                  newParamsList[idx] = {
+                    ...problemSelectionParams,
+                    maxDifficulty: parseInt(event.target.value, 10)
+                  };
+                  setProblemSelectionParamsList(newParamsList);
+                }}
+              />
+            </InputGroup>
+          </Col>
+        </FormGroup>
+      ))}
+      <div style={{ paddingBottom: 16 }}>
+        <Button
+          color={"link"}
+          onClick={() => {
+            let addedElement;
+            if (problemSelectionParamsList.length === 0) {
+              addedElement = {
+                minDifficulty: 0,
+                maxDifficulty: 10000
+              };
+            } else {
+              addedElement = {
+                ...problemSelectionParamsList[
+                  problemSelectionParamsList.length - 1
+                ]
+              };
+            }
+
+            setProblemSelectionParamsList([
+              ...problemSelectionParamsList,
+              addedElement
+            ]);
+          }}
+        >
+          More problem ...
+        </Button>
+      </div>
 
       <FormGroup row>
         <Col>
           <Button
             color="success"
-            onClick={() => {
+            onClick={async () => {
+              const nProblems = problemSelectionParamsList.length;
+
               let candidateProblems = props.problems.map(problem => ({
                 problem,
                 model: props.problemModels.get(problem.id)
@@ -168,55 +255,80 @@ export default (props: Props) => {
               if (excludeExperimental) {
                 candidateProblems = candidateProblems.filter(problem => {
                   return (
-                    problem.model !== undefined && !problem.model.is_experimental
+                    problem.model !== undefined &&
+                    !problem.model.is_experimental
                   );
                 });
               }
 
-              if (excludeLowDifficulty) {
-                candidateProblems = candidateProblems.filter(problem => {
-                  return (
-                    isProblemModelWithDifficultyModel(problem.model) &&
-                    problem.model.difficulty >= difficultyLowerBound
+              if (excludeAlreadySolvedProblems) {
+                try {
+                  const alreadySolvedProblems = await Promise.all(
+                    props.expectedParticipantUserIds.map(cachedSubmissions)
+                  ).then(userSubmissions => {
+                    return List(userSubmissions)
+                      .flatten(true)
+                      .filter(submission => isAccepted(submission.result))
+                      .map(submission => submission.problem_id)
+                      .toSet();
+                  });
+                  candidateProblems = candidateProblems.filter(
+                    problem =>
+                      !alreadySolvedProblems.contains(problem.problem.id)
                   );
-                });
+                } catch (e) {
+                  alert(
+                    "Error happened during fetching submissions. See console."
+                  );
+                  throw e;
+                }
               }
 
-              if (excludeHighDifficulty) {
-                candidateProblems = candidateProblems.filter(problem => {
-                  return (
-                    isProblemModelWithDifficultyModel(problem.model) &&
-                    problem.model.difficulty <= difficultyUpperBound
-                  );
-                });
-              }
+              candidateProblems = shuffleList(candidateProblems).toList();
 
-              const tokenizedUserIds = List.of(...excludeUserIds.split(" "));
-              Promise.all(tokenizedUserIds.map(cachedSubmissions)).then(
-                userSubmissions => {
-                  const solvedProblemIds = List(userSubmissions)
-                    .flatten(true)
-                    .filter(submission => isAccepted(submission.result))
-                    .map(submission => submission.problem_id)
-                    .toSet();
+              const selectedProblems: Problem[] = [];
+              const alreadySelectedProblemIds = new Set<string>();
+              const selectionFailedProblemNumbers: number[] = [];
+              problemSelectionParamsList.forEach(
+                (problemSelectionParams, idx) => {
+                  let found = false;
+                  candidateProblems.forEach(problem => {
+                    if (
+                      found ||
+                      alreadySelectedProblemIds.has(problem.problem.id)
+                    ) {
+                      return;
+                    }
 
-                  const filteredProblem = candidateProblems
-                    .map(problem => problem.problem)
-                    .filter(problem => !solvedProblemIds.contains(problem.id));
-                  if (filteredProblem.size < nProblems) {
-                    alert(
-                      "Only " +
-                        filteredProblem.size +
-                        " problems matched, while " +
-                        nProblems +
-                        " problems requested."
-                    );
+                    if (
+                      isProblemModelWithDifficultyModel(problem.model) &&
+                      problem.model.difficulty >=
+                        problemSelectionParams.minDifficulty &&
+                      problem.model.difficulty <=
+                        problemSelectionParams.maxDifficulty
+                    ) {
+                      alreadySelectedProblemIds.add(problem.problem.id);
+                      selectedProblems.push(problem.problem);
+                      found = true;
+                      return;
+                    }
+                  });
+                  if (!found) {
+                    selectionFailedProblemNumbers.push(idx);
                   }
-                  props.selectProblem(
-                    ...shuffleList(filteredProblem, nProblems).toArray()
-                  );
                 }
               );
+
+              if (selectedProblems.length < nProblems) {
+                alert(
+                  `Only ${
+                    selectedProblems.length
+                  } problems are prepared. (Failed to assign a problem for problem ${selectionFailedProblemNumbers
+                    .map(num => num + 1)
+                    .join(",")})`
+                );
+              }
+              props.selectProblem(...selectedProblems);
             }}
           >
             Add

--- a/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSetGenerator.tsx
@@ -40,7 +40,7 @@ interface ProblemSetSelectionPreset {
 }
 
 const ABC_PRESET: ProblemSetSelectionPreset = {
-  displayName: "Preset 1",
+  displayName: "Level 1",
   problemSelectionParams: [
     { minDifficulty: 0, maxDifficulty: 50 },
     { minDifficulty: 10, maxDifficulty: 100 },
@@ -52,7 +52,7 @@ const ABC_PRESET: ProblemSetSelectionPreset = {
 };
 
 const ARC_PRESET: ProblemSetSelectionPreset = {
-  displayName: "Preset 2",
+  displayName: "Level 2",
   problemSelectionParams: [
     { minDifficulty: 800, maxDifficulty: 1200 },
     { minDifficulty: 1200, maxDifficulty: 1800 },
@@ -62,7 +62,7 @@ const ARC_PRESET: ProblemSetSelectionPreset = {
 };
 
 const AGC_PRESET: ProblemSetSelectionPreset = {
-  displayName: "Preset 3",
+  displayName: "Level 3",
   problemSelectionParams: [
     { minDifficulty: 400, maxDifficulty: 1200 },
     { minDifficulty: 1200, maxDifficulty: 2400 },
@@ -244,6 +244,7 @@ export default (props: Props) => {
         <Col>
           <Button
             color="success"
+            disabled={problemSelectionParamsList.length === 0}
             onClick={async () => {
               const nProblems = problemSelectionParamsList.length;
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -14,19 +14,20 @@ import {
   Row,
   UncontrolledDropdown
 } from "reactstrap";
-import { Range, Map, List } from "immutable";
+import { List, Map, Range } from "immutable";
 import { connect, PromiseState } from "react-refetch";
 import * as CachedApiClient from "../../../utils/CachedApiClient";
 import { ProblemId } from "../../../interfaces/Status";
 import Problem from "../../../interfaces/Problem";
 import moment from "moment";
-import { Redirect } from "react-router-dom";
 import { USER_GET } from "../ApiUrl";
 import ProblemSearchBox from "../../../components/ProblemSearchBox";
 import { formatMode, VirtualContestItem, VirtualContestMode } from "../types";
 import ProblemLink from "../../../components/ProblemLink";
 import ProblemModel from "../../../interfaces/ProblemModel";
 import ProblemSetGenerator from "../../../components/ProblemSetGenerator";
+import HelpBadgeTooltip from "../../../components/HelpBadgeTooltip";
+import { Redirect } from "react-router";
 
 const ContestConfig = (props: InnerProps) => {
   const [title, setTitle] = useState(props.initialTitle);
@@ -40,6 +41,15 @@ const ContestConfig = (props: InnerProps) => {
   const [endMinute, setEndMinute] = useState(props.initialEndMinute);
   const [problemSet, setProblemSet] = useState(props.initialProblems);
   const [mode, setMode] = useState(props.initialMode);
+  const [
+    expectedParticipantUserIdsText,
+    setExpectedParticipantUserIdsText
+  ] = useState("");
+
+  const expectedParticipantUserIds =
+    expectedParticipantUserIdsText.length > 0
+      ? expectedParticipantUserIdsText.split(" ")
+      : [];
 
   if (props.loginState.rejected) {
     return <Redirect to="/" />;
@@ -183,6 +193,25 @@ const ContestConfig = (props: InnerProps) => {
         </Col>
       </Row>
 
+      <Row className="my-2">
+        <Col>
+          <Label>
+            Expected Participants
+            <HelpBadgeTooltip id={"help-expected-participants"}>
+              This list is used for checking if the problems in the list are
+              already solved by each participant.
+            </HelpBadgeTooltip>
+          </Label>
+          <Input
+            placeholder="AtCoder ID list separated by space"
+            value={expectedParticipantUserIdsText}
+            onChange={event => {
+              setExpectedParticipantUserIdsText(event.target.value);
+            }}
+          />
+        </Col>
+      </Row>
+
       <Row>
         <Col>
           <Label>Problems</Label>
@@ -277,17 +306,20 @@ const ContestConfig = (props: InnerProps) => {
 
       <Row>
         <Col>
-          <Label>Bacha Gacha</Label>
-        </Col>
-      </Row>
+          <div style={{ padding: 8, border: "solid 1px lightgray" }}>
+            <Label>Bacha Gacha</Label>
 
-      <Row className="my-2">
-        <Col>
-          <ProblemSetGenerator
-            problems={problemMap.valueSeq().toList()}
-            problemModels={problemModelMap}
-            selectProblem={addProblemsIfNotSelected}
-          />
+            <Row className="my-2">
+              <Col>
+                <ProblemSetGenerator
+                  problems={problemMap.valueSeq().toList()}
+                  problemModels={problemModelMap}
+                  selectProblem={addProblemsIfNotSelected}
+                  expectedParticipantUserIds={expectedParticipantUserIds}
+                />
+              </Col>
+            </Row>
+          </div>
         </Col>
       </Row>
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -7,10 +7,7 @@ import {
   DropdownToggle,
   Input,
   InputGroup,
-  InputGroupAddon,
   Label,
-  ListGroup,
-  ListGroupItem,
   Row,
   UncontrolledDropdown
 } from "reactstrap";
@@ -23,11 +20,11 @@ import moment from "moment";
 import { USER_GET } from "../ApiUrl";
 import ProblemSearchBox from "../../../components/ProblemSearchBox";
 import { formatMode, VirtualContestItem, VirtualContestMode } from "../types";
-import ProblemLink from "../../../components/ProblemLink";
 import ProblemModel from "../../../interfaces/ProblemModel";
 import ProblemSetGenerator from "../../../components/ProblemSetGenerator";
 import HelpBadgeTooltip from "../../../components/HelpBadgeTooltip";
 import { Redirect } from "react-router";
+import ContestConfigProblemList from "./ContestConfigProblemList";
 
 const ContestConfig = (props: InnerProps) => {
   const [title, setTitle] = useState(props.initialTitle);
@@ -220,78 +217,13 @@ const ContestConfig = (props: InnerProps) => {
 
       <Row>
         <Col>
-          <ListGroup>
-            {problemSet.valueSeq().map((p, i) => {
-              const problemId = p.id;
-              const problem = problemMap.get(problemId);
-              return (
-                <ListGroupItem key={problemId}>
-                  <Button
-                    close
-                    onClick={() => {
-                      setProblemSet(problemSet.filter(x => x.id !== problemId));
-                    }}
-                  />
-                  {problem ? (
-                    <ProblemLink
-                      problemId={problem.id}
-                      contestId={problem.contest_id}
-                      problemTitle={problem.title}
-                    />
-                  ) : (
-                    problemId
-                  )}
-                  {p.point === null ? (
-                    <Button
-                      style={{ float: "right" }}
-                      onClick={() => {
-                        setProblemSet(
-                          problemSet.update(i, x => ({
-                            ...x,
-                            point: 0
-                          }))
-                        );
-                      }}
-                    >
-                      Set Point
-                    </Button>
-                  ) : null}
-                  {p.point !== null ? (
-                    <InputGroup>
-                      <Input
-                        type="number"
-                        value={p.point}
-                        onChange={e => {
-                          const parse = parseInt(e.target.value, 10);
-                          const point = !isNaN(parse) ? parse : 0;
-                          setProblemSet(
-                            problemSet.update(i, x => ({
-                              ...x,
-                              point
-                            }))
-                          );
-                        }}
-                      />
-                      <InputGroupAddon addonType="append">
-                        <Button
-                          onClick={() => {
-                            setProblemSet(
-                              problemSet.update(i, x => ({
-                                ...x,
-                                point: null
-                              }))
-                            );
-                          }}
-                        >
-                          Unset
-                        </Button>
-                      </InputGroupAddon>
-                    </InputGroup>
-                  ) : null}
-                </ListGroupItem>
-              );
-            })}
-          </ListGroup>
+          <ContestConfigProblemList
+            problemModelMap={problemModelMap}
+            problemMap={problemMap}
+            problemSet={problemSet}
+            setProblemSet={setProblemSet}
+            expectedParticipantUserIds={expectedParticipantUserIds}
+          />
         </Col>
       </Row>
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -73,106 +73,120 @@ const ContestConfig = (props: InnerProps) => {
   return (
     <>
       <Row>
-        <h1>{props.pageTitle}</h1>
+        <Col>
+          <h1>{props.pageTitle}</h1>
+        </Col>
       </Row>
 
       <Row className="my-2">
-        <Label>Contest Title</Label>
-        <Input
-          type="text"
-          placeholder="Contest Title"
-          value={title}
-          onChange={event => setTitle(event.target.value)}
-        />
-      </Row>
-
-      <Row className="my-2">
-        <Label>Description</Label>
-        <Input
-          type="text"
-          placeholder="Description"
-          value={memo}
-          onChange={event => setMemo(event.target.value)}
-        />
-      </Row>
-
-      <Row className="my-2">
-        <Label>Mode</Label>
-        <InputGroup>
-          <UncontrolledDropdown>
-            <DropdownToggle caret>{formatMode(mode)}</DropdownToggle>
-            <DropdownMenu>
-              <DropdownItem onClick={() => setMode(null)}>
-                {formatMode(null)}
-              </DropdownItem>
-              <DropdownItem onClick={() => setMode("lockout")}>
-                {formatMode("lockout")}
-              </DropdownItem>
-            </DropdownMenu>
-          </UncontrolledDropdown>
-        </InputGroup>
-      </Row>
-
-      <Row className="my-2">
-        <Label>Start Time</Label>
-        <InputGroup>
+        <Col>
+          <Label>Contest Title</Label>
           <Input
-            type="date"
-            value={startDate}
-            onChange={event => setStartDate(event.target.value)}
+            type="text"
+            placeholder="Contest Title"
+            value={title}
+            onChange={event => setTitle(event.target.value)}
           />
-          <Input
-            type="select"
-            value={startHour}
-            onChange={e => setStartHour(Number(e.target.value))}
-          >
-            {Range(0, 24).map(i => (
-              <option key={i}>{i}</option>
-            ))}
-          </Input>
-          <Input
-            type="select"
-            value={startMinute}
-            onChange={e => setStartMinute(Number(e.target.value))}
-          >
-            {Range(0, 60, 5).map(i => (
-              <option key={i}>{i}</option>
-            ))}
-          </Input>
-        </InputGroup>
+        </Col>
       </Row>
 
       <Row className="my-2">
-        <Label>End Time</Label>
-        <InputGroup>
+        <Col>
+          <Label>Description</Label>
           <Input
-            type="date"
-            value={endDate}
-            onChange={event => setEndDate(event.target.value)}
+            type="text"
+            placeholder="Description"
+            value={memo}
+            onChange={event => setMemo(event.target.value)}
           />
-          <Input
-            type="select"
-            value={endHour}
-            onChange={e => setEndHour(Number(e.target.value))}
-          >
-            {Range(0, 24).map(i => (
-              <option key={i}>{i}</option>
-            ))}
-          </Input>
-          <Input
-            type="select"
-            value={endMinute}
-            onChange={e => setEndMinute(Number(e.target.value))}
-          >
-            {Range(0, 60, 5).map(i => (
-              <option key={i}>{i}</option>
-            ))}
-          </Input>
-        </InputGroup>
+        </Col>
+      </Row>
+
+      <Row className="my-2">
+        <Col>
+          <Label>Mode</Label>
+          <InputGroup>
+            <UncontrolledDropdown>
+              <DropdownToggle caret>{formatMode(mode)}</DropdownToggle>
+              <DropdownMenu>
+                <DropdownItem onClick={() => setMode(null)}>
+                  {formatMode(null)}
+                </DropdownItem>
+                <DropdownItem onClick={() => setMode("lockout")}>
+                  {formatMode("lockout")}
+                </DropdownItem>
+              </DropdownMenu>
+            </UncontrolledDropdown>
+          </InputGroup>
+        </Col>
+      </Row>
+
+      <Row className="my-2">
+        <Col>
+          <Label>Start Time</Label>
+          <InputGroup>
+            <Input
+              type="date"
+              value={startDate}
+              onChange={event => setStartDate(event.target.value)}
+            />
+            <Input
+              type="select"
+              value={startHour}
+              onChange={e => setStartHour(Number(e.target.value))}
+            >
+              {Range(0, 24).map(i => (
+                <option key={i}>{i}</option>
+              ))}
+            </Input>
+            <Input
+              type="select"
+              value={startMinute}
+              onChange={e => setStartMinute(Number(e.target.value))}
+            >
+              {Range(0, 60, 5).map(i => (
+                <option key={i}>{i}</option>
+              ))}
+            </Input>
+          </InputGroup>
+        </Col>
+      </Row>
+
+      <Row className="my-2">
+        <Col>
+          <Label>End Time</Label>
+          <InputGroup>
+            <Input
+              type="date"
+              value={endDate}
+              onChange={event => setEndDate(event.target.value)}
+            />
+            <Input
+              type="select"
+              value={endHour}
+              onChange={e => setEndHour(Number(e.target.value))}
+            >
+              {Range(0, 24).map(i => (
+                <option key={i}>{i}</option>
+              ))}
+            </Input>
+            <Input
+              type="select"
+              value={endMinute}
+              onChange={e => setEndMinute(Number(e.target.value))}
+            >
+              {Range(0, 60, 5).map(i => (
+                <option key={i}>{i}</option>
+              ))}
+            </Input>
+          </InputGroup>
+        </Col>
       </Row>
 
       <Row>
-        <Label>Problems</Label>
+        <Col>
+          <Label>Problems</Label>
+        </Col>
       </Row>
 
       <Row>
@@ -253,41 +267,49 @@ const ContestConfig = (props: InnerProps) => {
       </Row>
 
       <Row className="my-2">
-        <ProblemSearchBox
-          problems={problemMap.valueSeq().toList()}
-          selectProblem={addProblemsIfNotSelected}
-        />
+        <Col>
+          <ProblemSearchBox
+            problems={problemMap.valueSeq().toList()}
+            selectProblem={addProblemsIfNotSelected}
+          />
+        </Col>
       </Row>
 
       <Row>
-        <Label>Bacha Gacha</Label>
+        <Col>
+          <Label>Bacha Gacha</Label>
+        </Col>
       </Row>
 
       <Row className="my-2">
-        <ProblemSetGenerator
-          problems={problemMap.valueSeq().toList()}
-          problemModels={problemModelMap}
-          selectProblem={addProblemsIfNotSelected}
-        />
+        <Col>
+          <ProblemSetGenerator
+            problems={problemMap.valueSeq().toList()}
+            problemModels={problemModelMap}
+            selectProblem={addProblemsIfNotSelected}
+          />
+        </Col>
       </Row>
 
       <Row className="my-2">
-        <Button
-          disabled={!isValid}
-          color={isValid ? "success" : "link"}
-          onClick={() =>
-            props.buttonPush({
-              title,
-              memo,
-              startSecond,
-              endSecond,
-              problems: problemSet,
-              mode
-            })
-          }
-        >
-          {props.buttonTitle}
-        </Button>
+        <Col>
+          <Button
+            disabled={!isValid}
+            color={isValid ? "success" : "link"}
+            onClick={() =>
+              props.buttonPush({
+                title,
+                memo,
+                startSecond,
+                endSecond,
+                problems: problemSet,
+                mode
+              })
+            }
+          >
+            {props.buttonTitle}
+          </Button>
+        </Col>
       </Row>
     </>
   );

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -5,6 +5,7 @@ import {
   DropdownItem,
   DropdownMenu,
   DropdownToggle,
+  FormFeedback,
   Input,
   InputGroup,
   Label,
@@ -42,6 +43,12 @@ const ContestConfig = (props: InnerProps) => {
     expectedParticipantUserIdsText,
     setExpectedParticipantUserIdsText
   ] = useState("");
+  const [
+    expectedParticipantsInputErrorMessage,
+    setExpectedParticipantsInputErrorMessage
+  ] = useState("");
+  const hasExpectedParticipantsInputError =
+    expectedParticipantsInputErrorMessage.length > 0;
 
   const expectedParticipantUserIds =
     expectedParticipantUserIdsText.length > 0
@@ -202,10 +209,14 @@ const ContestConfig = (props: InnerProps) => {
           <Input
             placeholder="AtCoder ID list separated by space"
             value={expectedParticipantUserIdsText}
+            invalid={hasExpectedParticipantsInputError}
             onChange={event => {
               setExpectedParticipantUserIdsText(event.target.value);
             }}
           />
+          {hasExpectedParticipantsInputError && (
+            <FormFeedback>{expectedParticipantsInputErrorMessage}</FormFeedback>
+          )}
         </Col>
       </Row>
 
@@ -218,6 +229,9 @@ const ContestConfig = (props: InnerProps) => {
       <Row>
         <Col>
           <ContestConfigProblemList
+            onSolvedProblemsFetchFinished={errorMessage => {
+              setExpectedParticipantsInputErrorMessage(errorMessage || "");
+            }}
             problemModelMap={problemModelMap}
             problemMap={problemMap}
             problemSet={problemSet}
@@ -248,6 +262,11 @@ const ContestConfig = (props: InnerProps) => {
                   problemModels={problemModelMap}
                   selectProblem={addProblemsIfNotSelected}
                   expectedParticipantUserIds={expectedParticipantUserIds}
+                  addButtonDisabled={hasExpectedParticipantsInputError}
+                  feedbackForDisabledAddButton={
+                    expectedParticipantsInputErrorMessage &&
+                    "Please fix expected participants field first"
+                  }
                 />
               </Col>
             </Row>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
@@ -120,6 +120,7 @@ interface OuterProps {
   problemSet: List<VirtualContestItem>;
   setProblemSet: (newProblemSet: List<VirtualContestItem>) => void;
   expectedParticipantUserIds: string[];
+  onSolvedProblemsFetchFinished: (errorMessage?: string | null) => void;
 }
 
 interface InnerProps extends OuterProps {
@@ -132,6 +133,7 @@ export default connect<OuterProps, InnerProps>(props => ({
     refreshing: true,
     value: async () => {
       const res: { [problem: string]: Set<string> } = {};
+      const failedUserIds: string[] = [];
       for (const userId of props.expectedParticipantUserIds) {
         try {
           const submissions = await cachedSubmissions(userId);
@@ -140,8 +142,15 @@ export default connect<OuterProps, InnerProps>(props => ({
             .map(submission => submission.problem_id)
             .toSet();
         } catch (e) {
-          // ignore
+          failedUserIds.push(userId);
         }
+      }
+      if (failedUserIds.length > 0) {
+        props.onSolvedProblemsFetchFinished(
+          `Fetch Failed for ${failedUserIds.join(", ")}`
+        );
+      } else {
+        props.onSolvedProblemsFetchFinished();
       }
       return res;
     }

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
@@ -24,10 +24,10 @@ const ContestConfigProblemList = (props: InnerProps) => {
         const problem = props.problemMap.get(problemId);
 
         const solvedUsers =
-          problem && props.userSolvedSubmissionsMapFetch.fulfilled
-            ? Object.entries(props.userSolvedSubmissionsMapFetch.value)
-                .filter(([user, submissions]) =>
-                  submissions.contains(problem.id)
+          problem && props.userSolvedProblemsMapFetch.fulfilled
+            ? Object.entries(props.userSolvedProblemsMapFetch.value)
+                .filter(([user, solvedProblems]) =>
+                  solvedProblems.contains(problem.id)
                 )
                 .map(([user, ignored]) => user)
             : [];
@@ -123,11 +123,11 @@ interface OuterProps {
 }
 
 interface InnerProps extends OuterProps {
-  userSolvedSubmissionsMapFetch: PromiseState<{ [user: string]: Set<string> }>;
+  userSolvedProblemsMapFetch: PromiseState<{ [user: string]: Set<string> }>;
 }
 
 export default connect<OuterProps, InnerProps>(props => ({
-  userSolvedSubmissionsMapFetch: {
+  userSolvedProblemsMapFetch: {
     comparison: props.expectedParticipantUserIds,
     refreshing: true,
     value: async () => {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import {
+  Button,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  ListGroup,
+  ListGroupItem
+} from "reactstrap";
+import { List, Map, Set } from "immutable";
+import { connect, PromiseState } from "react-refetch";
+import { cachedSubmissions } from "../../../utils/CachedApiClient";
+import Problem from "../../../interfaces/Problem";
+import { VirtualContestItem } from "../types";
+import ProblemLink from "../../../components/ProblemLink";
+import ProblemModel from "../../../interfaces/ProblemModel";
+import { isAccepted } from "../../../utils";
+
+const ContestConfigProblemList = (props: InnerProps) => {
+  return (
+    <ListGroup>
+      {props.problemSet.valueSeq().map((p, i) => {
+        const problemId = p.id;
+        const problem = props.problemMap.get(problemId);
+
+        const solvedUsers =
+          problem && props.userSolvedSubmissionsMapFetch.fulfilled
+            ? Object.entries(props.userSolvedSubmissionsMapFetch.value)
+                .filter(([user, submissions]) =>
+                  submissions.contains(problem.id)
+                )
+                .map(([user, ignored]) => user)
+            : [];
+
+        return (
+          <ListGroupItem
+            key={problemId}
+            style={{ backgroundColor: solvedUsers.length > 0 ? "#ffeeee" : "" }}
+          >
+            <Button
+              close
+              onClick={() => {
+                props.setProblemSet(
+                  props.problemSet.filter(x => x.id !== problemId)
+                );
+              }}
+            />
+            {problem ? (
+              <ProblemLink
+                problemId={problem.id}
+                contestId={problem.contest_id}
+                problemTitle={problem.title}
+                showDifficulty={true}
+                difficulty={props.problemModelMap.get(problemId)?.difficulty}
+                isExperimentalDifficulty={
+                  props.problemModelMap.get(problemId)?.is_experimental
+                }
+              />
+            ) : (
+              problemId
+            )}
+            {solvedUsers.length > 0 && <> solved by {solvedUsers.join(", ")}</>}
+            {p.point === null ? (
+              <Button
+                style={{ float: "right" }}
+                onClick={() => {
+                  props.setProblemSet(
+                    props.problemSet.update(i, x => ({
+                      ...x,
+                      point: 0
+                    }))
+                  );
+                }}
+              >
+                Set Point
+              </Button>
+            ) : null}
+            {p.point !== null ? (
+              <InputGroup>
+                <Input
+                  type="number"
+                  value={p.point}
+                  onChange={e => {
+                    const parse = parseInt(e.target.value, 10);
+                    const point = !isNaN(parse) ? parse : 0;
+                    props.setProblemSet(
+                      props.problemSet.update(i, x => ({
+                        ...x,
+                        point
+                      }))
+                    );
+                  }}
+                />
+                <InputGroupAddon addonType="append">
+                  <Button
+                    onClick={() => {
+                      props.setProblemSet(
+                        props.problemSet.update(i, x => ({
+                          ...x,
+                          point: null
+                        }))
+                      );
+                    }}
+                  >
+                    Unset
+                  </Button>
+                </InputGroupAddon>
+              </InputGroup>
+            ) : null}
+          </ListGroupItem>
+        );
+      })}
+    </ListGroup>
+  );
+};
+
+interface OuterProps {
+  problemModelMap: Map<string, ProblemModel>;
+  problemMap: Map<string, Problem>;
+  problemSet: List<VirtualContestItem>;
+  setProblemSet: (newProblemSet: List<VirtualContestItem>) => void;
+  expectedParticipantUserIds: string[];
+}
+
+interface InnerProps extends OuterProps {
+  userSolvedSubmissionsMapFetch: PromiseState<{ [user: string]: Set<string> }>;
+}
+
+export default connect<OuterProps, InnerProps>(props => ({
+  userSolvedSubmissionsMapFetch: {
+    comparison: props.expectedParticipantUserIds,
+    refreshing: true,
+    value: async () => {
+      const res: { [problem: string]: Set<string> } = {};
+      for (const userId of props.expectedParticipantUserIds) {
+        try {
+          const submissions = await cachedSubmissions(userId);
+          res[userId] = submissions
+            .filter(submission => isAccepted(submission.result))
+            .map(submission => submission.problem_id)
+            .toSet();
+        } catch (e) {
+          // ignore
+        }
+      }
+      return res;
+    }
+  }
+}))(ContestConfigProblemList);

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
@@ -39,7 +39,7 @@ const ContestCreatePage = (props: InnerProps) => {
       initialEndMinute={todayMinute}
       initialProblems={List()}
       initialMode={null}
-      buttonTitle="Create"
+      buttonTitle="Create Contest"
       buttonPush={({ title, memo, startSecond, endSecond, problems, mode }) =>
         props.createContest(
           {


### PR DESCRIPTION
**スクショ**
![image](https://user-images.githubusercontent.com/233559/72118477-9539f000-3394-11ea-8d1d-b7a897ab16c3.png)

### やったこと

**コンテスト作成ページUI**
- 問題一覧ページにDifficultyを表示する
- Expected participants(参加者する可能性のある人リスト)に書かれているユーザーリストに対して各問題が既に解かれているかどうかを表示する
![image](https://user-images.githubusercontent.com/233559/72118010-10020b80-3393-11ea-8598-dee5b5860ffb.png)

**バチャガチそのもの**
- 同じ難易度帯の問題をたくさん作る方式から問題難易度を指定してコンテストを生成する方式にしました。 
![image](https://user-images.githubusercontent.com/233559/72118125-84d54580-3393-11ea-964d-ab668382585d.png)
- ABC/ARC/AGCっぽい難易度(難易度の上界と下界は本当に適当)のプリセットをそれぞれLevel 1, Level 2, Level 3で用意しました。ABC/ARC/AGCやらEasy/Medium/Hardみたいなものではなく無味簡素な名前にした理由は次の二つです。
 (1) 非公式なものをABC/ARC/AGCとユーザーが呼び始める事態は避けたい。
 (2) 簡単とか難しいというのは人の主観によると思うので、呼称のせいで"Easy"が解けなくて落ち込むとかいうエクスペリエンスを危惧
![image](https://user-images.githubusercontent.com/233559/72118279-f7debc00-3393-11ea-8d57-73358c357bf7.png)
- チェックボックスの数を減らした

@amylase かなりアグレッシブなUI変更をしてしまいましたが、どう思いますか?


### やってないこと(廃止したこと?)
- Difficultyがついていない問題に対するランダム選択
