### PR TITLE
fix(frontend): fix options between 01 and 09 in ContestConfig

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestConfig.tsx
@@ -209,7 +209,9 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setStartHour(Number(e.target.value))}
             >
               {Range(0, 24).map((i) => (
-                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
+                <option key={i} value={i}>
+                  {i.toFixed().padStart(2, "0")}
+                </option>
               ))}
             </Input>
             <Input
@@ -218,7 +220,9 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setStartMinute(Number(e.target.value))}
             >
               {Range(0, 60, 5).map((i) => (
-                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
+                <option key={i} value={i}>
+                  {i.toFixed().padStart(2, "0")}
+                </option>
               ))}
             </Input>
           </InputGroup>
@@ -240,7 +244,9 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setEndHour(Number(e.target.value))}
             >
               {Range(0, 24).map((i) => (
-                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
+                <option key={i} value={i}>
+                  {i.toFixed().padStart(2, "0")}
+                </option>
               ))}
             </Input>
             <Input
@@ -249,7 +255,9 @@ const InnerContestConfig: React.FC<InnerProps> = (props) => {
               onChange={(e): void => setEndMinute(Number(e.target.value))}
             >
               {Range(0, 60, 5).map((i) => (
-                <option key={i}>{i.toFixed().padStart(2, "0")}</option>
+                <option key={i} value={i}>
+                  {i.toFixed().padStart(2, "0")}
+                </option>
               ))}
             </Input>
           </InputGroup>


### PR DESCRIPTION
Fixes #696.

#678 の 29f0895 のバグです。`option` に `value` を加えて直しました。