### PR TITLE
refactor: migrate everything from VirtualContest to VirtualContestInfo

### DIFF
--- a/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
+++ b/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
@@ -11,25 +11,10 @@ use internal_virtual_contest_items as v_items;
 use internal_virtual_contest_participants as v_participants;
 use internal_virtual_contests as v_contests;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
 
 const MAX_PROBLEM_NUM_PER_CONTEST: usize = 100;
 const RECENT_CONTEST_NUM: i64 = 1000;
-
-type VirtualContestTuple = (
-    String,         //id
-    String,         //title
-    String,         //memo
-    String,         //user_id
-    i64,            //start
-    i64,            //duration
-    Option<String>, //problem_id
-    Option<String>, //atcoder_user_id
-    Option<String>, //mode
-    Option<i64>,    //point
-    Option<i64>,    //order
-);
 
 #[derive(Serialize, Queryable)]
 pub struct VirtualContestInfo {
@@ -44,20 +29,6 @@ pub struct VirtualContestInfo {
     pub(crate) mode: Option<String>,
 
     pub(crate) is_public: bool,
-}
-
-#[deprecated(note = "want to migrate to VirtualContestInfo")]
-#[derive(Serialize)]
-pub struct VirtualContest {
-    id: String,
-    title: String,
-    memo: String,
-    owner_user_id: String,
-    pub(crate) start_epoch_second: i64,
-    pub(crate) duration_second: i64,
-    mode: Option<String>,
-    pub(crate) problems: Vec<VirtualContestItem>,
-    participants: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -89,8 +60,8 @@ pub trait VirtualContestManager {
         is_public: bool,
     ) -> Result<()>;
 
-    fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContest>>;
-    fn get_participated_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContest>>;
+    fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>>;
+    fn get_participated_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>>;
     fn get_single_contest_info(&self, contest_id: &str) -> Result<VirtualContestInfo>;
     fn get_single_contest_participants(&self, contest_id: &str) -> Result<Vec<String>>;
     fn get_single_contest_problems(&self, contest_id: &str) -> Result<Vec<VirtualContestItem>>;
@@ -156,67 +127,22 @@ impl VirtualContestManager for PgConnection {
             .execute(self)?;
         Ok(())
     }
-    fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContest>> {
+    fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>> {
         let data = v_contests::table
-            .left_join(v_items::table.on(v_items::internal_virtual_contest_id.eq(v_contests::id)))
-            .left_join(
-                v_participants::table
-                    .on(v_participants::internal_virtual_contest_id.eq(v_contests::id)),
-            )
-            .left_join(
-                i_users::table.on(v_participants::internal_user_id.eq(i_users::internal_user_id)),
-            )
             .filter(v_contests::internal_user_id.eq(internal_user_id))
-            .select((
-                v_contests::id,
-                v_contests::title,
-                v_contests::memo,
-                v_contests::internal_user_id,
-                v_contests::start_epoch_second,
-                v_contests::duration_second,
-                v_items::problem_id.nullable(),
-                i_users::atcoder_user_id.nullable(),
-                v_contests::mode,
-                v_items::user_defined_point,
-                v_items::user_defined_order,
-            ))
-            .load::<VirtualContestTuple>(self)?;
-
-        let virtual_contests = construct_virtual_contests(data);
-        Ok(virtual_contests)
+            .load::<VirtualContestInfo>(self)?;
+        Ok(data)
     }
-    fn get_participated_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContest>> {
-        let participated_contest_ids = v_participants::table
-            .filter(v_participants::internal_user_id.eq(internal_user_id))
-            .select(v_participants::internal_virtual_contest_id)
-            .load::<String>(self)?;
-
+    fn get_participated_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>> {
         let data = v_contests::table
-            .left_join(v_items::table.on(v_items::internal_virtual_contest_id.eq(v_contests::id)))
             .left_join(
                 v_participants::table
                     .on(v_participants::internal_virtual_contest_id.eq(v_contests::id)),
             )
-            .left_join(
-                i_users::table.on(v_participants::internal_user_id.eq(i_users::internal_user_id)),
-            )
-            .filter(v_contests::id.eq_any(participated_contest_ids))
-            .select((
-                v_contests::id,
-                v_contests::title,
-                v_contests::memo,
-                v_contests::internal_user_id,
-                v_contests::start_epoch_second,
-                v_contests::duration_second,
-                v_items::problem_id.nullable(),
-                i_users::atcoder_user_id.nullable(),
-                v_contests::mode,
-                v_items::user_defined_point,
-                v_items::user_defined_order,
-            ))
-            .load::<VirtualContestTuple>(self)?;
-        let virtual_contests = construct_virtual_contests(data);
-        Ok(virtual_contests)
+            .filter(v_participants::internal_user_id.eq(internal_user_id))
+            .select(v_contests::all_columns)
+            .load::<VirtualContestInfo>(self)?;
+        Ok(data)
     }
 
     fn get_running_contest_problems(&self, time: i64) -> Result<Vec<String>> {
@@ -336,63 +262,4 @@ impl VirtualContestManager for PgConnection {
         .execute(self)?;
         Ok(())
     }
-}
-
-fn construct_virtual_contests(data: Vec<VirtualContestTuple>) -> Vec<VirtualContest> {
-    let mut contest_set = BTreeSet::new();
-    let mut problem_map = BTreeMap::new();
-    let mut participants = BTreeMap::new();
-    for (id, title, memo, owner, start, duration, problem_id, user_id, mode, point, order) in
-        data.into_iter()
-    {
-        contest_set.insert((id.clone(), title, memo, owner, start, duration, mode));
-        if let Some(problem_id) = problem_id {
-            problem_map
-                .entry(id.clone())
-                .or_insert_with(BTreeSet::new)
-                .insert((problem_id, point, order));
-        }
-        if let Some(user_id) = user_id {
-            participants
-                .entry(id)
-                .or_insert_with(BTreeSet::new)
-                .insert(user_id);
-        }
-    }
-
-    contest_set
-        .into_iter()
-        .map(
-            |(id, title, memo, owner_user_id, start_epoch_second, duration_second, mode)| {
-                let problems = problem_map
-                    .get(&id)
-                    .map(|set| {
-                        set.iter()
-                            .cloned()
-                            .map(|(problem_id, point, order)| VirtualContestItem {
-                                id: problem_id,
-                                point,
-                                order,
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_else(Vec::new);
-                let participants = participants
-                    .get(&id)
-                    .map(|set| set.iter().cloned().collect::<Vec<_>>())
-                    .unwrap_or_else(Vec::new);
-                VirtualContest {
-                    id,
-                    title,
-                    memo,
-                    owner_user_id,
-                    start_epoch_second,
-                    duration_second,
-                    problems,
-                    participants,
-                    mode,
-                }
-            },
-        )
-        .collect::<Vec<_>>()
 }

--- a/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
@@ -69,7 +69,7 @@ async fn test_virtual_contest() -> Result<()> {
     let mut response = surf::post(url("/internal-api/contest/create", port))
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
-            "title":"contest title",
+            "title": "contest title",
             "memo": "contest memo",
             "start_epoch_second": 1,
             "duration_second": 2
@@ -83,7 +83,7 @@ async fn test_virtual_contest() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "id": format!("{}", contest_id),
-            "title":"contest title",
+            "title": "contest title",
             "memo": "contest memo",
             "start_epoch_second": 1,
             "duration_second": 2
@@ -105,9 +105,8 @@ async fn test_virtual_contest() -> Result<()> {
                 "memo": "contest memo",
                 "title": "contest title",
                 "id": format!("{}", contest_id),
-                "participants": [],
-                "problems": [],
-                "mode": null
+                "mode": null,
+                "is_public": true,
             }
         ])
     );
@@ -140,9 +139,8 @@ async fn test_virtual_contest() -> Result<()> {
                 "memo": "contest memo",
                 "title": "contest title",
                 "id": format!("{}", contest_id),
-                "participants": ["atcoder_user1"],
-                "problems": [],
-                "mode": null
+                "mode": null,
+                "is_public": true,
             }
         ])
     );
@@ -183,9 +181,8 @@ async fn test_virtual_contest() -> Result<()> {
                 "memo": "contest memo",
                 "title": "contest title",
                 "id": format!("{}", contest_id),
-                "participants": ["atcoder_user1"],
-                "problems": [],
-                "mode": null
+                "mode": null,
+                "is_public": true,
             }
         ])
     );
