### PR TITLE
feat: add penalty to virtual contest

### DIFF
--- a/atcoder-problems-backend/src/server/virtual_contest.rs
+++ b/atcoder-problems-backend/src/server/virtual_contest.rs
@@ -19,6 +19,7 @@ where
         duration_second: i64,
         mode: Option<String>,
         is_public: Option<bool>,
+        penalty: f64,
     }
     let (q, conn, user_id) = request.post_unpack::<Q>().await?;
     let contest_id = conn.create_contest(
@@ -29,6 +30,7 @@ where
         q.duration_second,
         q.mode.as_deref(),
         q.is_public.unwrap_or(true),
+        q.penalty,
     )?;
     let body = serde_json::json!({ "contest_id": contest_id });
     let response = Response::ok().body_json(&body)?;
@@ -48,6 +50,7 @@ where
         duration_second: i64,
         mode: Option<String>,
         is_public: Option<bool>,
+        penalty: f64,
     }
 
     let (q, conn, _) = request.post_unpack::<Q>().await?;
@@ -59,6 +62,7 @@ where
         q.duration_second,
         q.mode.as_deref(),
         q.is_public.unwrap_or(true),
+        q.penalty,
     )?;
     Ok(Response::ok().body_json(&serde_json::json!({}))?)
 }

--- a/atcoder-problems-backend/src/server/virtual_contest.rs
+++ b/atcoder-problems-backend/src/server/virtual_contest.rs
@@ -19,7 +19,7 @@ where
         duration_second: i64,
         mode: Option<String>,
         is_public: Option<bool>,
-        penalty: f64,
+        penalty_second: i64,
     }
     let (q, conn, user_id) = request.post_unpack::<Q>().await?;
     let contest_id = conn.create_contest(
@@ -30,7 +30,7 @@ where
         q.duration_second,
         q.mode.as_deref(),
         q.is_public.unwrap_or(true),
-        q.penalty,
+        q.penalty_second,
     )?;
     let body = serde_json::json!({ "contest_id": contest_id });
     let response = Response::ok().body_json(&body)?;
@@ -50,7 +50,7 @@ where
         duration_second: i64,
         mode: Option<String>,
         is_public: Option<bool>,
-        penalty: f64,
+        penalty_second: i64,
     }
 
     let (q, conn, _) = request.post_unpack::<Q>().await?;
@@ -62,7 +62,7 @@ where
         q.duration_second,
         q.mode.as_deref(),
         q.is_public.unwrap_or(true),
-        q.penalty,
+        q.penalty_second,
     )?;
     Ok(Response::ok().body_json(&serde_json::json!({}))?)
 }

