### PR TITLE
feat(frontend): add tooltips explaining timezone for streak calculation

### DIFF
--- a/atcoder-problems-frontend/.prettierrc.json
+++ b/atcoder-problems-frontend/.prettierrc.json
@@ -1,5 +1,5 @@
 {
   "arrowParens": "always",
   "trailingComma": "es5",
-  "endOfLine":"auto"
+  "endOfLine": "auto"
 }

--- a/atcoder-problems-frontend/src/components/Ranking.tsx
+++ b/atcoder-problems-frontend/src/components/Ranking.tsx
@@ -4,7 +4,7 @@ import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
 import { RankingEntry } from "../interfaces/RankingEntry";
 
 interface Props {
-  title: string;
+  title: React.ReactNode;
   ranking: RankingEntry[];
 }
 

--- a/atcoder-problems-frontend/src/pages/StreakRanking.tsx
+++ b/atcoder-problems-frontend/src/pages/StreakRanking.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Ranking from "../components/Ranking";
 import { RankingEntry } from "../interfaces/RankingEntry";
 import { connect, PromiseState } from "react-refetch";
-import { UncontrolledTooltip } from "reactstrap";
+import { Badge, UncontrolledTooltip } from "reactstrap";
 import * as CachedApiClient from "../utils/CachedApiClient";
 
 interface Props {
@@ -13,7 +13,10 @@ const StreakRanking: React.FC<Props> = (props) => (
   <Ranking
     title={
       <>
-        Streak Ranking <span id="streakRankingTooltip">(?)</span>
+        Streak Ranking{" "}
+        <Badge pill id="streakRankingTooltip">
+          ?
+        </Badge>
         <UncontrolledTooltip target="streakRankingTooltip" placement="right">
           The streak ranking is based on <strong>Japan Standard Time</strong>{" "}
           (JST, UTC+9).

--- a/atcoder-problems-frontend/src/pages/StreakRanking.tsx
+++ b/atcoder-problems-frontend/src/pages/StreakRanking.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Ranking from "../components/Ranking";
 import { RankingEntry } from "../interfaces/RankingEntry";
 import { connect, PromiseState } from "react-refetch";
+import { UncontrolledTooltip } from "reactstrap";
 import * as CachedApiClient from "../utils/CachedApiClient";
 
 interface Props {
@@ -10,7 +11,15 @@ interface Props {
 
 const StreakRanking: React.FC<Props> = (props) => (
   <Ranking
-    title="Streak Ranking"
+    title={
+      <>
+        Streak Ranking <span id="streakRankingTooltip">(?)</span>
+        <UncontrolledTooltip target="streakRankingTooltip" placement="right">
+          The streak ranking is based on <strong>Japan Standard Time</strong>{" "}
+          (JST, UTC+9).
+        </UncontrolledTooltip>
+      </>
+    }
     ranking={props.rankingFetch.fulfilled ? props.rankingFetch.value : []}
   />
 );

--- a/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Col, Row, UncontrolledTooltip } from "reactstrap";
+import { Badge, Col, Row, UncontrolledTooltip } from "reactstrap";
 import { ordinalSuffixOf } from "../../../utils";
 import { formatMomentDate, getToday } from "../../../utils/DateUtil";
 import { connect, PromiseState } from "react-refetch";
@@ -91,15 +91,13 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
       value: props.ratedPointSum,
       rank: props.sumRank.fulfilled ? props.sumRank.value : undefined,
     },
-    {
-      key: "Longest Streak",
-      value: `${longestStreak} days`,
-      rank: props.streakRank.fulfilled ? props.streakRank.value : undefined,
-    },
   ];
 
   const yesterdayLabel = formatMomentDate(getToday().add(-1, "day"));
   const isIncreasing = prevDateLabel >= yesterdayLabel;
+  const longestStreakRank = props.streakRank.fulfilled
+    ? props.streakRank.value
+    : undefined;
   return (
     <>
       <Row className="my-2 border-bottom">
@@ -108,22 +106,7 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
       <Row className="my-3">
         {achievements.map(({ key, value, rank }) => (
           <Col key={key} className="text-center" xs="6" md="3">
-            <h6>
-              {key}
-              {key === "Longest Streak" && (
-                <>
-                  {" "}
-                  <span id="longestStreakTooltip">(?)</span>
-                  <UncontrolledTooltip
-                    target="longestStreakTooltip"
-                    placement="right"
-                  >
-                    The longest streak is based on{" "}
-                    <strong>Japan Standard Time</strong> (JST, UTC+9).
-                  </UncontrolledTooltip>
-                </>
-              )}
-            </h6>
+            <h6>{key}</h6>
             <h3>{value}</h3>
             <h6 className="text-muted">
               {rank !== undefined
@@ -132,9 +115,35 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
             </h6>
           </Col>
         ))}
+        <Col key="Longest Streak" className="text-center" xs="6" md="3">
+          <h6>
+            Longest Streak{" "}
+            <Badge pill id="longestStreakTooltip">
+              ?
+            </Badge>
+            <UncontrolledTooltip
+              target="longestStreakTooltip"
+              placement="right"
+            >
+              The longest streak is based on{" "}
+              <strong>Japan Standard Time</strong> (JST, UTC+9).
+            </UncontrolledTooltip>
+          </h6>
+          <h3>{longestStreak} days</h3>
+          <h6 className="text-muted">
+            {longestStreakRank !== undefined
+              ? `${longestStreakRank + 1}${ordinalSuffixOf(
+                  longestStreakRank + 1
+                )}`
+              : ""}
+          </h6>
+        </Col>
         <Col key="Current Streak" className="text-center" xs="6" md="3">
           <h6>
-            Current Streak <span id="currentStreakTooltip">(?)</span>
+            Current Streak{" "}
+            <Badge pill id="currentStreakTooltip">
+              ?
+            </Badge>
             <UncontrolledTooltip
               target="currentStreakTooltip"
               placement="right"

--- a/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Col, Row } from "reactstrap";
+import { Col, Row, UncontrolledTooltip } from "reactstrap";
 import { ordinalSuffixOf } from "../../../utils";
 import { formatMomentDate, getToday } from "../../../utils/DateUtil";
 import { connect, PromiseState } from "react-refetch";
@@ -108,7 +108,22 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
       <Row className="my-3">
         {achievements.map(({ key, value, rank }) => (
           <Col key={key} className="text-center" xs="6" md="3">
-            <h6>{key}</h6>
+            <h6>
+              {key}
+              {key === "Longest Streak" && (
+                <>
+                  {" "}
+                  <span id="longestStreakTooltip">(?)</span>
+                  <UncontrolledTooltip
+                    target="longestStreakTooltip"
+                    placement="right"
+                  >
+                    The longest streak is based on{" "}
+                    <strong>Japan Standard Time</strong> (JST, UTC+9).
+                  </UncontrolledTooltip>
+                </>
+              )}
+            </h6>
             <h3>{value}</h3>
             <h6 className="text-muted">
               {rank !== undefined
@@ -118,7 +133,15 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
           </Col>
         ))}
         <Col key="Current Streak" className="text-center" xs="6" md="3">
-          <h6>Current Streak</h6>
+          <h6>
+            Current Streak <span id="currentStreakTooltip">(?)</span>
+            <UncontrolledTooltip
+              target="currentStreakTooltip"
+              placement="right"
+            >
+              The current streak is based on <strong>Local Time</strong>.
+            </UncontrolledTooltip>
+          </h6>
           <h3>{isIncreasing ? currentStreak : 0} days</h3>
           <h6 className="text-muted">{`Last AC: ${prevDateLabel}`}</h6>
         </Col>


### PR DESCRIPTION
Resolves #410.

ここは `(?)` より `fa-question-circle` を使いたいですが現在のプロジェクトには `font-awesome` がないため使うべきかを聞きたいです。

![image](https://user-images.githubusercontent.com/6523469/82206977-b8c10880-993b-11ea-8cda-3ae725839c63.png)
![image](https://user-images.githubusercontent.com/6523469/82207012-c4143400-993b-11ea-9fb8-fcc523bc2459.png)
