### PR TITLE
chore: cause committing to fail for ESLint warnings

### DIFF
--- a/atcoder-problems-frontend/package.json
+++ b/atcoder-problems-frontend/package.json
@@ -27,7 +27,7 @@
     "*.{css,scss,html,json,md}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings=0"
     ],
     "../**/*.md": "prettier --write",
     "package.json": [


### PR DESCRIPTION
よく ESLint の warning のせいで CI fail になるので、ESLint の warning があったら commit できないようにします。