### PR TITLE
feat(frontend): improve ContestConfig UI

### DIFF
--- a/atcoder-problems-frontend/src/components/HelpBadgeModal.tsx
+++ b/atcoder-problems-frontend/src/components/HelpBadgeModal.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import { Modal, ModalHeader, ModalBody, Badge, Tooltip } from "reactstrap";
+
+interface Props {
+  id: string;
+  children: React.ReactNode;
+  title?: React.ReactNode;
+  tooltipText?: React.ReactNode;
+}
+
+const HelpBadgeModal = (props: Props) => {
+  const { title, children, id, tooltipText } = props;
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isTooltipOpen, setTooltipOpen] = useState(false);
+
+  const toggleModal = (): void => setModalOpen(!isModalOpen);
+  const badgeId = "HelpBadgeTooltipModal-" + id;
+
+  return (
+    <>
+      <Badge
+        color="secondary"
+        pill
+        id={badgeId}
+        style={{ cursor: "pointer" }}
+        onClick={toggleModal}
+      >
+        ?
+      </Badge>
+      <Tooltip
+        placement="top"
+        target={badgeId}
+        isOpen={isTooltipOpen}
+        toggle={(): void => setTooltipOpen(!isTooltipOpen)}
+      >
+        {tooltipText ?? "Click to see detailed explanation."}
+      </Tooltip>
+      <Modal isOpen={isModalOpen} toggle={toggleModal}>
+        <ModalHeader toggle={toggleModal}>{title ?? "Help"}</ModalHeader>
+        <ModalBody>{children}</ModalBody>
+      </Modal>
+    </>
+  );
+};
+
+export default HelpBadgeModal;

--- a/atcoder-problems-frontend/src/components/HelpBadgeModal.tsx
+++ b/atcoder-problems-frontend/src/components/HelpBadgeModal.tsx
@@ -8,7 +8,7 @@ interface Props {
   tooltipText?: React.ReactNode;
 }
 
