### PR TITLE
Fix #432

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import {
   BootstrapTable,
   TableHeaderColumn,
+  FilterData,
   PaginationPanelProps
 } from "react-bootstrap-table";
 
@@ -82,6 +83,12 @@ const SubmissionList = (props: Props) => {
           );
         },
         afterSearch: (search: string, result: ReadonlyArray<any>) => {
+          setDataSize(result.length);
+        },
+        afterColumnFilter: (
+          filterConds: ReadonlyArray<FilterData>,
+          result: ReadonlyArray<any>
+        ) => {
           setDataSize(result.length);
         }
       }}

--- a/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/SubmissionList.tsx
@@ -25,6 +25,7 @@ interface Props {
 
 const SubmissionList = (props: Props) => {
   const [dataSize, setDataSize] = useState(0);
+  let dataSizeTmp: number = dataSize;
   const { submissions, problems, problemModels } = props;
   const titleMap = problems.reduce(
     (map, p) => map.set(p.id, p.title),
@@ -89,7 +90,14 @@ const SubmissionList = (props: Props) => {
           filterConds: ReadonlyArray<FilterData>,
           result: ReadonlyArray<any>
         ) => {
-          setDataSize(result.length);
+          if (dataSize !== result.length) {
+            dataSizeTmp = result.length;
+          }
+        },
+        afterTableComplete: () => {
+          if (dataSizeTmp !== dataSize) {
+            setDataSize(dataSizeTmp);
+          }
         }
       }}
     >


### PR DESCRIPTION
`afterColumnFilter()` のタイミングで `setDataSize()` すると react-bootstrap-table に行データとして undefined が渡されてしまい，ページが真っ白になります．
`afterTableComplete()` のタイミングまで `setDataSize()` するのを待てば不具合は現出しないため，state 管理しない中間変数 `dataSizeTmp` を介することで，表向き正常な動作を実現しています．

正常に動作はするものの，あまりよい設計ではないので，他に適切な設計があればそれに全面的に従いたいと思います．