### PR TITLE
fix(frontend): set the max height of dropdowns

### DIFF
--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -12,6 +12,11 @@ code {
     monospace;
 }
 
+.dropdown-menu {
+  max-height: 256px;
+  overflow-y: auto;
+}
+
 .tooltip {
   pointer-events: none;
 }


### PR DESCRIPTION
close #423 

ドロップダウンの高さの上限値を決め打ちしています。

#### Before

![image](https://user-images.githubusercontent.com/9990535/82118180-60a9cb00-97b0-11ea-90c7-c44722feb7b9.png)

#### After

![image](https://user-images.githubusercontent.com/9990535/82118174-58ea2680-97b0-11ea-8830-c8a49168c550.png)
