### PR TITLE
display login user score at the top of the virtual contest table (#570)

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -233,6 +233,7 @@ interface OuterProps {
   readonly start: number;
   readonly end: number;
   readonly enableAutoRefresh: boolean;
+  readonly atCoderUserId: string;
 }
 
 interface InnerProps extends OuterProps {
@@ -266,8 +267,107 @@ function compareProblem<T extends { id: string; order: number | null }>(
   return a.id.localeCompare(b.id);
 }
 
+interface ContestTableRowProps {
+  userId: string;
+  index: number;
+  problems: {
+    item: VirtualContestItem;
+    title?: string | undefined;
+    contestId?: string | undefined;
+  }[];
+  bestSubmissions: BestSubmissionEntry[];
+  items: {
+    id: string;
+    point: number | null;
+    order: number | null;
+    contestId: string | undefined;
+    title: string | undefined;
+  }[];
+  showProblems: boolean;
+  start: number;
+  showEstimatedPerformances: boolean;
+  estimatedPerformances: {
+    performance: number;
+    userId: string;
+  }[];
+}
+
+const ContestTableRow: React.FC<ContestTableRowProps> = ({
+  userId,
+  index,
+  problems,
+  bestSubmissions,
+  items,
+  showProblems,
+  start,
+  showEstimatedPerformances,
+  estimatedPerformances,
+}) => {
+  const totalResult = calcTotalResult(
+    userId,
+    problems.map((p) => p.item),
+    bestSubmissions
+  );
+  return (
+    <tr>
+      <th>{index + 1}</th>
+      <th>{userId}</th>
+      {!showProblems
+        ? null
+        : items.sort(compareProblem).map((problem) => {
+            const info = bestSubmissions.find(
+              (e) => e.userId === userId && e.problemId === problem.id
+            )?.bestSubmissionInfo;
+            if (!info) {
+              return (
+                <td key={problem.id} style={{ textAlign: "center" }}>
+                  -
+                </td>
+              );
+            }
+            const best = info.bestSubmission;
+            const trials =
+              info.trialsBeforeBest +
+              (isAccepted(info.bestSubmission.result) ? 0 : 1);
+            const point =
+              problem.point !== null
+                ? isAccepted(best.result)
+                  ? problem.point
+                  : 0
+                : best.point;
+            return (
+              <td key={problem.id}>
+                <ScoreCell
+                  trials={trials}
+                  maxPoint={point}
+                  time={best.epoch_second - start}
+                />
+              </td>
+            );
+          })}
+      <td>
+        <ScoreCell
+          trials={totalResult.trialsBeforeBest}
+          maxPoint={totalResult.point}
+          time={totalResult.lastBestSubmissionTime - start}
+        />
+      </td>
+      {showEstimatedPerformances ? (
+        <td>
+          <EstimatedPerformance
+            estimatedPerformance={
+              estimatedPerformances.find((e) => e.userId === userId)
+                ?.performance
+            }
+          />
+        </td>
+      ) : null}
+    </tr>
+  );
+};
+
 const InnerContestTable: React.FC<InnerProps> = (props) => {
-  const { showProblems, problems, users, start, end } = props;
+  const { showProblems, problems, users, start, end, atCoderUserId } = props;
   const problemModels = props.problemModels.fulfilled
     ? props.problemModels.value
     : ImmutableMap<ProblemId, ProblemModel>();
@@ -293,6 +393,11 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     problems.map((p) => p.item),
     bestSubmissions
   );
+
+  const loginUserIndex = sortedUserIds.findIndex(
+    (userId) => userId === atCoderUserId
+  );
+
   const estimatedPerformances = props.enableEstimatedPerformances
     ? getEstimatedPerformances(
         users,
@@ -343,68 +448,33 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
         </tr>
       </thead>
       <tbody>
+        {loginUserIndex >= 0 ? (
+          <ContestTableRow
+            userId={atCoderUserId}
+            index={loginUserIndex}
+            problems={problems}
+            bestSubmissions={bestSubmissions}
+            items={items}
+            showProblems={showProblems}
+            start={start}
+            showEstimatedPerformances={showEstimatedPerformances}
+            estimatedPerformances={estimatedPerformances}
+          />
+        ) : null}
         {sortedUserIds.map((userId, i) => {
-          const totalResult = calcTotalResult(
-            userId,
-            problems.map((p) => p.item),
-
-            bestSubmissions
-          );
           return (
-            <tr key={i}>
-              <th>{i + 1}</th>
-              <th>{userId}</th>
-              {!showProblems
-                ? null
-                : items.sort(compareProblem).map((problem) => {
-                    const info = bestSubmissions.find(
-                      (e) => e.userId === userId && e.problemId === problem.id
-                    )?.bestSubmissionInfo;
-                    if (!info) {
-                      return (
-                        <td key={problem.id} style={{ textAlign: "center" }}>
-                          -
-                        </td>
-                      );
-                    }
-                    const best = info.bestSubmission;
-                    const trials =
-                      info.trialsBeforeBest +
-                      (isAccepted(info.bestSubmission.result) ? 0 : 1);
-                    const point =
-                      problem.point !== null
-                        ? isAccepted(best.result)
-                          ? problem.point
-                          : 0
-                        : best.point;
-                    return (
-                      <td key={problem.id}>
-                        <ScoreCell
-                          trials={trials}
-                          maxPoint={point}
-                          time={best.epoch_second - start}
-                        />
-                      </td>
-                    );
-                  })}
-              <td>
-                <ScoreCell
-                  trials={totalResult.trialsBeforeBest}
-                  maxPoint={totalResult.point}
-                  time={totalResult.lastBestSubmissionTime - start}
-                />
-              </td>
-              {showEstimatedPerformances ? (
-                <td>
-                  <EstimatedPerformance
-                    estimatedPerformance={
-                      estimatedPerformances.find((e) => e.userId === userId)
-                        ?.performance
-                    }
-                  />
-                </td>
-              ) : null}
-            </tr>
+            <ContestTableRow
+              key={userId}
+              userId={userId}
+              index={i}
+              problems={problems}
+              bestSubmissions={bestSubmissions}
+              items={items}
+              showProblems={showProblems}
+              start={start}
+              showEstimatedPerformances={showEstimatedPerformances}
+              estimatedPerformances={estimatedPerformances}
+            />
           );
         })}
       </tbody>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -237,7 +237,7 @@ interface OuterProps {
   readonly end: number;
   readonly enableAutoRefresh: boolean;
   readonly atCoderUserId: string;
-  readonly showYourselfTop: boolean;
+  readonly pinMe: boolean;
 }
 
 interface InnerProps extends OuterProps {
@@ -378,7 +378,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     start,
     end,
     atCoderUserId,
-    showYourselfTop,
+    pinMe,
   } = props;
   const problemModels = props.problemModels.fulfilled
     ? props.problemModels.value
@@ -460,7 +460,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
         </tr>
       </thead>
       <tbody>
-        {showYourselfTop && loginUserIndex >= 0 ? (
+        {pinMe && loginUserIndex >= 0 ? (
           <ContestTableRow
             userId={atCoderUserId}
             index={loginUserIndex}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -237,6 +237,7 @@ interface OuterProps {
   readonly end: number;
   readonly enableAutoRefresh: boolean;
   readonly atCoderUserId: string;
+  readonly showYourselfTop: boolean;
 }
 
 interface InnerProps extends OuterProps {
@@ -370,7 +371,15 @@ const ContestTableRow: React.FC<ContestTableRowProps> = ({
 };
 
 const InnerContestTable: React.FC<InnerProps> = (props) => {
-  const { showProblems, problems, users, start, end, atCoderUserId } = props;
+  const {
+    showProblems,
+    problems,
+    users,
+    start,
+    end,
+    atCoderUserId,
+    showYourselfTop,
+  } = props;
   const problemModels = props.problemModels.fulfilled
     ? props.problemModels.value
     : new Map<ProblemId, ProblemModel>();
@@ -451,7 +460,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
         </tr>
       </thead>
       <tbody>
-        {loginUserIndex >= 0 ? (
+        {showYourselfTop && loginUserIndex >= 0 ? (
           <ContestTableRow
             userId={atCoderUserId}
             index={loginUserIndex}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -45,7 +45,7 @@ interface InnerProps extends OuterProps {
 
 const InnerShowContest: React.FC<InnerProps> = (props) => {
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
-  const [showYourselfTop, setShowYourselfTop] = useState(false);
+  const [pinMe, setPinMe] = useState(false);
   const history = useHistory();
   const { contestInfoFetch, userInfoGet, problemMapFetch } = props;
 
@@ -178,12 +178,12 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
             {autoRefreshEnabled ? "Enabled" : "Disabled"}
           </Button>
           <Button
-            outline={!showYourselfTop}
-            active={showYourselfTop}
-            onClick={(): void => setShowYourselfTop(!showYourselfTop)}
+            outline={!pinMe}
+            active={pinMe}
+            onClick={(): void => setPinMe(!pinMe)}
           >
-            <Octicon icon={showYourselfTop ? Check : Eye} /> Show Yourself on
-            the Top {showYourselfTop ? "Enabled" : "Disabled"}
+            <Octicon icon={pinMe ? Check : Eye} />{" "}
+            {pinMe ? "Pin me" : "Unpin me"}
           </Button>
         </Col>
       </Row>
@@ -218,7 +218,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               end={end}
               enableAutoRefresh={autoRefreshEnabled}
               atCoderUserId={atCoderUserId}
-              showYourselfTop={showYourselfTop}
+              pinMe={pinMe}
             />
           )}
         </Col>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -198,6 +198,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               start={start}
               end={end}
               enableAutoRefresh={autoRefreshEnabled}
+              atCoderUserId={atCoderUserId}
             />
           )}
         </Col>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -169,22 +169,26 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
             ) : null}
             <TweetButton title={contestInfo.title} id={contestInfo.id} />
           </ButtonGroup>{" "}
-          <Button
-            outline={!autoRefreshEnabled}
-            active={autoRefreshEnabled}
-            onClick={(): void => setAutoRefreshEnabled(!autoRefreshEnabled)}
-          >
-            <Octicon icon={autoRefreshEnabled ? Check : Sync} /> Auto Refresh{" "}
-            {autoRefreshEnabled ? "Enabled" : "Disabled"}
-          </Button>
-          <Button
-            outline={!pinMe}
-            active={pinMe}
-            onClick={(): void => setPinMe(!pinMe)}
-          >
-            <Octicon icon={pinMe ? Check : Eye} />{" "}
-            {pinMe ? "Pin me" : "Unpin me"}
-          </Button>
+          <ButtonGroup>
+            <Button
+              outline={!autoRefreshEnabled}
+              active={autoRefreshEnabled}
+              onClick={(): void => setAutoRefreshEnabled(!autoRefreshEnabled)}
+            >
+              <Octicon icon={autoRefreshEnabled ? Check : Sync} /> Auto Refresh{" "}
+              {autoRefreshEnabled ? "Enabled" : "Disabled"}
+            </Button>
+            {alreadyJoined ? (
+              <Button
+                outline={!pinMe}
+                active={pinMe}
+                onClick={(): void => setPinMe(!pinMe)}
+              >
+                <Octicon icon={pinMe ? Check : Eye} />{" "}
+                {pinMe ? "Pin me" : "Unpin me"}
+              </Button>
+            ) : null}
+          </ButtonGroup>
         </Col>
       </Row>
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   Table,
 } from "reactstrap";
-import Octicon, { Check, Sync, Eye } from "@primer/octicons-react";
+import Octicon, { Check, Sync, Pin } from "@primer/octicons-react";
 import { Map as ImmutableMap } from "immutable";
 import * as CachedApi from "../../../../utils/CachedApiClient";
 import { ProblemId } from "../../../../interfaces/Status";
@@ -184,8 +184,8 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                 active={pinMe}
                 onClick={(): void => setPinMe(!pinMe)}
               >
-                <Octicon icon={pinMe ? Check : Eye} />{" "}
-                {pinMe ? "Pin me" : "Unpin me"}
+                <Octicon icon={pinMe ? Check : Pin} />{" "}
+                {pinMe ? "Unpin me" : "Pin me"}
               </Button>
             ) : null}
           </ButtonGroup>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   Table,
 } from "reactstrap";
-import Octicon, { Check, Sync } from "@primer/octicons-react";
+import Octicon, { Check, Sync, Eye } from "@primer/octicons-react";
 import { Map as ImmutableMap } from "immutable";
 import * as CachedApi from "../../../../utils/CachedApiClient";
 import { ProblemId } from "../../../../interfaces/Status";
@@ -45,6 +45,7 @@ interface InnerProps extends OuterProps {
 
 const InnerShowContest: React.FC<InnerProps> = (props) => {
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
+  const [showYourselfTop, setShowYourselfTop] = useState(false);
   const history = useHistory();
   const { contestInfoFetch, userInfoGet, problemMapFetch } = props;
 
@@ -176,6 +177,14 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
             <Octicon icon={autoRefreshEnabled ? Check : Sync} /> Auto Refresh{" "}
             {autoRefreshEnabled ? "Enabled" : "Disabled"}
           </Button>
+          <Button
+            outline={!showYourselfTop}
+            active={showYourselfTop}
+            onClick={(): void => setShowYourselfTop(!showYourselfTop)}
+          >
+            <Octicon icon={showYourselfTop ? Check : Eye} /> Show Yourself on
+            the Top {showYourselfTop ? "Enabled" : "Disabled"}
+          </Button>
         </Col>
       </Row>
 
@@ -209,6 +218,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               end={end}
               enableAutoRefresh={autoRefreshEnabled}
               atCoderUserId={atCoderUserId}
+              showYourselfTop={showYourselfTop}
             />
           )}
         </Col>


### PR DESCRIPTION
resolves #570 
自分のスコアと順位がテーブルの一番上に追加されるようにしてみました。
ON/OFFを選択できるようにはしていません。←選択できた方が良いでしょうか？

ご検討お願いします！！

<img width="1298" alt="スクリーンショット 2020-07-05 12 34 53" src="https://user-images.githubusercontent.com/52167040/86527122-cecc5d80-bed6-11ea-9593-e2e2ce6d1155.png">