-const HelpBadgeModal = (props: Props) => {
+export const HelpBadgeModal = (props: Props) => {
   const { title, children, id, tooltipText } = props;
   const [isModalOpen, setModalOpen] = useState(false);
   const [isTooltipOpen, setTooltipOpen] = useState(false);
@@ -42,5 +42,3 @@ const HelpBadgeModal = (props: Props) => {
     </>
   );
 };
-
-export default HelpBadgeModal;

--- a/atcoder-problems-frontend/src/components/ProblemSearchBox.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSearchBox.tsx
@@ -41,7 +41,7 @@ export const ProblemSearchBox: React.FC<Props> = (props) => {
     <>
       <Input
         type="text"
-        placeholder="Search Problems"
+        placeholder="Search here to add problems."
         value={problemSearch}
         onChange={(e): void => {
           setProblemSearch(e.target.value);

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -30,7 +30,7 @@ import {
 import ProblemModel from "../../../interfaces/ProblemModel";
 import { ProblemSetGenerator } from "../../../components/ProblemSetGenerator";
 import HelpBadgeTooltip from "../../../components/HelpBadgeTooltip";
-import HelpBadgeModal from "../../../components/HelpBadgeModal";
+import { HelpBadgeModal } from "../../../components/HelpBadgeModal";
 import ContestConfigProblemList from "./ContestConfigProblemList";
 
 const toUnixSecond = (date: string, hour: number, minute: number): number => {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -105,6 +105,8 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
         </Col>
       </Row>
 
+      <h2 className="my-3">Contest Information</h2>
+
       <Row className="my-2">
         <Col>
           <Label>Contest Title</Label>
@@ -121,7 +123,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
         <Col>
           <Label>Description</Label>
           <Input
-            type="text"
+            type="textarea"
             placeholder="Description"
             value={memo}
             onChange={(event): void => setMemo(event.target.value)}
@@ -187,7 +189,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setStartHour(Number(e.target.value))}
             >
               {Range(0, 24).map((i) => (
-                <option key={i}>{i}</option>
+                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
               ))}
             </Input>
             <Input
@@ -196,7 +198,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setStartMinute(Number(e.target.value))}
             >
               {Range(0, 60, 5).map((i) => (
-                <option key={i}>{i}</option>
+                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
               ))}
             </Input>
           </InputGroup>
@@ -218,7 +220,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setEndHour(Number(e.target.value))}
             >
               {Range(0, 24).map((i) => (
-                <option key={i}>{i}</option>
+                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
               ))}
             </Input>
             <Input
@@ -227,7 +229,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setEndMinute(Number(e.target.value))}
             >
               {Range(0, 60, 5).map((i) => (
-                <option key={i}>{i}</option>
+                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
               ))}
             </Input>
           </InputGroup>
@@ -237,7 +239,7 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
       <Row className="my-2">
         <Col>
           <Label>
-            Expected Participants
+            Expected Participants{" "}
             <HelpBadgeTooltip id={"help-expected-participants"}>
               This list is used for checking if the problems in the list are
               already solved by each participant.
@@ -257,13 +259,9 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
         </Col>
       </Row>
 
-      <Row>
-        <Col>
-          <Label>Problems</Label>
-        </Col>
-      </Row>
+      <h2 className="my-3">Contest Problemset</h2>
 
-      <Row>
+      <Row className="my-2">
         <Col>
           <ContestConfigProblemList
             onSolvedProblemsFetchFinished={(errorMessage): void => {
@@ -287,10 +285,19 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
         </Col>
       </Row>
 
+      <h2 className="my-3">
+        Bacha Gacha{" "}
+        <HelpBadgeTooltip id={"help-bacha-gacha"}>
+          This is a feature that helps you generate problems by picking problems
+          within certain ranges of difficulties, which is then appended to your
+          problemset.
+        </HelpBadgeTooltip>
+      </h2>
+
       <Row>
         <Col>
           <div style={{ padding: 8, border: "solid 1px lightgray" }}>
-            <Label>Bacha Gacha</Label>
+            <Label>Options</Label>
 
             <Row className="my-2">
               <Col>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -30,6 +30,7 @@ import {
 import ProblemModel from "../../../interfaces/ProblemModel";
 import { ProblemSetGenerator } from "../../../components/ProblemSetGenerator";
 import HelpBadgeTooltip from "../../../components/HelpBadgeTooltip";
+import HelpBadgeModal from "../../../components/HelpBadgeModal";
 import ContestConfigProblemList from "./ContestConfigProblemList";
 
 const toUnixSecond = (date: string, hour: number, minute: number): number => {
@@ -154,7 +155,26 @@ const ContestConfig: React.FC<InnerProps> = (props) => {
 
       <Row className="my-2">
         <Col>
-          <Label>Mode</Label>
+          <Label>
+            Mode{" "}
+            <HelpBadgeModal
+              title="Explanation of Different Modes"
+              id="help-virtual-contest-modes"
+            >
+              <p>
+                <b>Normal:</b> similar to normal contests. Contestants are
+                ranked by total score, then penalty.
+              </p>
+              <p>
+                <b>Lockout:</b> only the first contestant who solved the problem
+                gets the score for the problem.
+              </p>
+              <p>
+                <b>Training:</b> contestants are ranked by total number of
+                solved problems, then time of last accepted submission.
+              </p>
+            </HelpBadgeModal>
+          </Label>
           <InputGroup>
             <UncontrolledDropdown>
               <DropdownToggle caret>{formatMode(mode)}</DropdownToggle>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfigProblemList.tsx
@@ -22,6 +22,13 @@ const ContestConfigProblemList: React.FC<InnerProps> = (props) => {
   const { problemSet } = props;
   return (
     <ListGroup>
+      {problemSet.isEmpty() && (
+        <ListGroupItem>
+          You have not added any problems yet. Use the search box below to
+          search for problems to add to the contest.
+        </ListGroupItem>
+      )}
+
       {problemSet.valueSeq().map((p, i) => {
         const problemId = p.id;
         const problem = props.problemMap.get(problemId);


### PR DESCRIPTION
新しいユーザーがコンテストを作るときの問題とこのページをもっと分かりやすくするように、`ContestConfig` を変えました。

* ページをセクションに分けました。（Contest Information、Contest Problemset、Bacha Gacha）
* Description を `text` → `textarea` にしました。
* Mode が多くなったため、詳しい説明を追加しました。
* 時間のテキストを変えました。（`0` → `00` など）
* 問題がないとき、説明を追加しました。
* `ProblemSearchBox` の `placeholder` を変えました。
* Bacha Gacha の説明を追加しました。

# プレビュー

## Full Page

![image](https://user-images.githubusercontent.com/6523469/87329636-d42a4780-c569-11ea-8000-6ff31c520f0d.png)

## Modes Explanation

![image](https://user-images.githubusercontent.com/6523469/87329754-08056d00-c56a-11ea-8b97-5a2c7c28914c.png)
![image](https://user-images.githubusercontent.com/6523469/87329738-0340b900-c56a-11ea-8191-e1fe49865802.png)

## Bacha Gacha Tooltip

![image](https://user-images.githubusercontent.com/6523469/87329711-f623ca00-c569-11ea-82f9-86ca060f331a.png)
