### PR TITLE
Use query string & router for UserPage tabs

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert, Nav, NavItem, NavLink, Row, Spinner } from "reactstrap";
+import { NavLink as RouterLink, useLocation } from "react-router-dom";
 
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
@@ -20,7 +21,6 @@ import { convertMap } from "../../utils/ImmutableMigration";
 import { PieChartBlock } from "./PieChartBlock";
 import { AchievementBlock } from "./AchievementBlock";
 import { ProgressChartBlock } from "./ProgressChartBlock";
-import { useLocalStorage } from "../../utils/LocalStorage";
 
 const userPageTabs = [
   "Achievement",
@@ -30,6 +30,8 @@ const userPageTabs = [
   "Recommendation",
   "Languages"
 ];
+
+const TAB_PARAM = "userPageTab";
 
 type UserPageTab = typeof userPageTabs[number];
 
@@ -47,10 +49,9 @@ interface InnerProps extends OuterProps {
 }
 
 const InnerUserPage = (props: InnerProps) => {
-  const [userPageTab, setUserPageTab] = useLocalStorage<UserPageTab>(
-    "UserPageTab",
-    "Achievement"
-  );
+  const location = useLocation();
+  const userPageTab: UserPageTab =
+    new URLSearchParams(location.search).get(TAB_PARAM) || "Achievement";
 
   const {
     userId,
@@ -119,16 +120,22 @@ const InnerUserPage = (props: InnerProps) => {
         <h1>{userId}</h1>
       </Row>
       <Nav tabs>
-        {userPageTabs.map((tab, i) => (
-          <NavItem key={i}>
-            <NavLink
-              active={userPageTab === tab}
-              onClick={() => setUserPageTab(tab)}
-            >
-              {tab}
-            </NavLink>
-          </NavItem>
-        ))}
+        {userPageTabs.map(tab => {
+          const params = new URLSearchParams();
+          params.set(TAB_PARAM, tab);
+
+          return (
+            <NavItem key={tab}>
+              <NavLink
+                tag={RouterLink}
+                isActive={() => tab === userPageTab}
+                to={`${location.pathname}?${params.toString()}`}
+              >
+                {tab}
+              </NavLink>
+            </NavItem>
+          );
+        })}
       </Nav>
       {userPageTab === "Achievement" ? (
         <AchievementBlock userId={userId} dailyCount={dailyCount.toArray()} />


### PR DESCRIPTION
この変更ではUserPageにおいて、選択されているタブを保持するために、URLのquery stringを使います。

ローカルストレージの代わりにquery stringを使う利点は、

* URLをコピー&ペーストして別のブラウザで開いても、目的のタブが選択された状態になる。
* 複数のブラウザタブで、UserPageを開いているとき、どれか一つのブラウザタブで、UserPageのタブの選択を変更したとき、ほかのブラウザタブに影響を与えない。具体的には、
    1. UserPageのAchievementタブを開いたブラウザタブを二つ開く（それぞれ、タブ１、タブ２と呼ぶ）
    1. タブ１で、開いているUserPageでLanguageタブを選択する。
    1. タブ２を更新する。
という動作をしたとき、タブ２ではAchievementタブが選択されたままになる。（ローカルストレージを使った方法では、タブ２でもLanguageタブが選択されてしまう。）

があります。

せっかくreact-routerを使っているので、`<Switch>`を使えないかと試してみましたが、おそらくreact-routerが使っているライブラリ（[path-to-regexp](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0)）のバージョンが古いせいで、query stringに対してマッチができないようです。

本当は、query stringではなく、パスを使いたいんですが、すでにライバルユーザー名用に使われているので諦めました。