### PR TITLE
fix(frontend): enforce username format and sanitize username

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/index.tsx
@@ -104,39 +104,44 @@ const InnerMyAccountPage = (props: InnerProps): JSX.Element => {
         </Nav>
         <TabContent activeTab={activeTab}>
           <TabPane tabId="Account Info">
-            <Row className="my-2">
-              <Col sm="12">
-                <h2>Account Info</h2>
-              </Col>
-            </Row>
-            <Row className="my-2">
-              <Col sm="12">
-                <Label>AtCoder User ID</Label>
-                <Input
-                  type="text"
-                  placeholder="AtCoder User ID"
-                  value={userId}
-                  onChange={(event): void => setUserId(event.target.value)}
-                />
-              </Col>
-            </Row>
-            <Row className="my-2">
-              <Col sm="12">
-                <Button
-                  disabled={updating}
-                  onClick={(): void => props.updateUserInfo(userId)}
-                >
-                  {updating ? "Updating..." : "Update"}
-                </Button>
-              </Col>
-            </Row>
-            <Row className="my-2">
-              <Col sm="12">
-                <Alert color="success" isOpen={updated}>
-                  Updated
-                </Alert>
-              </Col>
-            </Row>
+            <form
+              onSubmit={(event): void => {
+                event.preventDefault();
+                props.updateUserInfo(userId);
+              }}
+            >
+              <Row className="my-2">
+                <Col sm="12">
+                  <h2>Account Info</h2>
+                </Col>
+              </Row>
+              <Row className="my-2">
+                <Col sm="12">
+                  <Label>AtCoder User ID</Label>
+                  <Input
+                    type="text"
+                    placeholder="AtCoder User ID"
+                    value={userId}
+                    pattern="[a-zA-Z0-9_]*"
+                    onChange={(event): void => setUserId(event.target.value)}
+                  />
+                </Col>
+              </Row>
+              <Row className="my-2">
+                <Col sm="12">
+                  <Button disabled={updating} as="button" type="submit">
+                    {updating ? "Updating..." : "Update"}
+                  </Button>
+                </Col>
+              </Row>
+              <Row className="my-2">
+                <Col sm="12">
+                  <Alert color="success" isOpen={updated}>
+                    Updated
+                  </Alert>
+                </Col>
+              </Row>
+            </form>
           </TabPane>
 
           <TabPane tabId="My Contests">

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
@@ -23,7 +23,8 @@ export const SmallScoreCell: React.FC<Props> = (props) => {
   const { maxPoint, trials, problem, time, id } = props;
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const cellId = `small-score-cell-${id}`;
+  const sanitizedId = id.replace(/[^A-Za-z_-]/g, "");
+  const cellId = `small-score-cell-${sanitizedId}`;
   const classes =
     "small-score-cell " +
     (isNumber(maxPoint) && isNumber(trials) && isNumber(time)


### PR DESCRIPTION
スペースが含まれるユーザー名（`userId`）のせいで `TrainingContestTable` が壊れます。

* `userId` をサニタイズして、バグを直しました。
  * このように「直して」も、提出は反映されません。ただ、直さなければページが白になります。
* `MyAccountPage` の `input` を `format` で、入力できるユーザー名を制限しました。
  * 今は `[A-Za-z0-9_]*` ではない AtCoder ユーザー名がありますか…？