### PR TITLE
Adds a tabIndex to the path parameter of the training page.

### DIFF
--- a/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { Container, Row, Table, Nav, NavItem, NavLink, Col } from "reactstrap";
 import Octicon, { Check, Search } from "@primer/octicons-react";
+import { Link } from "react-router-dom";
 import { Course } from "../../interfaces/Course";
 import Problem from "../../interfaces/Problem";
 import ProblemModel from "../../interfaces/ProblemModel";
@@ -107,7 +108,6 @@ const SetPieChart: React.FC<SetPieChartProps> = (props) => {
 interface OuterProps {
   course: Course;
   selectedSet: number;
-  onSelectedSet: (order: number) => void;
   submissions: Submission[];
 }
 
@@ -117,8 +117,7 @@ interface InnerProps extends OuterProps {
 }
 
 const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
-  const { course, selectedSet, onSelectedSet } = props;
-
+  const { course, selectedSet } = props;
   const problemSet = course.set_list;
   problemSet.sort((a, b) => a.order - b.order);
   const currentSelectedSet =
@@ -143,7 +142,6 @@ const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
       (problem: Problem | undefined): problem is Problem =>
         problem !== undefined
     );
-
   return (
     <Container fluid>
       <Row className="my-2">
@@ -171,11 +169,13 @@ const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
       <Nav tabs>
         {problemSet.map((set, i) => (
           <NavItem key={i}>
-            <NavLink
-              active={selectedSet === set.order}
-              onClick={(): void => onSelectedSet(set.order)}
-            >
-              <h3>{set.title}</h3>
+            <NavLink active={selectedSet === set.order}>
+              <Link
+                to={`/training/${course.title}/${set.order}`}
+                style={{ textDecoration: "none", color: "black" }}
+              >
+                <h3>{set.title}</h3>
+              </Link>
             </NavLink>
           </NavItem>
         ))}

--- a/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { Container, Row, Table, Nav, NavItem, NavLink, Col } from "reactstrap";
 import Octicon, { Check, Search } from "@primer/octicons-react";
@@ -106,6 +106,8 @@ const SetPieChart: React.FC<SetPieChartProps> = (props) => {
 
 interface OuterProps {
   course: Course;
+  selectedSet: number;
+  onSelectedSet: (order: number) => void;
   submissions: Submission[];
 }
 
@@ -115,12 +117,10 @@ interface InnerProps extends OuterProps {
 }
 
 const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
-  const { course } = props;
-  const [selectedSet, setSelectedSet] = useState(course.set_list[0].order);
+  const { course, selectedSet, onSelectedSet } = props;
 
   const problemSet = course.set_list;
   problemSet.sort((a, b) => a.order - b.order);
-
   const currentSelectedSet =
     problemSet.find((set) => set.order === selectedSet)?.problems ?? [];
   currentSelectedSet.sort((a, b) => a.order - b.order);
@@ -173,7 +173,7 @@ const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
           <NavItem key={i}>
             <NavLink
               active={selectedSet === set.order}
-              onClick={(): void => setSelectedSet(set.order)}
+              onClick={(): void => onSelectedSet(set.order)}
             >
               <h3>{set.title}</h3>
             </NavLink>

--- a/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
@@ -169,13 +169,13 @@ const InnerSingleCourseView: React.FC<InnerProps> = (props) => {
       <Nav tabs>
         {problemSet.map((set, i) => (
           <NavItem key={i}>
-            <NavLink active={selectedSet === set.order}>
-              <Link
-                to={`/training/${course.title}/${set.order}`}
-                style={{ textDecoration: "none", color: "black" }}
-              >
-                <h3>{set.title}</h3>
-              </Link>
+            <NavLink
+              active={selectedSet === set.order}
+              tag={Link}
+              to={`/training/${course.title}/${set.order}`}
+              style={{ color: "black" }}
+            >
+              <h3>{set.title}</h3>
             </NavLink>
           </NavItem>
         ))}

--- a/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
@@ -49,9 +49,6 @@ const InnerTrainingList: React.FC<Props> = (props) => {
           render={({ match }): React.ReactNode => {
             const courseTitle = match.params.courseTitle;
             const setListOrder = match.params.setListOrder;
-            const onSelectedSet = (order: number) => {
-              history.push(`${path}/${courseTitle}/${order}`);
-            };
             const course = courses.find((c) => c.title === courseTitle);
             if (course) {
               const defaultSetListOrder = course.set_list[0].order;
@@ -63,7 +60,6 @@ const InnerTrainingList: React.FC<Props> = (props) => {
                   submissions={submissions}
                   course={course}
                   selectedSet={selectedSet}
-                  onSelectedSet={onSelectedSet}
                 />
               );
             } else {

--- a/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { Alert, Spinner } from "reactstrap";
 import { useRouteMatch, Switch, Route } from "react-router-dom";
+import { useHistory } from "react-router";
 import { Course } from "../../interfaces/Course";
 import { loadCourses } from "../../utils/StaticDataStorage";
 import { UserResponse } from "../Internal/types";
@@ -22,7 +23,7 @@ interface Props {
 
 const InnerTrainingList: React.FC<Props> = (props) => {
   const { path } = useRouteMatch();
-
+  const history = useHistory();
   if (props.courses.pending) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
   }
@@ -44,13 +45,34 @@ const InnerTrainingList: React.FC<Props> = (props) => {
           <TrainingList submissions={submissions} courses={courses} />
         </Route>
         <Route
-          path={`${path}/:courseTitle`}
+          path={`${path}/:courseTitle/:tabIndex?`}
           render={({ match }): React.ReactNode => {
             const courseTitle = match.params.courseTitle;
+            const tabIndexParam = match.params.tabIndex;
+            const onSelectedSet = (order: number) => {
+              history.push(`${path}/${courseTitle}/${order}`);
+            };
             const course = courses.find((c) => c.title === courseTitle);
-            return course ? (
-              <SingleCourseView submissions={submissions} course={course} />
-            ) : null;
+            if (course) {
+              const defaultTabIndex = course.set_list[0].order;
+              const tabIndex = parseInt(tabIndexParam ?? `${defaultTabIndex}`);
+              const selectedSet =
+                !isNaN(tabIndex) &&
+                tabIndex > 0 &&
+                tabIndex <= course.set_list.length
+                  ? tabIndex
+                  : defaultTabIndex;
+              return (
+                <SingleCourseView
+                  submissions={submissions}
+                  course={course}
+                  selectedSet={selectedSet}
+                  onSelectedSet={onSelectedSet}
+                />
+              );
+            } else {
+              return null;
+            }
           }}
         />
       </Switch>

--- a/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
@@ -45,23 +45,19 @@ const InnerTrainingList: React.FC<Props> = (props) => {
           <TrainingList submissions={submissions} courses={courses} />
         </Route>
         <Route
-          path={`${path}/:courseTitle/:tabIndex?`}
+          path={`${path}/:courseTitle/:setListOrder?`}
           render={({ match }): React.ReactNode => {
             const courseTitle = match.params.courseTitle;
-            const tabIndexParam = match.params.tabIndex;
+            const setListOrder = match.params.setListOrder;
             const onSelectedSet = (order: number) => {
               history.push(`${path}/${courseTitle}/${order}`);
             };
             const course = courses.find((c) => c.title === courseTitle);
             if (course) {
-              const defaultTabIndex = course.set_list[0].order;
-              const tabIndex = parseInt(tabIndexParam ?? `${defaultTabIndex}`);
+              const defaultSetListOrder = course.set_list[0].order;
               const selectedSet =
-                !isNaN(tabIndex) &&
-                tabIndex > 0 &&
-                tabIndex <= course.set_list.length
-                  ? tabIndex
-                  : defaultTabIndex;
+                course.set_list.find((set) => setListOrder === `${set.order}`)
+                  ?.order ?? defaultSetListOrder;
               return (
                 <SingleCourseView
                   submissions={submissions}

--- a/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { Alert, Spinner } from "reactstrap";
 import { useRouteMatch, Switch, Route } from "react-router-dom";
-import { useHistory } from "react-router";
 import { Course } from "../../interfaces/Course";
 import { loadCourses } from "../../utils/StaticDataStorage";
 import { UserResponse } from "../Internal/types";
@@ -23,7 +22,6 @@ interface Props {
 
 const InnerTrainingList: React.FC<Props> = (props) => {
   const { path } = useRouteMatch();
-  const history = useHistory();
   if (props.courses.pending) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
   }


### PR DESCRIPTION
# 概要

いつも便利に使わせて頂いております。

TrainingページにおいてEasy, Medium, Hardのタブ切り替えを固定したいのですが(例えばHardを開いた状態のURLがほしい)、内部stateによって行われているため、パスパラメータで渡すスタイルにしてみました。


# やったこと

- `TrainingPage/index.tsx` に `tabIndex` パスパラメータをオプショナルで追加
- `SingleCourseView.tsx` で selectedSetをpropsで受け取るスタイルに変更
- タブのorderを変更すると、`history.push` で遷移するスタイルに変更

その他の論点はコード内でコメントします。

__動作__
↓data setを読み込めてない状態で動かしてますが、selectedSetを利用する処理部分に変更はないので問題なく動作すると思います。

![a](https://user-images.githubusercontent.com/749051/88693938-daf4b500-d13a-11ea-90f0-efbeda59560a.gif)

よろしくおねがいします。