### PR TITLE
fix(frontend): change colors in dark theme

### DIFF
--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -28,86 +28,94 @@ import SingleProblemList from "./pages/Internal/ProblemList/SingleProblemList";
 import { RecentSubmissions } from "./pages/RecentSubmissions";
 import { TrainingPage } from "./pages/TrainingPage";
 import { ACCOUNT_INFO } from "./utils/RouterPath";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <div>
-        <div className="sticky-top">
-          <NavigationBar />
+    <ThemeProvider>
+      <Router>
+        <div>
+          <div className="sticky-top">
+            <NavigationBar />
+          </div>
+
+          <Container
+            className="my-5"
+            style={{ width: "100%", maxWidth: "90%" }}
+          >
+            <Switch>
+              <Route exact path="/ac" component={ACRanking} />
+              <Route exact path="/fast" component={FastestRanking} />
+              <Route exact path="/short" component={ShortRanking} />
+              <Route exact path="/first" component={FirstRanking} />
+              <Route exact path="/sum" component={SumRanking} />
+              <Route exact path="/streak" component={StreakRanking} />
+              <Route exact path="/lang" component={LanguageOwners} />
+              <Route
+                path="/user/:userIds([a-zA-Z0-9_]+)+"
+                render={({ match }): React.ReactElement => {
+                  const userIds: string | undefined = match.params.userIds;
+                  const userId: string = (userIds ?? "").split("/")[0];
+                  return <UserPage userId={userId} />;
+                }}
+              />
+              <Route
+                path="/table/:userIds([a-zA-Z0-9_]*)*"
+                render={({ match }): React.ReactElement => {
+                  const userIds: string | undefined = match.params.userIds;
+                  const userId = (userIds ?? "").split("/")[0];
+                  const rivals = (userIds ?? "/").split("/");
+                  const rivalList = List(rivals)
+                    .skip(1)
+                    .filter((x) => x.length > 0);
+                  return <TablePage userId={userId} rivals={rivalList} />;
+                }}
+              />
+              <Route
+                path="/list/:userIds([a-zA-Z0-9_]*)*"
+                render={({ match }): React.ReactElement => {
+                  const userIds: string | undefined = match.params.userIds;
+                  const userId = (userIds ?? "").split("/")[0];
+                  const rivals = (userIds ?? "/").split("/");
+                  const rivalList = List(rivals)
+                    .skip(1)
+                    .filter((x) => x.length > 0);
+                  return <ListPage userId={userId} rivals={rivalList} />;
+                }}
+              />
+
+              {/*Virtual Contests*/}
+              <Route
+                path="/contest/show/:contestId([a-zA-Z0-9_-]+)"
+                component={ShowContest}
+              />
+              <Route path="/contest/create" component={ContestCreatePage} />
+              <Route
+                path="/contest/update/:contestId([a-zA-Z0-9_-]+)"
+                component={ContestUpdatePage}
+              />
+              <Route path="/contest/recent" component={RecentContestList} />
+
+              {/*User Settings*/}
+              <Route path={ACCOUNT_INFO} component={MyAccountPage} />
+
+              {/*Problem List*/}
+              <Route
+                path="/problemlist/:listId([a-zA-Z0-9_-]+)"
+                component={SingleProblemList}
+              />
+              <Route path="/submissions/recent" component={RecentSubmissions} />
+
+              {/*Training*/}
+              <Route path="/training" component={TrainingPage} />
+
+              {/*Default Path*/}
+              <Redirect path="/" to="/table/" />
+            </Switch>
+          </Container>
         </div>
