### PR TITLE
fix(frontend): change brown and orange difficulty colors

### DIFF
--- a/atcoder-problems-frontend/src/style/_theme-dark.scss
+++ b/atcoder-problems-frontend/src/style/_theme-dark.scss
@@ -231,12 +231,12 @@ $table-bg-level: 7;
 $table-border-level: -10;
 
 $difficulty-grey-color: #c0c0c0 !default;
-$difficulty-brown-color: #ffa244 !default;
+$difficulty-brown-color: #b08c56 !default;
 $difficulty-green-color: #3faf3f !default;
 $difficulty-cyan-color: #42e0e0 !default;
 $difficulty-blue-color: #8888ff !default;
 $difficulty-yellow-color: #ffff56 !default;
-$difficulty-orange-color: #ffc86f !default;
+$difficulty-orange-color: #ffb836 !default;
 $difficulty-red-color: #ff6767 !default;
 
 $success-bg-color: #005c08;

--- a/atcoder-problems-frontend/src/style/theme.ts
+++ b/atcoder-problems-frontend/src/style/theme.ts
@@ -14,12 +14,12 @@ export const ThemeDark: typeof ThemeLight = {
   ...ThemeLight,
   difficultyBlackColor: "#FFFFFF",
   difficultyGreyColor: "#C0C0C0",
-  difficultyBrownColor: "#FFA244",
+  difficultyBrownColor: "#B08C56",
   difficultyGreenColor: "#3FAF3F",
   difficultyCyanColor: "#42E0E0",
   difficultyBlueColor: "#8888FF",
   difficultyYellowColor: "#FFFF56",
-  difficultyOrangeColor: "#FFC86F",
+  difficultyOrangeColor: "#FFB836",
   difficultyRedColor: "#FF6767",
 };
 


### PR DESCRIPTION
Resolves #720.

見分けやすくするように、茶色と橙色を選び直しました。

## プレビュー

![image](https://user-images.githubusercontent.com/6523469/89046321-5fd01080-d37f-11ea-8347-d9a9b2ca845f.png)
