### PR TITLE
Cache some API results into localStorage

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -53,7 +53,7 @@ const TablePage: React.FC<InnerProps> = props => {
 
   const problemModels = problemModelsFetch.fulfilled
     ? problemModelsFetch.value
-    : Map<ProblemId, ProblemModel>();
+    : CachedApiClient.oldProblemModels();
   const contestToProblems = contestToProblemsFetch.fulfilled
     ? contestToProblemsFetch.value
     : Map<ContestId, List<Problem>>();
@@ -62,7 +62,7 @@ const TablePage: React.FC<InnerProps> = props => {
     : Map<ContestId, Contest>();
   const statusLabelMap = statusLabelMapFetch.fulfilled
     ? statusLabelMapFetch.value
-    : Map<ProblemId, ProblemStatus>();
+    : CachedApiClient.oldStatusLabelMap();
   const abc = contests.filter((v, k) => k.match(/^abc\d{3}$/));
   const arc = contests.filter((v, k) => k.match(/^arc\d{3}$/));
   const agc = contests.filter((v, k) => k.match(/^agc\d{3}$/));

--- a/atcoder-problems-frontend/src/utils/CachedApiClient.ts
+++ b/atcoder-problems-frontend/src/utils/CachedApiClient.ts
@@ -57,8 +57,14 @@ let CACHED_PROBLEM_MODELS: undefined | Promise<Map<ProblemId, ProblemModel>>;
 export const cachedProblemModels = () => {
   if (CACHED_PROBLEM_MODELS === undefined) {
     CACHED_PROBLEM_MODELS = fetchProblemModels();
+    CACHED_PROBLEM_MODELS.then(value =>
+      localStorage.setItem("problemModels", JSON.stringify(Array.from(value.entries())))
+    );
   }
   return CACHED_PROBLEM_MODELS;
+};
+export const oldProblemModels = () => {
+  return Map<ProblemId, ProblemModel>(JSON.parse(localStorage.getItem("problemModels") || "{}") as Array<[ProblemId, ProblemModel]>);
 };
 
 let CACHED_CONTESTS: undefined | Promise<Map<ContestId, Contest>>;
@@ -231,8 +237,14 @@ export const cachedStatusLabelMap = (userId: string, rivals: List<string>) => {
         }
       })
     );
+    STATUS_LABEL_MAP.statusLabelMap.then(value =>
+      localStorage.setItem("statusLabelMap", JSON.stringify(Array.from(value.entries())))
+    );
   }
   return STATUS_LABEL_MAP.statusLabelMap;
+};
+export const oldStatusLabelMap = () => {
+  return Map<ProblemId, ProblemStatus>(JSON.parse(localStorage.getItem("statusLabelMap") || "{}") as Array<[string, ProblemStatus]>);
 };
 
 let SUM_RANKING: undefined | Promise<List<RankingEntry>>;


### PR DESCRIPTION
ページを開き直すたびに毎回 API を叩いているためサーバが結果を返すまでページが表示されず遅いという問題があります。これを解決するため、ページを開いた直後から API の結果が帰ってくるまでの間は localStorage にためておいた前回の API リクエストの結果を使うようにします。

- 必要最低限の種類の API に対して簡易な形で実装しています。react 側に手を入れるのが最適なはずですが、react-refetch のまわりがよく分からなかったためです。
- すべてクライアント側の処理なのでサーバへの負荷は変化しません。
- 副次効果としてサーバが落ちててもしばらくの間は表示ができるようになるはずです。