### PR TITLE
fix: #463

### DIFF
--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -13,6 +13,10 @@ code {
     monospace;
 }
 
+.tooltip {
+  pointer-events: none;
+}
+
 .nav-tabs .nav-link {
   cursor: pointer;
 }


### PR DESCRIPTION
https://github.com/reactstrap/reactstrap/issues/1728

こちらの事象に近しい気がしたので、記載されているワークアラウンドをcssに記載したところ
正しくtooltipが出るようになったので、プルリクを上げておきます。

あんまり、ちゃんとテストしていないので、なにか気になる点あればテストしますし
Declineしていただいても構いません。