### PR TITLE
feat: AC Trophies generator

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACTrophyGenerator.ts
@@ -1,0 +1,52 @@
+import { Trophy, TrophySubmission } from "./Trophy";
+
+const generateACTrophiesWithOneProblem = (
+  acProblemIds: Set<string>
+): Trophy[] => {
+  const milestones: [string, string, string][] = [
+    ["Transcendental number", "Accept WorldTourFinals2019-E", "wtf19_e"],
+  ];
+  return milestones.map(([draftTitle, reason, problem_id]) => {
+    const title = draftTitle;
+    const achieved = acProblemIds.has(problem_id);
+    const sortId = `accept-${problem_id}`;
+    return { title, reason, achieved, sortId };
+  });
+};
+
+const generateACTrophiesWithProblems = (
+  acProblemIds: Set<string>
+): Trophy[] => {
+  const milestones: [string, string, string[]][] = [
+    [
+      "World traveler2019",
+      "Accept all problems in WorldTourFinals2019",
+      ["wtf19_a", "wtf19_b", "wtf19_c1", "wtf19_c2", "wtf19_d", "wtf19_e"],
+    ],
+  ];
+  return milestones.map(([draftTitle, reason, problem_ids]) => {
+    const title = draftTitle;
+    const achieved = problem_ids.every((problem_id) =>
+      acProblemIds.has(problem_id)
+    );
+    const sortId = `accept-all-${draftTitle}`;
+    return { title, reason, achieved, sortId };
+  });
+};
+
+const uniqueACProblemIds = (submissions: TrophySubmission[]): Set<string> => {
+  const acProblemIds = submissions
+    .filter((submissions) => submissions.submission.result === "AC")
+    .map((submission) => submission.submission.problem_id);
+  return new Set(acProblemIds);
+};
+
+export const generateACTrophies = (
+  allSubmissions: TrophySubmission[]
+): Trophy[] => {
+  const trophies = [] as Trophy[];
+  const acProblemIds = uniqueACProblemIds(allSubmissions);
+  trophies.push(...generateACTrophiesWithOneProblem(acProblemIds));
+  trophies.push(...generateACTrophiesWithProblems(acProblemIds));
+  return trophies;
+};

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
@@ -5,6 +5,7 @@ import ProblemModel from "../../../interfaces/ProblemModel";
 import { ProblemId } from "../../../interfaces/Status";
 import Submission from "../../../interfaces/Submission";
 import { generateACCountTrophies } from "./ACCountTrophyGenerator";
+import { generateACTrophies } from "./ACTrophyGenerator";
 import { generateStreakTrophies } from "./StreakTrophyGenerator";
 import { Trophy } from "./Trophy";
 
@@ -23,6 +24,7 @@ export const TrophyBlock = (props: Props): JSX.Element => {
   const trophies = [] as Trophy[];
   trophies.push(...generateStreakTrophies(trophySubmissions));
   trophies.push(...generateACCountTrophies(trophySubmissions));
+  trophies.push(...generateACTrophies(trophySubmissions));
 
   const filteredTrophies = trophies
     .sort((a, b) => a.sortId.localeCompare(b.sortId))


### PR DESCRIPTION
- ある問題に正解した
- ある問題集合全てに正解した

上記2通りに対するトロフィーです。
ACした問題のproblem_id一覧をset<string>で持った上で、各milestoneに設定されているproblem_idを照会するといった流れです。

トロフィー生成部分を2通りに実装を分けているのは、トロフィーを追加するときを考えると、トロフィーが「1つの問題」に対してか「複数の問題」に対してかが明白に分かれていた方がやりやすいと考えたからです。