@@ -194,7 +191,7 @@ async fn test_virtual_contest() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "contest_id": format!("{}", contest_id),
-            "problems": [{"id":"problem_1", "point":100}],
+            "problems": [{ "id": "problem_1", "point": 100 }],
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -203,7 +200,7 @@ async fn test_virtual_contest() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "contest_id": format!("{}", contest_id),
-            "problems": [{"id":"problem_1", "point":100}],
+            "problems": [{ "id": "problem_1", "point": 100 }],
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -212,7 +209,7 @@ async fn test_virtual_contest() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "contest_id": format!("{}", contest_id),
-            "problems": [{"id":"problem_1", "point":100}, {"id": "problem_2"}],
+            "problems": [{ "id": "problem_1", "point": 100 }, { "id": "problem_2" }],
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -231,9 +228,8 @@ async fn test_virtual_contest() -> Result<()> {
                 "memo": "contest memo",
                 "title": "contest title",
                 "id": format!("{}", contest_id),
-                "participants": ["atcoder_user1"],
-                "problems": [{"id":"problem_1", "point":100, "order":null}, {"id": "problem_2", "point":null, "order":null}],
-                "mode":null,
+                "mode": null,
+                "is_public": true,
             }
         ])
     );
@@ -257,7 +253,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "mode": null,
                 "is_public": true,
             },