-
-        <Container className="my-5" style={{ width: "100%", maxWidth: "90%" }}>
-          <Switch>
-            <Route exact path="/ac" component={ACRanking} />
-            <Route exact path="/fast" component={FastestRanking} />
-            <Route exact path="/short" component={ShortRanking} />
-            <Route exact path="/first" component={FirstRanking} />
-            <Route exact path="/sum" component={SumRanking} />
-            <Route exact path="/streak" component={StreakRanking} />
-            <Route exact path="/lang" component={LanguageOwners} />
-            <Route
-              path="/user/:userIds([a-zA-Z0-9_]+)+"
-              render={({ match }): React.ReactElement => {
-                const userIds: string | undefined = match.params.userIds;
-                const userId: string = (userIds ?? "").split("/")[0];
-                return <UserPage userId={userId} />;
-              }}
-            />
-            <Route
-              path="/table/:userIds([a-zA-Z0-9_]*)*"
-              render={({ match }): React.ReactElement => {
-                const userIds: string | undefined = match.params.userIds;
-                const userId = (userIds ?? "").split("/")[0];
-                const rivals = (userIds ?? "/").split("/");
-                const rivalList = List(rivals)
-                  .skip(1)
-                  .filter((x) => x.length > 0);
-                return <TablePage userId={userId} rivals={rivalList} />;
-              }}
-            />
-            <Route
-              path="/list/:userIds([a-zA-Z0-9_]*)*"
-              render={({ match }): React.ReactElement => {
-                const userIds: string | undefined = match.params.userIds;
-                const userId = (userIds ?? "").split("/")[0];
-                const rivals = (userIds ?? "/").split("/");
-                const rivalList = List(rivals)
-                  .skip(1)
-                  .filter((x) => x.length > 0);
-                return <ListPage userId={userId} rivals={rivalList} />;
-              }}
-            />
-
-            {/*Virtual Contests*/}
-            <Route
-              path="/contest/show/:contestId([a-zA-Z0-9_-]+)"
-              component={ShowContest}
-            />
-            <Route path="/contest/create" component={ContestCreatePage} />
-            <Route
-              path="/contest/update/:contestId([a-zA-Z0-9_-]+)"
-              component={ContestUpdatePage}
-            />
-            <Route path="/contest/recent" component={RecentContestList} />
-
-            {/*User Settings*/}
-            <Route path={ACCOUNT_INFO} component={MyAccountPage} />
-
-            {/*Problem List*/}
-            <Route
-              path="/problemlist/:listId([a-zA-Z0-9_-]+)"
-              component={SingleProblemList}
-            />
-            <Route path="/submissions/recent" component={RecentSubmissions} />
-
-            {/*Training*/}
-            <Route path="/training" component={TrainingPage} />
-            <Redirect path="/" to="/table/" />
-          </Switch>
-        </Container>
-      </div>
-    </Router>
+      </Router>
+    </ThemeProvider>
   );
 };
 

--- a/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
+++ b/atcoder-problems-frontend/src/components/DifficultyCircle.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { Badge, Tooltip } from "reactstrap";
 import { getRatingColor, getRatingColorCode } from "../utils";