--- a/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
+++ b/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
@@ -29,7 +29,7 @@ pub struct VirtualContestInfo {
     pub(crate) mode: Option<String>,
 
     pub(crate) is_public: bool,
-    pub(crate) penalty: f64,
+    pub(crate) penalty_second: i64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -49,7 +49,7 @@ pub trait VirtualContestManager {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
-        penalty: f64,
+        penalty_second: i64,
     ) -> Result<String>;
     fn update_contest(
         &self,
@@ -60,7 +60,7 @@ pub trait VirtualContestManager {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
-        penalty: f64,
+        penalty_second: i64,
     ) -> Result<()>;
 
     fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>>;
@@ -92,7 +92,7 @@ impl VirtualContestManager for PgConnection {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
-        penalty: f64,
+        penalty_second: i64,
     ) -> Result<String> {
         let uuid = Uuid::new_v4().to_string();
         insert_into(v_contests::table)
@@ -105,7 +105,7 @@ impl VirtualContestManager for PgConnection {
                 v_contests::duration_second.eq(duration_second),
                 v_contests::mode.eq(mode),
                 v_contests::is_public.eq(is_public),
-                v_contests::penalty.eq(penalty),
+                v_contests::penalty_second.eq(penalty_second),
             )])
             .execute(self)?;
         Ok(uuid)
@@ -119,7 +119,7 @@ impl VirtualContestManager for PgConnection {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
-        penalty: f64,
+        penalty_second: i64,
     ) -> Result<()> {
         update(v_contests::table.filter(v_contests::id.eq(id)))
             .set((
@@ -129,7 +129,7 @@ impl VirtualContestManager for PgConnection {
                 v_contests::duration_second.eq(duration_second),
                 v_contests::mode.eq(mode),
                 v_contests::is_public.eq(is_public),
-                v_contests::penalty.eq(penalty),
+                v_contests::penalty_second.eq(penalty_second),
             ))
             .execute(self)?;
         Ok(())

--- a/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
+++ b/atcoder-problems-backend/src/sql/internal/virtual_contest_manager.rs
@@ -29,6 +29,7 @@ pub struct VirtualContestInfo {
     pub(crate) mode: Option<String>,
 
     pub(crate) is_public: bool,
+    pub(crate) penalty: f64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -48,6 +49,7 @@ pub trait VirtualContestManager {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
+        penalty: f64,
     ) -> Result<String>;
     fn update_contest(
         &self,
@@ -58,6 +60,7 @@ pub trait VirtualContestManager {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
+        penalty: f64,
     ) -> Result<()>;
 
     fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>>;
@@ -89,6 +92,7 @@ impl VirtualContestManager for PgConnection {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
+        penalty: f64,
     ) -> Result<String> {
         let uuid = Uuid::new_v4().to_string();
         insert_into(v_contests::table)
@@ -101,6 +105,7 @@ impl VirtualContestManager for PgConnection {
                 v_contests::duration_second.eq(duration_second),
                 v_contests::mode.eq(mode),
                 v_contests::is_public.eq(is_public),
+                v_contests::penalty.eq(penalty),
             )])
             .execute(self)?;
         Ok(uuid)
@@ -114,6 +119,7 @@ impl VirtualContestManager for PgConnection {
         duration_second: i64,
         mode: Option<&str>,
         is_public: bool,
+        penalty: f64,
     ) -> Result<()> {
         update(v_contests::table.filter(v_contests::id.eq(id)))
             .set((
@@ -123,6 +129,7 @@ impl VirtualContestManager for PgConnection {
                 v_contests::duration_second.eq(duration_second),
                 v_contests::mode.eq(mode),
                 v_contests::is_public.eq(is_public),
+                v_contests::penalty.eq(penalty),
             ))
             .execute(self)?;
         Ok(())

--- a/atcoder-problems-backend/src/sql/schema.rs
+++ b/atcoder-problems-backend/src/sql/schema.rs
@@ -181,6 +181,7 @@ table! {
         duration_second -> Int8,
         mode -> Nullable<Varchar>,
         is_public -> Bool,
+        penalty -> Float8,
     }
 }
 

--- a/atcoder-problems-backend/src/sql/schema.rs
+++ b/atcoder-problems-backend/src/sql/schema.rs
@@ -181,7 +181,7 @@ table! {
         duration_second -> Int8,
         mode -> Nullable<Varchar>,
         is_public -> Bool,
-        penalty -> Float8,
+        penalty_second -> Int8,
     }
 }
 

--- a/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
@@ -62,7 +62,7 @@ async fn test_virtual_contest() -> Result<()> {
     let response = surf::post(url("/internal-api/user/update", port))
         .set_header("Cookie", cookie_header.as_str())
         .body_json(&json!({
-                "atcoder_user_id": "atcoder_user1"
+            "atcoder_user_id": "atcoder_user1"
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -72,7 +72,8 @@ async fn test_virtual_contest() -> Result<()> {
             "title": "contest title",
             "memo": "contest memo",
             "start_epoch_second": 1,
-            "duration_second": 2
+            "duration_second": 2,
+            "penalty": 0.0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -86,7 +87,8 @@ async fn test_virtual_contest() -> Result<()> {
             "title": "contest title",
             "memo": "contest memo",
             "start_epoch_second": 1,
-            "duration_second": 2
+            "duration_second": 2,
+            "penalty": 300.0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -107,6 +109,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
+                "penalty": 300.0,
             }
         ])
     );
@@ -141,6 +144,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
+                "penalty": 300.0,
             }
         ])
     );
@@ -183,6 +187,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
+                "penalty": 300.0,
             }
         ])
     );
