### PR TITLE
fix(frontend): show time with penalty in virtual contests

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -253,6 +253,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
               new Map<ProblemId, ReducedProblemResult>()
             }
             userTotalResult={totalResultByUser.get(atCoderUserId)}
+            penaltySecond={penaltySecond}
           />
         ) : null}
         {showingUserIds.map((userId, i) => {
@@ -270,6 +271,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
                 new Map<ProblemId, ReducedProblemResult>()
               }
               userTotalResult={totalResultByUser.get(userId)}
+              penaltySecond={penaltySecond}
             />
           );
         })}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
@@ -32,6 +32,7 @@ interface ContestTableRowProps {
     title?: string;
   }[];
   start: number;
+  penaltySecond: number;
   showProblems: boolean;
   estimatedPerformance?: number;
   reducedProblemResults: Map<ProblemId, ReducedProblemResult>;
@@ -45,10 +46,19 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
     showProblems,
     items,
     start,
+    penaltySecond,
     reducedProblemResults,
     userTotalResult,
     estimatedPerformance,
   } = props;
+
+  const totalTime =
+    typeof userTotalResult !== "undefined"
+      ? userTotalResult.lastUpdatedEpochSecond +
+        penaltySecond * userTotalResult.penalties -
+        start
+      : 0;
+
   return (
     <tr>
       <th>{rank + 1}</th>
@@ -79,7 +89,7 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
         <ScoreCell
           trials={userTotalResult?.penalties ?? 0}
           maxPoint={userTotalResult?.point ?? 0}
-          time={(userTotalResult?.lastUpdatedEpochSecond ?? start) - start}
+          time={totalTime}
         />
       </td>
       {estimatedPerformance !== undefined && (

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
@@ -52,12 +52,11 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
     estimatedPerformance,
   } = props;
 
-  const totalTime =
-    typeof userTotalResult !== "undefined"
-      ? userTotalResult.lastUpdatedEpochSecond +
-        penaltySecond * userTotalResult.penalties -
-        start
-      : 0;
+  const totalTime = userTotalResult
+    ? userTotalResult.lastUpdatedEpochSecond +
+      penaltySecond * userTotalResult.penalties -
+      start
+    : 0;
 
   return (
     <tr>


### PR DESCRIPTION
Fixes #699.

ペナルティ合計済みの時間が表示されるようにしました。

## プレビュー

![image](https://user-images.githubusercontent.com/6523469/88064346-bf6b3680-cb9d-11ea-894f-0f85d3f2fef6.png)
