### PR TITLE
submissions API が遅いので速くする

### DIFF
--- a/atcoder-problems-backend/src/crawler/fix_crawler.rs
+++ b/atcoder-problems-backend/src/crawler/fix_crawler.rs
@@ -104,6 +104,9 @@ mod tests {
         fn update_submission_count(&self) -> Result<()> {
             unimplemented!()
         }
+        fn update_user_submission_count(&self, _: &str) -> Result<()> {
+            unimplemented!()
+        }
 
         fn update_delta_submission_count(&self, _: &[Submission]) -> Result<()> {
             unimplemented!()

--- a/atcoder-problems-backend/src/crawler/recent_crawler.rs
+++ b/atcoder-problems-backend/src/crawler/recent_crawler.rs
@@ -94,6 +94,9 @@ mod tests {
             fn update_submission_count(&self) -> Result<()> {
                 unimplemented!()
             }
+            fn update_user_submission_count(&self, _: &str) -> Result<()> {
+                unimplemented!()
+            }
 
             fn update_delta_submission_count(&self, _: &[Submission]) -> Result<()> {
                 unimplemented!()

--- a/atcoder-problems-backend/src/crawler/whole_contest_crawler.rs
+++ b/atcoder-problems-backend/src/crawler/whole_contest_crawler.rs
@@ -72,6 +72,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn update_user_submission_count(&self, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+
         fn update_delta_submission_count(&self, _: &[Submission]) -> Result<()> {
             unimplemented!()
         }

--- a/atcoder-problems-backend/src/server/user_submissions.rs
+++ b/atcoder-problems-backend/src/server/user_submissions.rs
@@ -22,6 +22,9 @@ pub(crate) async fn get_user_submissions<A>(request: Request<AppData<A>>) -> Res
         let submissions = conn.get_submissions(SubmissionRequest::UserAll { user_id })?;
         let heavy_count = submissions.len();
         let heavy_etag = utils::calc_etag_for_user(user_id, heavy_count);
+        if heavy_etag.as_str() != lite_etag.as_str() {
+            let _ = conn.update_user_submission_count(user_id);
+        }
         if heavy_etag.as_str() == etag {
             Ok(Response::not_modified())
         } else {

--- a/atcoder-problems-backend/src/sql/submission_client.rs
+++ b/atcoder-problems-backend/src/sql/submission_client.rs
@@ -117,7 +117,7 @@ impl SubmissionClient for PgConnection {
     fn update_user_submission_count(&self, user_id: &str) -> Result<()> {
         sql_query(r"
                 INSERT INTO submission_count (user_id, count)
-                SELECT user_id, count(*) FROM submissions GROUP BY user_id WHERE user_id = ?
+                SELECT user_id, count(*) FROM submissions WHERE user_id = ? GROUP BY user_id
                 ON CONFLICT (user_id) DO UPDATE SET count=EXCLUDED.count",
             )
             .bind::<Text, _>(user_id)


### PR DESCRIPTION
`heavy_etag` と `lite_etag` が存在していますが、外部から観察する限りこれがあまり一致していません。なので、これがずれてたら更新します。
挿入時に同時に更新するのが適切なのですが、とりあえず取得時の更新で実装しました。

更新がなくても毎回 O(N) 時間かかってて遅かった (6秒程度かかるのはつらい) ところが O(1) になるはずです。ただし、サーバ準備が面倒なので手元での計測はしていません。