### PR TITLE
Listページのフィルタ選択状況をURLに保持する

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -21,6 +21,7 @@ import { convertMap } from "../../utils/ImmutableMigration";
 import { PieChartBlock } from "./PieChartBlock";
 import { AchievementBlock } from "./AchievementBlock";
 import { ProgressChartBlock } from "./ProgressChartBlock";
+import { generatePathWithParams } from "../../utils/QueryString";
 
 const userPageTabs = [
   "Achievement",
@@ -120,22 +121,17 @@ const InnerUserPage = (props: InnerProps) => {
         <h1>{userId}</h1>
       </Row>
       <Nav tabs>
-        {userPageTabs.map(tab => {
-          const params = new URLSearchParams();
-          params.set(TAB_PARAM, tab);
-
-          return (
-            <NavItem key={tab}>
-              <NavLink
-                tag={RouterLink}
-                isActive={() => tab === userPageTab}
-                to={`${location.pathname}?${params.toString()}`}
-              >
-                {tab}
-              </NavLink>
-            </NavItem>
-          );
-        })}
+        {userPageTabs.map(tab => (
+          <NavItem key={tab}>
+            <NavLink
+              tag={RouterLink}
+              isActive={() => tab === userPageTab}
+              to={generatePathWithParams(location, { [TAB_PARAM]: tab })}
+            >
+              {tab}
+            </NavLink>
+          </NavItem>
+        ))}
       </Nav>
       {userPageTab === "Achievement" ? (
         <AchievementBlock userId={userId} dailyCount={dailyCount.toArray()} />

--- a/atcoder-problems-frontend/src/utils/QueryString.ts
+++ b/atcoder-problems-frontend/src/utils/QueryString.ts
@@ -1,0 +1,11 @@
+import { Location } from "history";
+
+export const generatePathWithParams = (
+  location: Location,
+  params: Record<string, string>
+): string => {
+  const searchParams = new URLSearchParams(location.search);
+  Object.keys(params).forEach(key => searchParams.set(key, params[key]));
+
+  return `${location.pathname}?${searchParams.toString()}`;
+};


### PR DESCRIPTION
Listページにおいて、フィルタの選択状況をURLのquery stringに追加するようにします。

この変更によって、以下のことが実現されます。

* ユーザーがフィルターを選択した状態でページを更新しても、選択したフィルターの状態が保存される（現在の実装では、Reactのステートに保持されているため、ページをリロードするとすべて解除される）
* ユーザーが、フィルターの選択情報を保持したまま、ほかのユーザーにListページを共有できる

Listページにある次の機能については、同様の機能を追加していません。理由は需要があるかよくわからないからです。

* "Difficulty Status"セクションの"Including/Excluding"ボタン
* "Problem List"セクションの
    * Searchテキストボックス
    * 1ページ当たりの問題の表示件数
    * 現在表示しているページ番号