### PR TITLE
fixed performance estimation

### DIFF
--- a/atcoder-problems-frontend/src/interfaces/ProblemModel.ts
+++ b/atcoder-problems-frontend/src/interfaces/ProblemModel.ts
@@ -42,6 +42,7 @@ export const isProblemModelWithDifficultyModel = (
 export interface ProblemModelWithTimeModel {
   readonly slope: number;
   readonly intercept: number;
+  readonly variance: number;
   readonly difficulty: number | undefined;
   readonly rawDifficulty: number | undefined;
   readonly discrimination: number | undefined;
@@ -53,6 +54,7 @@ export const isProblemModelWithTimeModel = (
 ): obj is ProblemModelWithTimeModel =>
   typeof obj.slope === "number" &&
   typeof obj.intercept === "number" &&
+  typeof obj.variance === "number" &&
   (typeof obj.difficulty === "number" ||
     typeof obj.difficulty === "undefined") &&
   (typeof obj.rawDifficulty === "number" ||


### PR DESCRIPTION
#571

ブートストラップサンプルを生成するときに、問題が難しくて解けないときは単純に問題を飛ばすことにしました。また、所要時間を計算するときに乱数を取るのを忘れていたので、ちゃんとやるようにしました。

Before
![image](https://user-images.githubusercontent.com/967121/82227907-5e3ba280-9963-11ea-8878-9ad3b3111eac.png)

After
![image](https://user-images.githubusercontent.com/967121/82227923-64318380-9963-11ea-90e0-84b3c25eaaef.png)
