### PR TITLE
Color max-diff heatmat cells for unrated problems with black

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/FilteringHeatmap.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/FilteringHeatmap.tsx
@@ -44,13 +44,13 @@ const createTableData = (
     const date = formatMomentDate(moment(startDate).add(i, "day"));
     if (showMode === "Max Difficulty") {
       const submissions = submissionsByDate.get(date) ?? [];
-      const difficulties = submissions
-        .map((s) => problemModels.get(s.problem_id)?.difficulty)
-        .filter((d): d is number => d !== undefined);
+      const difficulties = submissions.map(
+        (s) => problemModels.get(s.problem_id)?.difficulty ?? -1
+      );
       if (difficulties.length > 0) {
         const value = difficulties.reduce(
           (max, difficulty) => Math.max(max, difficulty),
-          0
+          -1
         );
         tableData.push({ date, value });
       } else {
@@ -127,7 +127,7 @@ export const InnerFilteringHeatmap: React.FC<InnerProps> = (props) => {
   const formatTooltip =
     showMode === "Max Difficulty"
       ? (date: string, difficulty: number): string =>
-          `${date} Max Difficulty: ${difficulty}`
+          `${date} Max Difficulty: ${difficulty >= 0 ? difficulty : "-"}`
       : (date: string, count: number): string =>
           formatCountTooltip(date, count, showMode);
   const getColor =

--- a/atcoder-problems-frontend/src/style/theme.ts
+++ b/atcoder-problems-frontend/src/style/theme.ts
@@ -1,5 +1,5 @@
 export const ThemeLight = {
-  difficultyBlackColor: "#101010",
+  difficultyBlackColor: "#404040",
   difficultyGreyColor: "#808080",
   difficultyBrownColor: "#804000",
   difficultyGreenColor: "#008000",


### PR DESCRIPTION
## 概要

Max Difficulty Heatmap において，Difficulty 値が存在しない問題しか解いていない日に対応するセルを黒色に塗ります．
これまで EDPC 埋めなどの精進が Max Difficulty Heatmap 上ではただの空白期間になってしまい，なんだか悲しい見た目になってしまっていたので，解いたことがわかるようにします．

### 変更前
![image](https://user-images.githubusercontent.com/59337901/88410667-a4a0f800-ce11-11ea-8737-63309b4581d9.png)

### 変更後
![image](https://user-images.githubusercontent.com/59337901/88410728-b387aa80-ce11-11ea-8f08-76c17668ab5f.png)

## その他

- 黒で塗るかどうかの有効・無効をチェックボックスで切り替える機能も考えられますが，UI が若干ごちゃつくので，現状では付けていません．必要そうなら付けます．
- 今までの黒色 (#101010) だと真っ黒すぎで，Heatmap 上での主張が強すぎたので，少し明るめに変更しました．
- この機能は，私が欲しているために追加を希望するものではありますが，Twitter 上で同様の要望を目にしたこともあるので，最低限の需要はあるのではないかと踏んでいます．