-            "problems": [{"id":"problem_1", "point":100, "order":null}, {"id": "problem_2", "point":null, "order":null}],
+            "problems": [{ "id": "problem_1", "point": 100, "order": null }, { "id": "problem_2", "point": null, "order": null }],
             "participants": ["atcoder_user1"],
         })
     );
@@ -274,7 +270,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "start_epoch_second": 1,
                 "memo": "contest memo",
                 "title": "contest title",
-                "is_public":true,
+                "is_public": true,
                 "id": format!("{}", contest_id),
                 "mode": null
             }
@@ -303,7 +299,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
     let mut response = surf::post(url("/internal-api/contest/create", port))
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
-            "title":"visible",
+            "title": "visible",
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2
@@ -323,7 +319,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "id": format!("{}", contest_id),
-            "title":"invisible",
+            "title": "invisible",
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
@@ -340,7 +336,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
     let mut response = surf::post(url("/internal-api/contest/create", port))
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
-            "title":"invisible",
+            "title": "invisible",
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
@@ -360,7 +356,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
             "id": contest_id,
-            "title":"visible",
+            "title": "visible",
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,

--- a/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/MyContestList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/MyContestList.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { connect, PromiseState } from "react-refetch";
 import { VirtualContestTable } from "../VirtualContestTable";
-import { VirtualContest } from "../types";
+import { VirtualContestInfo } from "../types";
 import { CONTEST_JOINED, CONTEST_MY } from "../ApiUrl";
 
 interface Props {
-  ownedContestsGet: PromiseState<VirtualContest[] | null>;
-  joinedContestsGet: PromiseState<VirtualContest[] | null>;
+  ownedContestsGet: PromiseState<VirtualContestInfo[] | null>;
+  joinedContestsGet: PromiseState<VirtualContestInfo[] | null>;
 }
 const InnerMyContestList: React.FC<Props> = (props) => {
   const history = useHistory();

--- a/atcoder-problems-frontend/src/pages/Internal/types.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/types.ts
@@ -28,11 +28,6 @@ export interface VirtualContestInfo {
   readonly is_public: boolean;
 }
 
-export interface VirtualContest extends VirtualContestInfo {
-  readonly problems: VirtualContestItem[];
-  readonly participants: string[];
-}
-
 export interface VirtualContestDetails {
   readonly info: VirtualContestInfo;
   readonly problems: VirtualContestItem[];


### PR DESCRIPTION
`VirtualContest` は deprecated のため、`get_own_contests` と `get_participated_contests` を `VirtualContestInfo` に移行しました。

E2E Tests とフロントエンドのコードも変えました。