@@ -230,6 +235,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
+                "penalty": 300.0,
             }
         ])
     );
@@ -252,6 +258,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
+                "penalty": 300.0,
             },
             "problems": [{ "id": "problem_1", "point": 100, "order": null }, { "id": "problem_2", "point": null, "order": null }],
             "participants": ["atcoder_user1"],
@@ -272,7 +279,8 @@ async fn test_virtual_contest() -> Result<()> {
                 "title": "contest title",
                 "is_public": true,
                 "id": format!("{}", contest_id),
-                "mode": null
+                "mode": null,
+                "penalty": 300.0,
             }
         ])
     );
@@ -302,7 +310,8 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "title": "visible",
             "memo": "",
             "start_epoch_second": 1,
-            "duration_second": 2
+            "duration_second": 2,
+            "penalty": 300.0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -323,7 +332,8 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "is_public": false
+            "is_public": false,
+            "penalty": 300.0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -340,7 +350,8 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "is_public": false
+            "is_public": false,
+            "penalty": 300.0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -360,7 +371,8 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "is_public": true
+            "is_public": true,
+            "penalty": 300.0,
         }))?
         .await?;
     assert!(response.status().is_success());

--- a/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_virtual_contest.rs
@@ -73,7 +73,7 @@ async fn test_virtual_contest() -> Result<()> {
             "memo": "contest memo",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "penalty": 0.0,
+            "penalty_second": 0,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -88,7 +88,7 @@ async fn test_virtual_contest() -> Result<()> {
             "memo": "contest memo",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "penalty": 300.0,
+            "penalty_second": 300,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -109,7 +109,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
-                "penalty": 300.0,
+                "penalty_second": 300,
             }
         ])
     );
@@ -144,7 +144,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
-                "penalty": 300.0,
+                "penalty_second": 300,
             }
         ])
     );
@@ -187,7 +187,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
-                "penalty": 300.0,
+                "penalty_second": 300,
             }
         ])
     );
@@ -235,7 +235,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
-                "penalty": 300.0,
+                "penalty_second": 300,
             }
         ])
     );
@@ -258,7 +258,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "id": format!("{}", contest_id),
                 "mode": null,
                 "is_public": true,
-                "penalty": 300.0,
+                "penalty_second": 300,
             },
             "problems": [{ "id": "problem_1", "point": 100, "order": null }, { "id": "problem_2", "point": null, "order": null }],
             "participants": ["atcoder_user1"],
@@ -280,7 +280,7 @@ async fn test_virtual_contest() -> Result<()> {
                 "is_public": true,
                 "id": format!("{}", contest_id),
                 "mode": null,
-                "penalty": 300.0,
+                "penalty_second": 300,
             }
         ])
     );
@@ -311,7 +311,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "memo": "",
             "start_epoch_second": 1,
             "duration_second": 2,
-            "penalty": 300.0,
+            "penalty_second": 300,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -333,7 +333,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "start_epoch_second": 1,
             "duration_second": 2,
             "is_public": false,
-            "penalty": 300.0,
+            "penalty_second": 300,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -351,7 +351,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "start_epoch_second": 1,
             "duration_second": 2,
             "is_public": false,
-            "penalty": 300.0,
+            "penalty_second": 300,
         }))?
         .await?;
     assert!(response.status().is_success());
@@ -372,7 +372,7 @@ async fn test_virtual_contest_visibility() -> Result<()> {
             "start_epoch_second": 1,
             "duration_second": 2,
             "is_public": true,
-            "penalty": 300.0,
+            "penalty_second": 300,
         }))?
         .await?;
     assert!(response.status().is_success());

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -53,7 +53,9 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
   const [problemSet, setProblemSet] = useState(props.initialProblems);
   const [mode, setMode] = useState(props.initialMode);
   const [publicState, setPublicState] = useState(props.initialPublicState);
