### PR TITLE
fix(frontend): training mode solveCount calculation

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -55,14 +55,15 @@ export const calcTotalResult = (
         return state;
       }
 
+      const additionalPoint = point ? point : best.point;
       return {
         trialsBeforeBest: state.trialsBeforeBest + info.trialsBeforeBest,
         lastBestSubmissionTime: Math.max(
           state.lastBestSubmissionTime,
           best.epoch_second
         ),
-        point: state.point + (point ? point : best.point),
-        solveCount: state.solveCount + (point ? 1 : 0),
+        point: state.point + additionalPoint,
+        solveCount: state.solveCount + (additionalPoint > 0 ? 1 : 0),
       };
     },
     {


### PR DESCRIPTION
この前 `point` の意味を勘違いして、`solveCount` の計算が間違いました。

この commit の後、`solveCount` の計算は正しくなったと思います。