### PR TITLE
Virtual Contests に Duration の表示を追加しました。

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest.tsx
@@ -167,7 +167,8 @@ const InnerShowContest = (props: InnerProps) => {
           <h5>Mode: {formatMode(contestInfo.mode)}</h5>
           <h5>
             Time: {formatMomentDateTime(parseSecond(start))} -{" "}
-            {formatMomentDateTime(parseSecond(end))}
+            {formatMomentDateTime(parseSecond(end))} (
+            {Math.floor(contestInfo.duration_second / 60)} minutes)
           </h5>
           {end - now > 0 ? (
             <h5>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContestTable.tsx
@@ -36,7 +36,7 @@ export default (props: { contests: VirtualContest[] }) => {
         Start
       </TableHeaderColumn>
       <TableHeaderColumn
-        dataField="duration_second"
+        dataField="end_epoch_second"
         dataFormat={(_: number, contest: VirtualContest) => {
           const time = DateUtil.parseSecond(
             contest.start_epoch_second + contest.duration_second
@@ -45,6 +45,17 @@ export default (props: { contests: VirtualContest[] }) => {
         }}
       >
         End
+      </TableHeaderColumn>
+      <TableHeaderColumn
+        dataField="duration"
+        dataFormat={(_: number, contest: VirtualContest) => {
+          const durationMinute = Math.floor(contest.duration_second / 60);
+          const hour = `0${Math.floor(durationMinute / 60)}`.slice(-2);
+          const minute = `0${durationMinute % 60}`.slice(-2);
+          return hour + ":" + minute;
+        }}
+      >
+        Duration
       </TableHeaderColumn>
     </BootstrapTable>
   );


### PR DESCRIPTION
VirtualContestTable.tsx に追加した `Duration` の列は、AtCoderのコンテスト一覧ページ ( https://atcoder.jp/contests/ ) の表記 (日本語だと「時間」と書かれている列) と合わせています。

ShowContest.tsx に追加した `(～ minutes)` の表記は、AtCoderの各コンテストページ ( 例: https://atcoder.jp/contests/abc151 ) の上部の表記と合わせています。