-  const [penalty, setPenalty] = useState(props.initialPenalty);
+  const [penaltySecond, setPenaltySecond] = useState(
+    props.initialPenaltySecond
+  );
   const [
     expectedParticipantUserIdsText,
     setExpectedParticipantUserIdsText,
@@ -201,8 +203,10 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
           <Input
             type="number"
             placeholder="Penalty for each wrong submission in seconds"
-            defaultValue={penalty}
-            onChange={(event): void => setPenalty(event.target.valueAsNumber)}
+            defaultValue={penaltySecond}
+            onChange={(event): void =>
+              setPenaltySecond(event.target.valueAsNumber)
+            }
           />
         </Col>
       </Row>
@@ -365,7 +369,7 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
                 problems: problemSet,
                 mode,
                 publicState,
-                penalty,
+                penaltySecond,
               })
             }
           >
@@ -384,7 +388,7 @@ interface ContestInfo {
   endSecond: number;
   mode: VirtualContestMode;
   publicState: boolean;
-  penalty: number;
+  penaltySecond: number;
   problems: List<VirtualContestItem>;
 }
 
@@ -401,7 +405,7 @@ interface OuterProps {
   initialEndMinute: number;
   initialMode: VirtualContestMode;
   initialPublicState: boolean;
-  initialPenalty: number;
+  initialPenaltySecond: number;
 
   buttonPush: (contest: ContestInfo) => void;
   buttonTitle: string;

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -53,6 +53,7 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
   const [problemSet, setProblemSet] = useState(props.initialProblems);
   const [mode, setMode] = useState(props.initialMode);
   const [publicState, setPublicState] = useState(props.initialPublicState);
+  const [penalty, setPenalty] = useState(props.initialPenalty);
   const [
     expectedParticipantUserIdsText,
     setExpectedParticipantUserIdsText,
@@ -191,6 +192,18 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
               </DropdownMenu>
             </UncontrolledDropdown>
           </InputGroup>
+        </Col>
+      </Row>
+
+      <Row className="my-2">
+        <Col>
+          <Label>Penalty (seconds)</Label>
+          <Input
+            type="number"
+            placeholder="Penalty for each wrong submission in seconds"
+            defaultValue={penalty}
+            onChange={(event): void => setPenalty(event.target.valueAsNumber)}
+          />
         </Col>
       </Row>
 
@@ -352,6 +365,7 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
                 problems: problemSet,
                 mode,
                 publicState,
+                penalty,
               })
             }
           >
@@ -370,6 +384,7 @@ interface ContestInfo {
   endSecond: number;
   mode: VirtualContestMode;
   publicState: boolean;
+  penalty: number;
   problems: List<VirtualContestItem>;
 }
 
