### PR TITLE
Add custom pagination panel component

### DIFF
--- a/atcoder-problems-frontend/src/components/ListPaginationPanel.tsx
+++ b/atcoder-problems-frontend/src/components/ListPaginationPanel.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { PaginationPanelProps } from "react-bootstrap-table";
+import {
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  UncontrolledDropdown
+} from "reactstrap";
+import { NavLink } from "react-router-dom";
+
+interface Props {
+  paginationPanelProps: PaginationPanelProps;
+  dataSize: number;
+}
+
+const pageList = (
+  currPage: number,
+  pageStartIndex: number,
+  sizePerPage: number,
+  dataSize: number
+) => {
+  if (dataSize === 0) {
+    return [];
+  }
+
+  const pageNumbers: number[] = [currPage];
+  let tmpExp = 1;
+  while (true) {
+    tmpExp *= 2;
+    const tmpPageNumber = currPage - tmpExp + 1;
+    if (tmpPageNumber < pageStartIndex) {
+      break;
+    }
+    pageNumbers.unshift(tmpPageNumber);
+  }
+  if (pageNumbers[0] !== pageStartIndex) {
+    pageNumbers.unshift(pageStartIndex);
+  }
+
+  tmpExp = 1;
+  const maxPage = Math.ceil(dataSize / sizePerPage);
+  while (true) {
+    tmpExp *= 2;
+    const tmpPageNumber = currPage + tmpExp - 1;
+    if (tmpPageNumber > maxPage) {
+      break;
+    }
+    pageNumbers.push(tmpPageNumber);
+  }
+  if (pageNumbers.slice(-1)[0] !== maxPage) {
+    pageNumbers.push(maxPage);
+  }
+
+  return pageNumbers;
+};
+
+export const ListPaginationPanel: React.FC<Props> = props => {
+  const { paginationPanelProps, dataSize } = props;
+
+  const pageNumbers = pageList(
+    paginationPanelProps.currPage,
+    paginationPanelProps.pageStartIndex,
+    paginationPanelProps.sizePerPage,
+    dataSize
+  );
+
+  return (
+    <>
+      <div className="col-md-2 col-xs-2 col-sm-2 col-lg-2">
+        <UncontrolledDropdown className="react-bs-table-sizePerPage-dropdown">
+          <DropdownToggle caret>
+            {paginationPanelProps.sizePerPage}
+          </DropdownToggle>
+          <DropdownMenu>
+            {(paginationPanelProps.sizePerPageList as Array<{
+              text: string;
+              value: number;
+            }>).map(p => (
+              <DropdownItem
+                key={p.text}
+                onClick={() => paginationPanelProps.changeSizePerPage(p.value)}
+              >
+                {p.text}
+              </DropdownItem>
+            ))}
+          </DropdownMenu>
+        </UncontrolledDropdown>
+      </div>
+      <div
+        className="col-md-10 col-xs-10 col-sm-10 col-lg-10"
+        style={{ display: "block" }}
+      >
+        <ul
+          className="react-bootstrap-table-page-btns-ul pagination"
+          style={{ flexWrap: "wrap", justifyContent: "flex-end" }}
+        >
+          {pageNumbers.map((pageNumber: number) => {
+            const className =
+              (pageNumber === paginationPanelProps.currPage ? "active " : "") +
+              "page-item";
+            return (
+              <li
+                className={className}
+                key={pageNumber}
+                title={pageNumber.toString()}
+              >
+                <NavLink
+                  to="#"
+                  className="page-link"
+                  onClick={() => paginationPanelProps.changePage(pageNumber)}
+                >
+                  {pageNumber}
+                </NavLink>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </>
+  );
+};

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -1,4 +1,8 @@
-import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
+import {
+  BootstrapTable,
+  TableHeaderColumn,
+  PaginationPanelProps
+} from "react-bootstrap-table";
 import { StatusLabel } from "../../interfaces/Status";
 import { Badge } from "reactstrap";
 import React, { ReactElement } from "react";
@@ -16,6 +20,7 @@ import ProblemModel, {
   isProblemModelWithTimeModel
 } from "../../interfaces/ProblemModel";
 import { statusToTableColor } from "../../utils/TableColor";
+import { ListPaginationPanel } from "../../components/ListPaginationPanel";
 
 interface Props {
   fromPoint: number;
@@ -381,7 +386,15 @@ export const ListTable = (props: Props) => {
             text: "All",
             value: props.rowData.size
           }
-        ]
+        ],
+        paginationPanel: (paginationPanelProps: PaginationPanelProps) => {
+          return (
+            <ListPaginationPanel
+              paginationPanelProps={paginationPanelProps}
+              dataSize={props.rowData.size}
+            />
+          );
+        }
       }}
     >
       {columns.map(c => (

--- a/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
+import {
+  BootstrapTable,
+  TableHeaderColumn,
+  PaginationPanelProps
+} from "react-bootstrap-table";
 
 import Submission from "../../interfaces/Submission";
 import { formatMomentDate, parseSecond } from "../../utils/DateUtil";
@@ -10,6 +14,7 @@ import ProblemLink from "../../components/ProblemLink";
 import { Map } from "immutable";
 import { ProblemId } from "../../interfaces/Status";
 import ProblemModel from "../../interfaces/ProblemModel";
+import { ListPaginationPanel } from "../../components/ListPaginationPanel";
 
 interface Props {
   submissions: Submission[];
@@ -65,7 +70,15 @@ const SubmissionList = (props: Props) => {
             text: "All",
             value: submissions.length
           }
-        ]
+        ],
+        paginationPanel: (paginationPanelProps: PaginationPanelProps) => {
+          return (
+            <ListPaginationPanel
+              paginationPanelProps={paginationPanelProps}
+              dataSize={submissions.length}
+            />
+          );
+        }
       }}
     >
       <TableHeaderColumn


### PR DESCRIPTION
Replace default pagination panel with custom pagination panel, which enables us to go to any page in O(log N) operations, where N is list data length.

This change affects following components:
- Problem list
- Submisstion list