### PR TITLE
Add tooltip to describe unavailability of difficulty on Table page

### DIFF
--- a/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
+++ b/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Tooltip } from "reactstrap";
+import { Badge, Tooltip } from "reactstrap";
 import { getRatingColor, getRatingColorCode } from "../utils";
 
 interface Props {
@@ -38,10 +38,32 @@ export class DifficultyCircle extends React.Component<Props, LocalState> {
 
   render(): React.ReactNode {
     const { id, difficulty } = this.props;
-    if (difficulty === null) {
-      return null;
-    }
     const { tooltipOpen } = this.state;
+    const toggleTooltipState = (): void =>
+      this.setState({ tooltipOpen: !tooltipOpen });
+    const circleId = "DifficultyCircle-" + id;
+    if (difficulty === null) {
+      return (
+        <span>
+          <Badge
+            className="difficulty-unavailable-circle"
+            color="info"
+            id={circleId}
+            pill
+          >
+            ?
+          </Badge>
+          <Tooltip
+            placement="top"
+            target={circleId}
+            isOpen={tooltipOpen}
+            toggle={toggleTooltipState}
+          >
+            Difficulty is unavailable.
+          </Tooltip>
+        </span>
+      );
+    }
     const fillRatio: number =
       difficulty >= 3200 ? 1.0 : (difficulty % 400) / 400;
     const color: string = getColor(difficulty);
@@ -62,7 +84,6 @@ export class DifficultyCircle extends React.Component<Props, LocalState> {
           : `linear-gradient(to right, ${color}, white, ${color})`,
     });
     const title = `Difficulty: ${difficulty}`;
-    const circleId = "DifficultyCircle-" + id;
     return (
       <>
         <span
@@ -74,7 +95,7 @@ export class DifficultyCircle extends React.Component<Props, LocalState> {
           placement="top"
           target={circleId}
           isOpen={tooltipOpen}
-          toggle={(): void => this.setState({ tooltipOpen: !tooltipOpen })}
+          toggle={toggleTooltipState}
         >
           {title}
         </Tooltip>

--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -13,6 +13,7 @@ interface Props {
   difficulty?: number | null;
   showDifficulty?: boolean;
   isExperimentalDifficulty?: boolean;
+  showDifficultyUnavailable?: boolean;
 }
 
 const ProblemLink: React.FC<Props> = (props) => {
@@ -25,6 +26,7 @@ const ProblemLink: React.FC<Props> = (props) => {
     difficulty,
     showDifficulty,
     isExperimentalDifficulty,
+    showDifficultyUnavailable,
   } = props;
   const link = (
     <NewTabLink
@@ -34,12 +36,18 @@ const ProblemLink: React.FC<Props> = (props) => {
       {problemTitle}
     </NewTabLink>
   );
-  if (!showDifficulty || difficulty === null || difficulty === undefined) {
+  if (
+    !showDifficulty ||
+    difficulty === undefined ||
+    (difficulty === null && !showDifficultyUnavailable)
+  ) {
     return link;
   }
 
   const uniqueId = problemId + "-" + contestId;
   const experimentalIconId = "experimental-" + uniqueId;
+  const ratingColorClass =
+    difficulty === null ? undefined : getRatingColorClass(difficulty);
   return (
     <>
       <DifficultyCircle id={uniqueId} difficulty={difficulty} />
@@ -62,7 +70,7 @@ const ProblemLink: React.FC<Props> = (props) => {
         href={Url.formatProblemUrl(problemId, contestId)}
         target="_blank" // eslint-disable-line react/jsx-no-target-blank
         rel="noopener"
-        className={getRatingColorClass(difficulty)}
+        className={ratingColorClass}
       >
         {problemTitle}
       </a>

--- a/atcoder-problems-frontend/src/index.css
+++ b/atcoder-problems-frontend/src/index.css
@@ -33,6 +33,11 @@ code {
   }
 }
 
+.difficulty-unavailable-circle.badge {
+  margin-right: 5px;
+  font-size: 5px;
+}
+
 span.difficulty-circle {
   display: inline-block;
   border-radius: 50%;

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -146,6 +146,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
                       isExperimentalDifficulty={
                         !!model && model.is_experimental
                       }
+                      showDifficultyUnavailable
                       showDifficulty={props.showDifficulty}
                       contestId={contest.id}
                       problemId={problem.problem.id}

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -1,5 +1,5 @@
 import { List, Map as ImmutableMap, Set } from "immutable";
-import { Table, Row } from "reactstrap";
+import { Row, Table } from "reactstrap";
 import React from "react";
 import Contest from "../../interfaces/Contest";
 import Problem from "../../interfaces/Problem";
@@ -9,6 +9,7 @@ import ProblemLink from "../../components/ProblemLink";
 import ContestLink from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
 import SubmitTimespan from "../../components/SubmitTimespan";
+import { isRatedContest } from "./ContestClassifier";
 
 interface Props {
   contests: Contest[];
@@ -101,6 +102,7 @@ export const ContestTable: React.FC<Props> = (props) => {
                             isExperimentalDifficulty={
                               model ? model.is_experimental : false
                             }
+                            showDifficultyUnavailable={isRatedContest(contest)}
                             showDifficulty={props.showDifficulty}
                             problemId={problem.id}
                             problemTitle={problem.title}


### PR DESCRIPTION
Tableページにおいて、問題にdifficultyが存在しないときに、その旨を伝えるためのtooltipを表示します。 #350 

<img width="356" alt="acp-350" src="https://user-images.githubusercontent.com/9583566/82553677-77c92e00-9b9f-11ea-97ef-7f039d99bf46.PNG">

ただ、ABC/ARC/AGC以外のUnratedのコンテストの問題すべてに表示されても鬱陶しいと思ったので、Ratedのコンテストの存在するタブだけで表示しています。ListページやSubmissionページで表示していないのも同様の理由からです。