### PR TITLE
fix(frontend): show AtCoder user ID in account page

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, PromiseState, PropsMapInner } from "react-refetch";
 import {
   Alert,
@@ -35,13 +35,17 @@ interface InnerProps {
 
 const InnerMyAccountPage = (props: InnerProps): JSX.Element => {
   const { userInfoGet, updateUserInfoResponse } = props;
-  const currentAtCoderId =
-    userInfoGet.fulfilled && userInfoGet.value
-      ? userInfoGet.value.atcoder_user_id
-      : "";
 
-  const [userId, setUserId] = useState(currentAtCoderId ?? "");
+  const [userId, setUserId] = useState("");
   const [activeTab, setActiveTab] = useState<TabType>("Account Info");
+
+  useEffect(() => {
+    if (userInfoGet.fulfilled && userInfoGet.value) {
+      setUserId(userInfoGet.value.atcoder_user_id ?? "");
+    }
+    // We only want to set the userId when the userInfoGet promise is first fulfilled.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userInfoGet.fulfilled]);
 
   if (userInfoGet.rejected || updateUserInfoResponse.rejected) {
     return <Redirect to="/" />;


### PR DESCRIPTION
#630 の変更で、`userId` の初期値が `""` になりました。

この PR に `useEffect` で正しい値を設定しました。

![image](https://user-images.githubusercontent.com/6523469/85408387-08c46800-b597-11ea-820c-f700f6dd078b.png)
