### PR TITLE
Improve colorful mode feature

### DIFF
--- a/atcoder-problems-frontend/src/components/SubmitTimespan.tsx
+++ b/atcoder-problems-frontend/src/components/SubmitTimespan.tsx
@@ -5,6 +5,7 @@ import { ProblemStatus, StatusLabel } from "../interfaces/Status";
 interface Props {
   contest: Contest;
   problemStatus?: ProblemStatus;
+  enableColorfulMode: boolean;
 }
 
 const formatTimespan = (sec: number) => {
@@ -19,7 +20,10 @@ const formatTimespan = (sec: number) => {
 };
 
 const SubmitTimespan: React.FC<Props> = props => {
-  const { contest, problemStatus } = props;
+  const { contest, problemStatus, enableColorfulMode } = props;
+  if (!enableColorfulMode) {
+    return null;
+  }
 
   return (
     <div className="table-problem-timespan">

--- a/atcoder-problems-frontend/src/components/SubmitTimespan.tsx
+++ b/atcoder-problems-frontend/src/components/SubmitTimespan.tsx
@@ -4,7 +4,7 @@ import { ProblemStatus, StatusLabel } from "../interfaces/Status";
 
 interface Props {
   contest: Contest;
-  problemStatus: ProblemStatus | undefined;
+  problemStatus?: ProblemStatus;
 }
 
 const formatTimespan = (sec: number) => {
@@ -24,8 +24,8 @@ const SubmitTimespan: React.FC<Props> = props => {
   return (
     <div className="table-problem-timespan">
       {!problemStatus ||
-      (problemStatus.label !== StatusLabel.Success &&
-        problemStatus.label !== StatusLabel.Warning) ||
+      problemStatus.label !== StatusLabel.Success ||
+      problemStatus.epoch === void 0 ||
       problemStatus.epoch > contest.start_epoch_second + contest.duration_second
         ? ""
         : formatTimespan(problemStatus.epoch - contest.start_epoch_second)}

--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -61,16 +61,33 @@ span.difficulty-circle {
   position: relative;
 }
 
+/*
+.table-hover .table-success:hover>td, .table-hover .table-success:hover>th
+
+, table.table-striped>tbody>tr.table-warning-intime
+*/
 .table-success-intime, .table-success-intime>td, .table-success-intime>th {
   background-color: #9AD59E;
+}
+
+.table-warning-intime, .table-warning-intime>td, .table-warning-intime>th {
+  background-color: #FFDD99;
 }
 
 .table-success-before-contest, .table-success-before-contest>td, .table-success-before-contest>th {
   background-color: #99CCFF;
 }
 
-.table-warning-intime {
-  background-color: #FFDD99;
+.table-hover .table-success-intime:hover, .table-hover .table-success-intime:hover>td, .table-hover .table-success-intime:hover>th {
+  background-color: #88CC88;
+}
+
+.table-hover .table-warning-intime:hover, .table-hover .table-warning-intime:hover>td, .table-hover .table-warning-intime:hover>th {
+  background-color: #F0CC99;
+}
+
+.table-hover .table-success-before-contest:hover, .table-hover .table-success-before-contest:hover>td, .table-hover .table-success-before-contest:hover>th {
+  background-color: #88BBFF;
 }
 
 .table-problem-timespan {

--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -61,11 +61,7 @@ span.difficulty-circle {
   position: relative;
 }
 
-/*
-.table-hover .table-success:hover>td, .table-hover .table-success:hover>th
 
-, table.table-striped>tbody>tr.table-warning-intime
-*/
 .table-success-intime, .table-success-intime>td, .table-success-intime>th {
   background-color: #9AD59E;
 }

--- a/atcoder-problems-frontend/src/interfaces/Status.ts
+++ b/atcoder-problems-frontend/src/interfaces/Status.ts
@@ -9,7 +9,7 @@ export enum StatusLabel {
   None
 }
 
-export const successStatus = (epoch: number) => ({
+export const successStatus = (epoch?: number) => ({
   label: StatusLabel.Success as typeof StatusLabel.Success,
   epoch
 });

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -10,7 +10,10 @@ import {
   ProblemStatus,
   StatusLabel
 } from "../../interfaces/Status";
-import { statusToTableColor } from "../../utils/TableColor";
+import {
+  statusToTableColor,
+  statusLabelToTableColor
+} from "../../utils/TableColor";
 import ProblemLink from "../../components/ProblemLink";
 import ContestLink from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
@@ -21,6 +24,7 @@ interface Props {
   contestToProblems: Map<string, List<Problem>>;
   showSolved: boolean;
   showDifficulty: boolean;
+  enableColorfulMode: boolean;
   title: string;
   statusLabelMap: Map<ProblemId, ProblemStatus>;
   problemModels: Map<ProblemId, ProblemModel>;
@@ -99,10 +103,14 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
             _: string,
             { solvedAll, solvedAllIntime, solvedAllBeforeContest }: OneContest
           ) =>
-            solvedAllBeforeContest
-              ? "table-success-before-contest"
-              : solvedAllIntime
-              ? "table-success-intime"
+            props.enableColorfulMode
+              ? solvedAllBeforeContest
+                ? "table-success-before-contest"
+                : solvedAllIntime
+                ? "table-success-intime"
+                : solvedAll
+                ? "table-success"
+                : ""
               : solvedAll
               ? "table-success"
               : ""
@@ -124,7 +132,11 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
               const problem = problemStatus.get(i);
               return [
                 "table-problem",
-                problem ? statusToTableColor(problem.status, contest) : ""
+                !problem
+                  ? ""
+                  : props.enableColorfulMode
+                  ? statusToTableColor(problem.status, contest)
+                  : statusLabelToTableColor(problem.status.label)
               ]
                 .filter(nm => nm)
                 .join(" ");
@@ -152,6 +164,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
                     <SubmitTimespan
                       contest={contest}
                       problemStatus={problem.status}
+                      enableColorfulMode={props.enableColorfulMode}
                     />
                   </>
                 );

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -46,6 +46,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
         problemStatus.every(
           ({ status }) =>
             status.label === StatusLabel.Success &&
+            status.epoch !== void 0 &&
             status.epoch <= contest.start_epoch_second + contest.duration_second
         );
       const solvedAllBeforeContest =
@@ -53,6 +54,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = props => {
         problemStatus.every(
           ({ status }) =>
             status.label === StatusLabel.Success &&
+            status.epoch !== void 0 &&
             status.epoch < contest.start_epoch_second
         );
       return {

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -4,7 +4,10 @@ import Problem from "../../interfaces/Problem";
 import { Table, Row } from "reactstrap";
 import React from "react";
 import { ProblemId, ProblemStatus, StatusLabel } from "../../interfaces/Status";
-import { statusToTableColor } from "../../utils/TableColor";
+import {
+  statusToTableColor,
+  statusLabelToTableColor
+} from "../../utils/TableColor";
 import ProblemLink from "../../components/ProblemLink";
 import ContestLink from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
@@ -15,6 +18,7 @@ interface Props {
   contestToProblems: Map<string, List<Problem>>;
   showSolved: boolean;
   showDifficulty: boolean;
+  enableColorfulMode: boolean;
   problemModels: Map<ProblemId, ProblemModel>;
   statusLabelMap: Map<ProblemId, ProblemStatus>;
   title: string;
@@ -26,6 +30,7 @@ const ContestTable: React.FC<Props> = (props: Props) => {
     contestToProblems,
     showSolved,
     statusLabelMap,
+    enableColorfulMode,
     problemModels
   } = props;
   const mergedContests = contests
@@ -75,7 +80,9 @@ const ContestTable: React.FC<Props> = (props: Props) => {
                     <tr>
                       {problemInfo.map(({ problem, status, model }) => {
                         const color = status
-                          ? statusToTableColor(status, contest)
+                          ? enableColorfulMode
+                            ? statusToTableColor(status, contest)
+                            : statusLabelToTableColor(status.label)
                           : "";
                         return (
                           <td
@@ -101,6 +108,7 @@ const ContestTable: React.FC<Props> = (props: Props) => {
                             <SubmitTimespan
                               contest={contest}
                               problemStatus={status}
+                              enableColorfulMode={props.enableColorfulMode}
                             />
                           </td>
                         );

--- a/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
@@ -7,6 +7,8 @@ interface Props {
   toggleShowAccepted: () => void;
   showDifficulties: boolean;
   toggleShowDifficulties: () => void;
+  enableColorfulMode: boolean;
+  toggleEnableColorfulMode: () => void;
 }
 
 const Options: React.FC<Props> = props => {
@@ -33,6 +35,16 @@ const Options: React.FC<Props> = props => {
           <HelpBadgeTooltip id="difficulty">
             Internal rating to have 50% Solve Probability
           </HelpBadgeTooltip>
+        </Label>
+      </FormGroup>
+      <FormGroup check inline>
+        <Label check>
+          <Input
+            type="checkbox"
+            checked={props.enableColorfulMode}
+            onChange={props.toggleEnableColorfulMode}
+          />
+          Colorful Mode
         </Label>
       </FormGroup>
     </Row>

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -42,6 +42,7 @@ const TablePage: React.FC<InnerProps> = props => {
   const [activeTab, setActiveTab] = useState(TableTab.ABC);
   const [showAccepted, setShowAccepted] = useState(true);
   const [showDifficulty, setShowDifficulties] = useState(true);
+  const [enableColorfulMode, setEnableColorfulMode] = useState(true);
 
   const problemModels = problemModelsFetch.fulfilled
     ? problemModelsFetch.value
@@ -75,6 +76,10 @@ const TablePage: React.FC<InnerProps> = props => {
         toggleShowAccepted={() => setShowAccepted(!showAccepted)}
         showDifficulties={showDifficulty}
         toggleShowDifficulties={() => setShowDifficulties(!showDifficulty)}
+        enableColorfulMode={enableColorfulMode}
+        toggleEnableColorfulMode={() =>
+          setEnableColorfulMode(!enableColorfulMode)
+        }
       />
       <TableTabButtons active={activeTab} setActive={setActiveTab} />
       <ContestWrapper display={activeTab === TableTab.ABC}>
@@ -82,6 +87,7 @@ const TablePage: React.FC<InnerProps> = props => {
           problemModels={problemModels}
           showDifficulty={showDifficulty}
           showSolved={showAccepted}
+          enableColorfulMode={enableColorfulMode}
           contests={abc.valueSeq()}
           title="AtCoder Beginner Contest"
           contestToProblems={contestToProblems}
@@ -93,6 +99,7 @@ const TablePage: React.FC<InnerProps> = props => {
           problemModels={problemModels}
           showDifficulty={showDifficulty}
           showSolved={showAccepted}
+          enableColorfulMode={enableColorfulMode}
           contests={arc.valueSeq()}
           title="AtCoder Regular Contest"
           contestToProblems={contestToProblems}
@@ -104,6 +111,7 @@ const TablePage: React.FC<InnerProps> = props => {
           problemModels={problemModels}
           showDifficulty={showDifficulty}
           showSolved={showAccepted}
+          enableColorfulMode={enableColorfulMode}
           contests={agc.valueSeq()}
           title="AtCoder Grand Contest"
           contestToProblems={contestToProblems}
@@ -118,6 +126,7 @@ const TablePage: React.FC<InnerProps> = props => {
           title="Other Rated Contests"
           contestToProblems={contestToProblems}
           showSolved={showAccepted}
+          enableColorfulMode={enableColorfulMode}
           statusLabelMap={statusLabelMap}
         />
       </ContestWrapper>
@@ -129,6 +138,7 @@ const TablePage: React.FC<InnerProps> = props => {
           title="Other Contests"
           contestToProblems={contestToProblems}
           showSolved={showAccepted}
+          enableColorfulMode={enableColorfulMode}
           statusLabelMap={statusLabelMap}
         />
       </ContestWrapper>

--- a/atcoder-problems-frontend/src/utils/CachedApiClient.ts
+++ b/atcoder-problems-frontend/src/utils/CachedApiClient.ts
@@ -212,9 +212,9 @@ export const cachedStatusLabelMap = (userId: string, rivals: List<string>) => {
         const rivalsList = list
           .filter(s => rivals.contains(s.user_id))
           .filter(s => isAccepted(s.result));
-        const col = userList.find(s => isAccepted(s.result));
-        if (col) {
-          return successStatus(col.epoch_second);
+        const accepted = userList.filter(s => isAccepted(s.result));
+        if (!accepted.isEmpty()) {
+          return successStatus(accepted.map(s => s.epoch_second).min());
         } else if (!rivalsList.isEmpty()) {
           return failedStatus(
             rivalsList

--- a/atcoder-problems-frontend/src/utils/TableColor.ts
+++ b/atcoder-problems-frontend/src/utils/TableColor.ts
@@ -11,6 +11,7 @@ export const statusToTableColor = (
 
   if (
     status.label === StatusLabel.Success &&
+    status.epoch !== void 0 &&
     status.epoch <= contest.start_epoch_second + contest.duration_second
   ) {
     return status.epoch < contest.start_epoch_second

--- a/atcoder-problems-frontend/src/utils/TableColor.ts
+++ b/atcoder-problems-frontend/src/utils/TableColor.ts
@@ -27,7 +27,7 @@ export const statusToTableColor = (
   }
 };
 
-const statusLabelToTableColor = (label: StatusLabel) => {
+export const statusLabelToTableColor = (label: StatusLabel) => {
   switch (label) {
     case StatusLabel.Success:
       return "table-success";


### PR DESCRIPTION
Improve colorful mode feature:

- Add checkbox to toggle colorful mode on TablePage
- Color problems with ACs during contests always deep green, even if there exists ACs after contests
- Hide submission time of problems with WAs during contests and no ACs until now