### PR TITLE
Add rejected number to the contest chart

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/SmallPieChart.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/SmallPieChart.tsx
@@ -4,28 +4,34 @@ import { SinglePieChart } from "../../../components/SinglePieChart";
 const COLORS = {
   Accepted: "#32cd32",
   Trying: "#58616a",
+  Rejected: "#fd9",
 };
 
 interface SmallPieChartProps {
   title: string;
   trying: number;
   accepted: number;
+  rejected: number;
 }
 
 export const SmallPieChart: React.FC<SmallPieChartProps> = ({
   title,
   trying,
+  rejected,
   accepted,
 }) => {
   const data = [
     { value: accepted, color: COLORS.Accepted, name: "Accepted" },
+    { value: rejected, color: COLORS.Rejected, name: "Rejected" },
     { value: trying, color: COLORS.Trying, name: "Trying" },
   ];
   return (
     <div>
       <SinglePieChart data={data} />
       <h5>{title}</h5>
-      <h5 className="text-muted">{`${accepted} / ${accepted + trying}`}</h5>
+      <h5 className="text-muted">{`${accepted} (${rejected})  / ${
+        accepted + rejected + trying
+      }`}</h5>
     </div>
   );
 };

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -7,7 +7,7 @@ import { connect, PromiseState } from "react-refetch";
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
 import Contest from "../../interfaces/Contest";
-import { isAccepted } from "../../utils";
+import { isAccepted, isValidResult } from "../../utils";
 import { ContestId, ProblemId } from "../../interfaces/Status";
 import * as CachedApiClient from "../../utils/CachedApiClient";
 import ProblemModel from "../../interfaces/ProblemModel";

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -7,7 +7,7 @@ import { connect, PromiseState } from "react-refetch";
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
 import Contest from "../../interfaces/Contest";
-import { isAccepted, isValidResult } from "../../utils";
+import { isAccepted } from "../../utils";
 import { ContestId, ProblemId } from "../../interfaces/Status";
 import * as CachedApiClient from "../../utils/CachedApiClient";
 import ProblemModel from "../../interfaces/ProblemModel";


### PR DESCRIPTION

(Partially) Fixed #601

コンテストごとのPieChartでのRejectされた問題数を表示するようにしました。
Diffチャートでは色の問題で見せ方がわからなかったので、今回は変更しませんでした。

実際にはこんな感じに見えます
![Screenshot from 2020-06-26 18-33-29](https://user-images.githubusercontent.com/2667091/85843527-3e0dc780-b7dc-11ea-9f78-51d80fa22787.png)