@@ -386,6 +401,7 @@ interface OuterProps {
   initialEndMinute: number;
   initialMode: VirtualContestMode;
   initialPublicState: boolean;
+  initialPenalty: number;
 
   buttonPush: (contest: ContestInfo) => void;
   buttonTitle: string;

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
@@ -40,6 +40,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
       initialProblems={List()}
       initialMode={null}
       initialPublicState={false}
+      initialPenalty={300}
       buttonTitle="Create Contest"
       buttonPush={({
         title,
@@ -49,6 +50,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
         problems,
         mode,
         publicState,
+        penalty,
       }): void =>
         props.createContest(
           {
@@ -58,6 +60,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
             duration_second: endSecond - startSecond,
             mode,
             is_public: publicState,
+            penalty,
           },
           problems.toArray()
         )
@@ -73,6 +76,7 @@ interface Request {
   duration_second: number;
   mode: VirtualContestMode;
   is_public: boolean;
+  penalty: number;
 }
 
 interface Response {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestCreatePage.tsx
@@ -40,7 +40,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
       initialProblems={List()}
       initialMode={null}
       initialPublicState={false}
-      initialPenalty={300}
+      initialPenaltySecond={300}
       buttonTitle="Create Contest"
       buttonPush={({
         title,
@@ -50,7 +50,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
         problems,
         mode,
         publicState,
-        penalty,
+        penaltySecond,
       }): void =>
         props.createContest(
           {
@@ -60,7 +60,7 @@ const InnerContestCreatePage: React.FC<InnerProps> = (props) => {
             duration_second: endSecond - startSecond,
             mode,
             is_public: publicState,
-            penalty,
+            penalty_second: penaltySecond,
           },
           problems.toArray()
         )
@@ -76,7 +76,7 @@ interface Request {
   duration_second: number;
   mode: VirtualContestMode;
   is_public: boolean;
-  penalty: number;
+  penalty_second: number;
 }
 
 interface Response {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
@@ -16,7 +16,7 @@ interface Request {
   duration_second: number;
   mode: string | null;
   is_public: boolean;
-  penalty: number;
+  penalty_second: number;
 }
 
 interface OuterProps {
@@ -101,7 +101,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
       initialProblems={List(problems)}
       initialMode={contestInfo.mode}
       initialPublicState={contestInfo.is_public}
-      initialPenalty={contestInfo.penalty}
+      initialPenaltySecond={contestInfo.penalty_second}
       buttonTitle="Update"
       buttonPush={({
         title,
@@ -111,7 +111,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
         problems: ps,
         mode,
         publicState,
-        penalty,
+        penaltySecond,
       }): void => {
         props.updateContest(
           {
@@ -122,7 +122,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
             duration_second: endSecond - startSecond,
             mode,
             is_public: publicState,
-            penalty,
+            penalty_second: penaltySecond,
           },
           ps.toArray()
         );

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
@@ -16,6 +16,7 @@ interface Request {
   duration_second: number;
   mode: string | null;
   is_public: boolean;
+  penalty: number;
 }
 
 interface OuterProps {
@@ -100,6 +101,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
       initialProblems={List(problems)}
       initialMode={contestInfo.mode}
       initialPublicState={contestInfo.is_public}
+      initialPenalty={contestInfo.penalty}
       buttonTitle="Update"
       buttonPush={({
         title,
@@ -109,6 +111,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
         problems: ps,
         mode,
         publicState,
+        penalty,
       }): void => {
         props.updateContest(
           {
@@ -119,6 +122,7 @@ export const ContestUpdatePage = connect<OuterProps, InnerProps>((props) => ({
             duration_second: endSecond - startSecond,
             mode,
             is_public: publicState,
+            penalty,
           },
           ps.toArray()
         );

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -47,7 +47,7 @@ interface OuterProps {
   readonly enableAutoRefresh: boolean;
   readonly atCoderUserId: string;
   readonly pinMe: boolean;
-  readonly penalty: number;
+  readonly penaltySecond: number;
 }
 
 interface InnerProps extends OuterProps {
@@ -75,7 +75,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     end,
     atCoderUserId,
     pinMe,
-    penalty,
+    penaltySecond,
   } = props;
   const query = new URLSearchParams(useLocation().search);
   const showBots = !!query.get("bot");
@@ -134,7 +134,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
 
   const sortedUserIds = Array.from(totalResultByUser)
     .sort(([aId, aResult], [bId, bResult]) => {
-      const c = compareTotalResult(aResult, bResult, penalty);
+      const c = compareTotalResult(aResult, bResult, penaltySecond);
       return c !== 0 ? c : aId.localeCompare(bId);
     })
     .map(([userId]) => userId);

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -47,6 +47,7 @@ interface OuterProps {
   readonly enableAutoRefresh: boolean;
   readonly atCoderUserId: string;
   readonly pinMe: boolean;
+  readonly penalty: number;
 }
 
 interface InnerProps extends OuterProps {
@@ -74,6 +75,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     end,
     atCoderUserId,
     pinMe,
+    penalty,
   } = props;
   const query = new URLSearchParams(useLocation().search);
   const showBots = !!query.get("bot");
@@ -132,7 +134,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
 
   const sortedUserIds = Array.from(totalResultByUser)
     .sort(([aId, aResult], [bId, bResult]) => {
-      const c = compareTotalResult(aResult, bResult);
+      const c = compareTotalResult(aResult, bResult, penalty);
       return c !== 0 ? c : aId.localeCompare(bId);
     })
     .map(([userId]) => userId);

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.test.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.test.ts
@@ -4,6 +4,7 @@ import {
   calcUserTotalResult,
   ReducedProblemResult,
   reduceUserContestResult,
+  compareTotalResult,
 } from "./ResultCalcUtil";
 
 describe("reduce user's submissions", () => {
@@ -164,4 +165,60 @@ test("Calculate total result", () => {
     point: 100,
     lastUpdatedEpochSecond: 40,
   });
+});
+
+test("Compare total result", () => {
+  expect(
+    compareTotalResult(
+      {
+        // Higher Rank
+        point: 500,
+        lastUpdatedEpochSecond: 660,
+        penalties: 0,
+      },
+      {
+        // Lower Rank
+        point: 500,
+        lastUpdatedEpochSecond: 60,
+        penalties: 2,
+      },
+      300
+    )
+  ).toBeLessThan(0);
+
+  expect(
+    compareTotalResult(
+      {
+        // Higher Rank
+        point: 100,
+        lastUpdatedEpochSecond: 60,
+        penalties: 0,
+      },
+      {
+        // Lower Rank
+        point: 100,
+        lastUpdatedEpochSecond: 60,
+        penalties: 1,
+      },
+      0
+    )
+  ).toBeLessThan(0);
+
+  expect(
+    compareTotalResult(
+      {
+        // Lower Rank
+        point: 500,
+        lastUpdatedEpochSecond: 60,
+        penalties: 1,
+      },
+      {
+        // Higher Rank
+        point: 500,
+        lastUpdatedEpochSecond: 80,
+        penalties: 0,
+      },
+      300
+    )
+  ).toBeGreaterThan(0);
 });

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
@@ -76,7 +76,7 @@ export interface UserTotalResult {
 export const compareTotalResult = (
   aResult: UserTotalResult,
   bResult: UserTotalResult,
-  penalty = 0
+  penaltySecond = 0
 ) => {
   const aPoint = aResult.point;
   const bPoint = bResult.point;
@@ -84,8 +84,10 @@ export const compareTotalResult = (
     return bPoint - aPoint;
   }
 
-  const aSecond = aResult.lastUpdatedEpochSecond + aResult.penalties * penalty;
-  const bSecond = bResult.lastUpdatedEpochSecond + bResult.penalties * penalty;
+  const aSecond =
+    aResult.lastUpdatedEpochSecond + aResult.penalties * penaltySecond;
+  const bSecond =
+    bResult.lastUpdatedEpochSecond + bResult.penalties * penaltySecond;
   if (aSecond !== bSecond) {
     return aSecond - bSecond;
   }

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
@@ -75,7 +75,8 @@ export interface UserTotalResult {
 
 export const compareTotalResult = (
   aResult: UserTotalResult,
-  bResult: UserTotalResult
+  bResult: UserTotalResult,
+  penalty = 0
 ) => {
   const aPoint = aResult.point;
   const bPoint = bResult.point;
@@ -83,8 +84,8 @@ export const compareTotalResult = (
     return bPoint - aPoint;
   }
 
-  const aSecond = aResult.lastUpdatedEpochSecond;
-  const bSecond = bResult.lastUpdatedEpochSecond;
+  const aSecond = aResult.lastUpdatedEpochSecond + aResult.penalties * penalty;
+  const bSecond = bResult.lastUpdatedEpochSecond + bResult.penalties * penalty;
   if (aSecond !== bSecond) {
     return aSecond - bSecond;
   }

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -85,7 +85,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
 
   const start = contestInfo.start_epoch_second;
   const end = contestInfo.start_epoch_second + contestInfo.duration_second;
-  const penalty = contestInfo.penalty;
+  const penaltySecond = contestInfo.penalty_second;
   const alreadyJoined =
     userIdIsSet && contestParticipants.includes(atCoderUserId);
   const now = Math.floor(Date.now() / 1000);
@@ -138,7 +138,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               </tr>
               <tr>
                 <th>Penalty</th>
-                <td>{contestInfo.penalty} seconds for each wrong submission</td>
+                <td>{penaltySecond} seconds for each wrong submission</td>
               </tr>
 
               {start < now && now < end ? (
@@ -241,7 +241,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               enableAutoRefresh={autoRefreshEnabled}
               atCoderUserId={atCoderUserId}
               pinMe={pinMe}
-              penalty={penalty}
+              penaltySecond={penaltySecond}
             />
           )}
         </Col>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -85,6 +85,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
 
   const start = contestInfo.start_epoch_second;
   const end = contestInfo.start_epoch_second + contestInfo.duration_second;
+  const penalty = contestInfo.penalty;
   const alreadyJoined =
     userIdIsSet && contestParticipants.includes(atCoderUserId);
   const now = Math.floor(Date.now() / 1000);
@@ -134,6 +135,10 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                   {formatMomentDateTimeDay(parseSecond(end))} (
                   {Math.floor(contestInfo.duration_second / 60)} minutes)
                 </td>
+              </tr>
+              <tr>
+                <th>Penalty</th>
+                <td>{contestInfo.penalty} seconds for each wrong submission</td>
               </tr>
 
               {start < now && now < end ? (
@@ -236,6 +241,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
               enableAutoRefresh={autoRefreshEnabled}
               atCoderUserId={atCoderUserId}
               pinMe={pinMe}
+              penalty={penalty}
             />
           )}
         </Col>

--- a/atcoder-problems-frontend/src/pages/Internal/types.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/types.ts
@@ -26,7 +26,7 @@ export interface VirtualContestInfo {
   readonly duration_second: number;
   readonly mode: VirtualContestMode;
   readonly is_public: boolean;
-  readonly penalty: number;
+  readonly penalty_second: number;
 }
 
 export interface VirtualContestDetails {

--- a/atcoder-problems-frontend/src/pages/Internal/types.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/types.ts
@@ -26,6 +26,7 @@ export interface VirtualContestInfo {
   readonly duration_second: number;
   readonly mode: VirtualContestMode;
   readonly is_public: boolean;
+  readonly penalty: number;
 }
 
 export interface VirtualContestDetails {

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -167,7 +167,7 @@ CREATE TABLE internal_virtual_contests (
   duration_second       BIGINT       NOT NULL,
   mode      VARCHAR(255) DEFAULT NULL,
   is_public BOOLEAN NOT NULL DEFAULT TRUE,
-  penalty   DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+  penalty_second   BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (id)
 );
 CREATE INDEX ON internal_virtual_contests (internal_user_id);

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -166,7 +166,8 @@ CREATE TABLE internal_virtual_contests (
   start_epoch_second    BIGINT       NOT NULL,
   duration_second       BIGINT       NOT NULL,
   mode      VARCHAR(255) DEFAULT NULL,
-  is_public boolean NOT NULL DEFAULT TRUE,
+  is_public BOOLEAN NOT NULL DEFAULT TRUE,
+  penalty   DOUBLE PRECISION NOT NULL DEFAULT 0.0,
   PRIMARY KEY (id)
 );
 CREATE INDEX ON internal_virtual_contests (internal_user_id);


### PR DESCRIPTION
Fixes #582.

Virtual Contest のペナルティを実装しました。
今は `penalty` という field name を使っているが、`UserTotalResult` の `penalties` という key と似ているので、別の field name にしたほうがいいんですか。

# SQL Migration

```sql
-- Up
ALTER TABLE internal_virtual_contests
    ADD COLUMN penalty_second BIGINT NOT NULL DEFAULT 0;

-- Down
ALTER TABLE internal_virtual_contests
    DROP COLUMN penalty_second;
```

# プレビュー

## ShowContest

![image](https://user-images.githubusercontent.com/6523469/87672449-90238680-c7a5-11ea-90a3-966ee2ac6a73.png)

## ContestConfig

![image](https://user-images.githubusercontent.com/6523469/87672473-9b76b200-c7a5-11ea-819f-a5c261545078.png)
