### PR TITLE
Classify Heuristics Contest as Marathon

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
@@ -46,7 +46,7 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     return "JAG";
   }
   if (
-    /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova)/.exec(
+    /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title
     ) ||
     /(^future-meets-you-contest|^hokudai-hitachi)/.exec(contest.id) ||


### PR DESCRIPTION
TablePage 内で，Heuristics contest が現状だと Other Contests タブにいるので，Marathon タブに移しましょう．