### PR TITLE
fixed navbar collapse size (#656)

### DIFF
--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -113,7 +113,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
     <Navbar
       color="light"
       light
-      expand="lg"
+      expand="md"
       className="border-bottom"
       style={{ padding: 0 }}
     >
@@ -121,7 +121,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
         <Nav navbar style={{ padding: "0.5rem 1rem" }}>
           <Form inline>
             <Input
-              className="mt-2 mr-2 mt-lg-0"
+              className="mt-2 mr-2 mt-lg-0 mt-md-0"
               style={{ width: 160 }}
               onKeyPress={(e): void => {
                 if (e.key === "Enter") {
@@ -137,7 +137,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
             />
 
             <Input
-              className="mt-2 mr-2 mt-lg-0"
+              className="mt-2 mr-2 mt-lg-0 mt-md-0"
               style={{ width: 160 }}
               onKeyPress={(e): void => {
                 if (e.key === "Enter") {
@@ -152,7 +152,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setRivalIdString(e.target.value)}
             />
 
-            <ButtonGroup className="mt-2 mb-0 mt-lg-0">
+            <ButtonGroup className="mt-2 mb-0 mt-lg-0 mt-md-0">
               <Button tag={RouterLink} to={tablePath} color="light">
                 Table
               </Button>


### PR DESCRIPTION
window幅768px以上のときにUserSearchBarが出現するように修正しました。

これが
![Screenshot from 2020-07-08 21-08-07](https://user-images.githubusercontent.com/37650565/86917408-013cbb80-c160-11ea-8ee7-02e05a20a053.png)

768px以上のときに
![Screenshot from 2020-07-08 21-06-33](https://user-images.githubusercontent.com/37650565/86917415-03067f00-c160-11ea-972d-561e2ccb3ed4.png)

768px未満(スマホサイズ用)のときは修正前のままで
![Screenshot from 2020-07-08 21-07-43](https://user-images.githubusercontent.com/37650565/86917540-2c270f80-c160-11ea-9463-e7b3b2724e3e.png)