+import { Theme } from "../style/theme";
+import { useTheme } from "./ThemeProvider";
 
 interface Props {
   id: string;
@@ -11,7 +13,7 @@ interface LocalState {
   tooltipOpen: boolean;
 }
 
-function getColor(difficulty: number): string {
+function getColor(difficulty: number, theme: Theme): string {
   if (difficulty >= 3200) {
     if (difficulty < 3600) {
       // bronze
@@ -24,82 +26,68 @@ function getColor(difficulty: number): string {
       return "#ffd700";
     }
   } else {
-    return getRatingColorCode(getRatingColor(difficulty));
+    return getRatingColorCode(getRatingColor(difficulty), theme);
   }
 }
 
-export class DifficultyCircle extends React.Component<Props, LocalState> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      tooltipOpen: false,
-    };
-  }
-
-  render(): React.ReactNode {
-    const { id, difficulty } = this.props;
-    const { tooltipOpen } = this.state;
-    const toggleTooltipState = (): void =>
-      this.setState({ tooltipOpen: !tooltipOpen });
-    const circleId = "DifficultyCircle-" + id;
-    if (difficulty === null) {
-      return (
-        <span>
-          <Badge
-            className="difficulty-unavailable-circle"
-            color="info"
-            id={circleId}
-            pill
-          >
-            ?
-          </Badge>
-          <Tooltip
-            placement="top"
-            target={circleId}
-            isOpen={tooltipOpen}
-            toggle={toggleTooltipState}
-          >
-            Difficulty is unavailable.
-          </Tooltip>
-        </span>
-      );
-    }
-    const fillRatio: number =
-      difficulty >= 3200 ? 1.0 : (difficulty % 400) / 400;
-    const color: string = getColor(difficulty);
-    const r: number = parseInt(color.slice(1, 3), 16);
-    const g: number = parseInt(color.slice(3, 5), 16);
-    const b: number = parseInt(color.slice(5, 7), 16);
-    const styleOptions = Object({
-      borderColor: color,
-      background:
-        difficulty < 3200
-          ? `linear-gradient(to top, rgba(${r}, ${g}, ${b}, ${1.0}) 0%, rgba(${r}, ${g}, ${b}, ${1.0}) ${
-              fillRatio * 100
-            }%, rgba(${r}, ${g}, ${b}, ${0.0}) ${
-              fillRatio * 100
-            }%, rgba(${r}, ${g}, ${b}, ${0.0}) 100%)`
-          : difficulty < 3600
-          ? `linear-gradient(to right, ${color}, #FFDABD, ${color})`
-          : `linear-gradient(to right, ${color}, white, ${color})`,
-    });
-    const title = `Difficulty: ${difficulty}`;
+export const DifficultyCircle: React.FC<Props> = (props) => {
+  const { id, difficulty } = props;
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const theme = useTheme();
+  const toggleTooltipState = (): void => setTooltipOpen(!tooltipOpen);
+  const circleId = "DifficultyCircle-" + id;
+  if (difficulty === null) {
     return (
-      <>
-        <span
-          className="difficulty-circle"
-          style={styleOptions}
+      <span>
+        <Badge
+          className="difficulty-unavailable-circle"
+          color="info"
           id={circleId}
-        />
+          pill
+        >
+          ?
+        </Badge>
         <Tooltip
           placement="top"
           target={circleId}
           isOpen={tooltipOpen}
           toggle={toggleTooltipState}
         >
-          {title}
+          Difficulty is unavailable.
         </Tooltip>
-      </>
+      </span>
     );
   }
-}
+  const fillRatio: number = difficulty >= 3200 ? 1.0 : (difficulty % 400) / 400;
+  const color: string = getColor(difficulty, theme);
+  const r: number = parseInt(color.slice(1, 3), 16);
+  const g: number = parseInt(color.slice(3, 5), 16);
+  const b: number = parseInt(color.slice(5, 7), 16);
+  const styleOptions = Object({
+    borderColor: color,
+    background:
+      difficulty < 3200
+        ? `linear-gradient(to top, rgba(${r}, ${g}, ${b}, ${1.0}) 0%, rgba(${r}, ${g}, ${b}, ${1.0}) ${
+            fillRatio * 100
+          }%, rgba(${r}, ${g}, ${b}, ${0.0}) ${
+            fillRatio * 100
+          }%, rgba(${r}, ${g}, ${b}, ${0.0}) 100%)`
+        : difficulty < 3600
+        ? `linear-gradient(to right, ${color}, #FFDABD, ${color})`
+        : `linear-gradient(to right, ${color}, white, ${color})`,
+  });
+  const title = `Difficulty: ${difficulty}`;
+  return (
+    <>
+      <span className="difficulty-circle" style={styleOptions} id={circleId} />
+      <Tooltip
+        placement="top"
+        target={circleId}
+        isOpen={tooltipOpen}
+        toggle={toggleTooltipState}
+      >
+        {title}
+      </Tooltip>
+    </>
+  );
+};

--- a/atcoder-problems-frontend/src/components/ThemeProvider.tsx
+++ b/atcoder-problems-frontend/src/components/ThemeProvider.tsx
@@ -9,7 +9,7 @@ type ThemeContextProps = [ThemeId, (newThemeId: ThemeId) => void];
 export const ThemeContext = React.createContext<ThemeContextProps>([
   "light",
   (): void => {
-    throw "setThemeId is not implemented.";
+    throw new Error("setThemeId is not implemented.");
   },
 ]);
 

--- a/atcoder-problems-frontend/src/components/ThemeProvider.tsx
+++ b/atcoder-problems-frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import { useLocalStorage } from "../utils/LocalStorage";
+import { ThemeDark, ThemeLight, Theme } from "../style/theme";
+
+type ThemeId = "light" | "dark";
+type ThemeContextProps = [ThemeId, (newThemeId: ThemeId) => void];
+
+export const ThemeContext = React.createContext<ThemeContextProps>([
+  "light",
+  (): void => {
+    throw "setThemeId is not implemented.";
+  },
+]);
+
+interface ThemeProviderProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = (
+  props: ThemeProviderProps
+) => {
+  const [themeId, setThemeId] = useLocalStorage<ThemeId>("theme", "light");
+
+  return (
+    <ThemeContext.Provider value={[themeId, setThemeId]}>
+      <Helmet>
+        <html className={`theme-${themeId}`} />
+      </Helmet>
+
+      {props.children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): Theme => {
+  const [themeId] = React.useContext(ThemeContext);
+  return themeId === "light" ? ThemeLight : ThemeDark;
+};

--- a/atcoder-problems-frontend/src/components/ThemeSelector.tsx
+++ b/atcoder-problems-frontend/src/components/ThemeSelector.tsx
@@ -1,45 +1,36 @@
-import React from "react";
+import React, { useContext } from "react";
 import {
   UncontrolledDropdown,
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
 } from "reactstrap";
-import { Helmet } from "react-helmet";
-import { useLocalStorage } from "../utils/LocalStorage";
-
-type Theme = "light" | "dark";
+import { ThemeContext } from "./ThemeProvider";
 
 export const ThemeSelector: React.FC = () => {
-  const [theme, setTheme] = useLocalStorage<Theme>("theme", "light");
+  const [, setThemeId] = useContext(ThemeContext);
 
   return (
-    <>
-      <Helmet>
-        <html className={`theme-${theme}`} />
-      </Helmet>
-
-      <UncontrolledDropdown nav inNavbar>
-        <DropdownToggle nav caret>
-          Theme
-        </DropdownToggle>
-        <DropdownMenu>
-          <DropdownItem
-            tag="a"
-            style={{ cursor: "pointer" }}
-            onClick={(): void => setTheme("light")}
-          >
-            Light
-          </DropdownItem>
-          <DropdownItem
-            tag="a"
-            style={{ cursor: "pointer" }}
-            onClick={(): void => setTheme("dark")}
-          >
-            Dark (Beta)
-          </DropdownItem>
-        </DropdownMenu>
-      </UncontrolledDropdown>
-    </>
+    <UncontrolledDropdown nav inNavbar>
+      <DropdownToggle nav caret>
+        Theme
+      </DropdownToggle>
+      <DropdownMenu>
+        <DropdownItem
+          tag="a"
+          style={{ cursor: "pointer" }}
+          onClick={(): void => setThemeId("light")}
+        >
+          Light
+        </DropdownItem>
+        <DropdownItem
+          tag="a"
+          style={{ cursor: "pointer" }}
+          onClick={(): void => setThemeId("dark")}
+        >
+          Dark (Beta)
+        </DropdownItem>
+      </DropdownMenu>
+    </UncontrolledDropdown>
   );
 };

--- a/atcoder-problems-frontend/src/style/_custom.scss
+++ b/atcoder-problems-frontend/src/style/_custom.scss
@@ -1,20 +1,69 @@
 // Color Variables
 
-$difficulty-red-color: #ff0000 !default;
-$difficulty-orange-color: #ff8000 !default;
-$difficulty-yellow-color: #c0c000 !default;
-$difficulty-blue-color: #0000ff !default;
-$difficulty-cyan-color: #00c0c0 !default;
-$difficulty-green-color: #008000 !default;
-$difficulty-brown-color: #804000 !default;
 $difficulty-grey-color: #808080 !default;
+$difficulty-brown-color: #804000 !default;
+$difficulty-green-color: #008000 !default;
+$difficulty-cyan-color: #00c0c0 !default;
+$difficulty-blue-color: #0000ff !default;
+$difficulty-yellow-color: #c0c000 !default;
+$difficulty-orange-color: #ff8000 !default;
+$difficulty-red-color: #ff0000 !default;
+
+$success-bg-color: #c3e6cb !default;
+$success-hover-bg-color: #b1dfbb !default;
 
 $success-intime-bg-color: #9ad59e !default;
-$warning-intime-bg-color: #ffdd99 !default;
-$success-before-contest-bg-color: #99ccff !default;
 $success-intime-hover-bg-color: #88cc88 !default;
-$warning-intime-hover-bg-color: #f0cc99 !default;
+
+$success-before-contest-bg-color: #99ccff !default;
 $success-before-contest-hover-bg-color: #88bbff !default;
+
+$warning-bg-color: #ffeeba !default;
+$warning-hover-bg-color: #ffe8a1 !default;
+
+$warning-intime-bg-color: #ffdd99 !default;
+$warning-intime-hover-bg-color: #f0cc99 !default;
+
+$danger-bg-color: #f5c6cb !default;
+$danger-hover-bg-color: #f1b0b7 !default;
+
+// Table Background Override Hatch
+
+.table-success,
+.table-success > th,
+.table-success > td {
+  background-color: $success-bg-color !important;
+}
+
+.table-hover .table-success:hover,
+.table-hover .table-success:hover > th,
+.table-hover .table-success:hover > td {
+  background-color: $success-hover-bg-color !important;
+}
+
+.table-warning,
+.table-warning > th,
+.table-warning > td {
+  background-color: $warning-bg-color !important;
+}
+
+.table-hover .table-warning:hover,
+.table-hover .table-warning:hover > th,
+.table-hover .table-warning:hover > td {
+  background-color: $warning-hover-bg-color !important;
+}
+
+.table-danger,
+.table-danger > th,
+.table-danger > td {
+  background-color: $danger-bg-color !important;
+}
+
+.table-hover .table-danger:hover,
+.table-hover .table-danger:hover > th,
+.table-hover .table-danger:hover > td {
+  background-color: $danger-hover-bg-color !important;
+}
 
 // Style
 
@@ -120,7 +169,10 @@ span.difficulty-circle {
 
 .table-hover .table-success-intime:hover,
 .table-hover .table-success-intime:hover > td,
-.table-hover .table-success-intime:hover > th {
+.table-hover .table-success-intime:hover > th,
+.table-hover .table-success-language:hover,
+.table-hover .table-success-language:hover > td,
+.table-hover .table-success-language:hover > th {
   background-color: $success-intime-hover-bg-color;
 }
 

--- a/atcoder-problems-frontend/src/style/_theme-dark.scss
+++ b/atcoder-problems-frontend/src/style/_theme-dark.scss
@@ -40,16 +40,18 @@ $gray-800: #222 !default;
 $gray-900: #212529 !default;
 $black: #000 !default;
 
-$blue: #2a9fd6 !default;
-$indigo: #6610f2 !default;
-$purple: #6f42c1 !default;
-$pink: #e83e8c !default;
-$red: #cc0000 !default;
-$orange: #fd7e14 !default;
-$yellow: #ff8800 !default;
-$green: #77b300 !default;
-$teal: #20c997 !default;
+$blue: #0e7aac !default;
+$indigo: #5805dd !default;
+$purple: #5b28bb !default;
+$pink: #d61e74 !default;
+$red: #b40000 !default;
+$orange: #ff7809 !default;
+$yellow: #fdd90a !default;
+$green: #4b7000 !default;
+$teal: #0b9c71 !default;
 $cyan: #9933cc !default;
+
+$link-color: #36aae0 !default;
 
 $primary: $blue !default;
 $secondary: $gray-600 !default;
@@ -148,6 +150,12 @@ $pagination-disabled-border-color: $pagination-border-color !default;
 
 $jumbotron-bg: $gray-700 !default;
 
+// Alerts
+
+$alert-bg-level: 4 !default;
+$alert-border-level: -9 !default;
+$alert-color-level: -10 !default;
+
 // Cards
 
 $card-bg: $gray-700 !default;
@@ -217,17 +225,44 @@ $react-bs-table-border-color: $gray-700;
 
 // AtCoder Problems Color Override
 
+// Variables to make the auto generated color for tables sane.
 $table-bg-level: 7;
-$table-border-level: 6;
+$table-border-level: -10;
 
-$success-intime-bg-color: #39883f;
-$warning-intime-bg-color: #996f1c;
-$success-before-contest-bg-color: #15518d;
+$difficulty-grey-color: #c0c0c0 !default;
+$difficulty-brown-color: #ffa244 !default;
+$difficulty-green-color: #3faf3f !default;
+$difficulty-cyan-color: #42e0e0 !default;
+$difficulty-blue-color: #8888ff !default;
+$difficulty-yellow-color: #ffff56 !default;
+$difficulty-orange-color: #ffc86f !default;
+$difficulty-red-color: #ff6767 !default;
+
+$success-bg-color: #005c08;
+$success-hover-bg-color: darken($success-bg-color, 5%);
+
+$success-intime-bg-color: darken($success-bg-color, 5%);
 $success-intime-hover-bg-color: darken($success-intime-bg-color, 5%);
+
+$warning-bg-color: #5d3e00;
+$warning-hover-bg-color: darken($warning-bg-color, 5%);
+
+$warning-intime-bg-color: darken($warning-bg-color, 5%);
 $warning-intime-hover-bg-color: darken($warning-intime-bg-color, 5%);
+
+$success-before-contest-bg-color: #002a55;
 $success-before-contest-hover-bg-color: darken(
   $success-before-contest-bg-color,
   5%
 );
+
+$danger-bg-color: #4b0000;
+$danger-hover-bg-color: darken($danger-bg-color, 5%);
+
+table.table-bordered,
+table.table-bordered th,
+table.table-bordered td {
+  border-color: #484848 !important;
+}
 
 @import "common";

--- a/atcoder-problems-frontend/src/style/theme.ts
+++ b/atcoder-problems-frontend/src/style/theme.ts
@@ -1,0 +1,26 @@
+export const ThemeLight = {
+  difficultyBlackColor: "#101010",
+  difficultyGreyColor: "#808080",
+  difficultyBrownColor: "#804000",
+  difficultyGreenColor: "#008000",
+  difficultyCyanColor: "#00C0C0",
+  difficultyBlueColor: "#0000FF",
+  difficultyYellowColor: "#C0C000",
+  difficultyOrangeColor: "#FF8000",
+  difficultyRedColor: "#FF0000",
+};
+
+export const ThemeDark: typeof ThemeLight = {
+  ...ThemeLight,
+  difficultyBlackColor: "#FFFFFF",
+  difficultyGreyColor: "#C0C0C0",
+  difficultyBrownColor: "#FFA244",
+  difficultyGreenColor: "#3FAF3F",
+  difficultyCyanColor: "#42E0E0",
+  difficultyBlueColor: "#8888FF",
+  difficultyYellowColor: "#FFFF56",
+  difficultyOrangeColor: "#FFC86F",
+  difficultyRedColor: "#FF6767",
+};
+
+export type Theme = typeof ThemeLight;

--- a/atcoder-problems-frontend/src/utils/index.ts
+++ b/atcoder-problems-frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { List } from "immutable";
+import { Theme, ThemeLight } from "../style/theme";
 
 const userIdRegex = /[0-9a-zA-Z_]+/;
 export const ATCODER_USER_REGEXP = new RegExp(`^${userIdRegex.source}$`);
@@ -69,7 +70,7 @@ export const getRatingColor = (rating: number): RatingColor => {
   const index = Math.min(Math.floor(rating / 400), RatingColors.length - 2);
   return RatingColors[index + 1];
 };
-type RatingColorClassName =
+export type RatingColorClassName =
   | "difficulty-black"
   | "difficulty-grey"
   | "difficulty-brown"
@@ -102,26 +103,29 @@ export const getRatingColorClass = (rating: number): RatingColorClassName => {
       return "difficulty-red";
   }
 };
-export const getRatingColorCode = (ratingColor: RatingColor): string => {
+export const getRatingColorCode = (
+  ratingColor: RatingColor,
+  theme: Theme = ThemeLight
+): string => {
   switch (ratingColor) {
     case "Black":
-      return "#101010";
+      return theme.difficultyBlackColor;
     case "Grey":
-      return "#808080";
+      return theme.difficultyGreyColor;
     case "Brown":
-      return "#804000";
+      return theme.difficultyBrownColor;
     case "Green":
-      return "#008000";
+      return theme.difficultyGreenColor;
     case "Cyan":
-      return "#00C0C0";
+      return theme.difficultyCyanColor;
     case "Blue":
-      return "#0000FF";
+      return theme.difficultyBlueColor;
     case "Yellow":
-      return "#C0C000";
+      return theme.difficultyYellowColor;
     case "Orange":
-      return "#FF8000";
+      return theme.difficultyOrangeColor;
     case "Red":
-      return "#FF0000";
+      return theme.difficultyRedColor;
   }
 };
 


### PR DESCRIPTION
* ダークテーマの色を変えました。
  * Difficulty の色がオフィシャルの色と違うようになりました。
* テーマサポートがもっと複雑になりました。
  * `DifficultyCircle` の色はテーマによって違うになりました。色は `src/style/theme.ts` に置きました。
* ThemeProvider に Context を使いました。
* 問題の色が暗いバックグラウンドの上に見にくいため、**ダークテーマで**問題と `DifficultyCircle` の色を変えました。
  * このため、`DifficultyCircle` の中に `useTheme` のコールがあって、pure でないになった。大丈夫ですか。

これで、ダークテーマは使えるようになると思います。

## Before
![Preview of site before this PR](https://user-images.githubusercontent.com/6523469/85223601-a6346600-b3f6-11ea-9bdf-ebe49c5237fd.png)

## After
![Preview of site after this PR](https://user-images.githubusercontent.com/6523469/85223604-ae8ca100-b3f6-11ea-8be0-fc9935ab36c9.png)
