### PR TITLE
[replacement with sqlx] UserManager

### DIFF
--- a/atcoder-problems-backend/sql-client/src/internal/mod.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/mod.rs
@@ -1,2 +1,3 @@
 pub mod problem_list_manager;
 pub mod progress_reset_manager;
+pub mod user_manager;

--- a/atcoder-problems-backend/sql-client/src/internal/problem_list_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/problem_list_manager.rs
@@ -54,19 +54,19 @@ impl ProblemListManager for PgPool {
             ",
         )
         .bind(internal_user_id)
-        .map(|row: PgRow| {
-            let internal_list_id: String = row.get(0);
-            let internal_list_name: String = row.get(1);
-            let internal_user_id: String = row.get(2);
-            let problem_id: Option<String> = row.get(3);
-            let memo: Option<String> = row.get(4);
-            (
+        .try_map(|row: PgRow| {
+            let internal_list_id: String = row.try_get("internal_list_id")?;
+            let internal_list_name: String = row.try_get("internal_list_name")?;
+            let internal_user_id: String = row.try_get("internal_user_id")?;
+            let problem_id: Option<String> = row.try_get("problem_id")?;
+            let memo: Option<String> = row.try_get("memo")?;
+            Ok((
                 internal_list_id,
                 internal_list_name,
                 internal_user_id,
                 problem_id,
                 memo,
-            )
+            ))
         })
         .fetch_all(self)
         .await?;
@@ -200,7 +200,7 @@ impl ProblemListManager for PgPool {
             "SELECT problem_id FROM internal_problem_list_items WHERE internal_list_id = $1",
         )
         .bind(internal_list_id)
-        .map(|row: PgRow| row.get::<String, _>(0))
+        .try_map(|row: PgRow| row.try_get::<String, _>("problem_id"))
         .fetch_all(self)
         .await?;
         if problems.len() >= MAX_ITEM_NUM {

--- a/atcoder-problems-backend/sql-client/src/internal/progress_reset_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/progress_reset_manager.rs
@@ -76,13 +76,13 @@ impl ProgressResetManager for PgPool {
             ",
         )
         .bind(internal_user_id)
-        .map(|row: PgRow| {
-            let problem_id: String = row.get(0);
-            let reset_epoch_second: i64 = row.get(1);
-            ProgressResetItem {
+        .try_map(|row: PgRow| {
+            let problem_id: String = row.try_get("problem_id")?;
+            let reset_epoch_second: i64 = row.try_get("reset_epoch_second")?;
+            Ok(ProgressResetItem {
                 problem_id,
                 reset_epoch_second,
-            }
+            })
         })
         .fetch_all(self)
         .await?;

--- a/atcoder-problems-backend/sql-client/src/internal/user_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/user_manager.rs
@@ -1,0 +1,81 @@
+use crate::PgPool;
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Serialize;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct InternalUserInfo {
+    pub internal_user_id: String,
+    pub atcoder_user_id: Option<String>,
+}
+
+#[async_trait]
+pub trait UserManager {
+    async fn register_user(&self, internal_user_id: &str) -> Result<()>;
+    async fn update_internal_user_info(
+        &self,
+        internal_user_id: &str,
+        atcoder_user_id: &str,
+    ) -> Result<()>;
+    async fn get_internal_user_info(&self, internal_user_id: &str) -> Result<InternalUserInfo>;
+}
+
+#[async_trait]
+impl UserManager for PgPool {
+    async fn register_user(&self, internal_user_id: &str) -> Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO internal_users (internal_user_id)
+            VALUES ($1)
+            ON CONFLICT DO NOTHING
+            ",
+        )
+        .bind(internal_user_id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_internal_user_info(
+        &self,
+        internal_user_id: &str,
+        atcoder_user_id: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            r"
+            UPDATE internal_users
+            SET atcoder_user_id = $1
+            WHERE internal_user_id = $2
+            ",
+        )
+        .bind(atcoder_user_id)
+        .bind(internal_user_id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_internal_user_info(&self, internal_user_id: &str) -> Result<InternalUserInfo> {
+        let res = sqlx::query(
+            r"
+            SELECT internal_user_id, atcoder_user_id
+            FROM internal_users
+            WHERE internal_user_id = $1
+            ",
+        )
+        .bind(internal_user_id)
+        .map(|row: PgRow| {
+            let internal_user_id: String = row.get(0);
+            let atcoder_user_id: Option<String> = row.get(1);
+            InternalUserInfo {
+                internal_user_id,
+                atcoder_user_id,
+            }
+        })
+        .fetch_one(self)
+        .await?;
+        Ok(res)
+    }
+}

--- a/atcoder-problems-backend/sql-client/src/internal/user_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/user_manager.rs
@@ -66,13 +66,13 @@ impl UserManager for PgPool {
             ",
         )
         .bind(internal_user_id)
-        .map(|row: PgRow| {
-            let internal_user_id: String = row.get(0);
-            let atcoder_user_id: Option<String> = row.get(1);
-            InternalUserInfo {
+        .try_map(|row: PgRow| {
+            let internal_user_id: String = row.try_get("internal_user_id")?;
+            let atcoder_user_id: Option<String> = row.try_get("atcoder_user_id")?;
+            Ok(InternalUserInfo {
                 internal_user_id,
                 atcoder_user_id,
-            }
+            })
         })
         .fetch_one(self)
         .await?;

--- a/atcoder-problems-backend/sql-client/tests/test_problem_list_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_problem_list_manager.rs
@@ -11,13 +11,13 @@ async fn test_problem_list_manager() {
     let pool = utils::initialize_and_connect_to_test_sql().await;
     utils::setup_internal_user(&pool, internal_user_id, atcoder_user_id).await;
 
-    // get_list
-    assert!(pool.get_list(internal_user_id).await.unwrap().is_empty());
+    assert!(
+        pool.get_list(internal_user_id).await.unwrap().is_empty(),
+        "`get_list` here should return an empty list, but got not empty."
+    );
 
-    // create_list
     let list_id = pool.create_list(internal_user_id, list_name).await.unwrap();
 
-    // get_single_list
     let list = pool.get_single_list(&list_id).await.unwrap();
     assert_eq!(
         list,
@@ -26,17 +26,19 @@ async fn test_problem_list_manager() {
             internal_list_name: list_name.to_string(),
             internal_user_id: internal_user_id.to_string(),
             items: vec![],
-        }
+        },
+        "`get_single_list` returned an unexpected value."
     );
 
-    // update_list
     pool.update_list(&list_id, "list_name_updated")
         .await
         .unwrap();
     let list = pool.get_single_list(&list_id).await.unwrap();
-    assert_eq!(list.internal_list_name, "list_name_updated");
+    assert_eq!(
+        list.internal_list_name, "list_name_updated",
+        "`internal_list_name` should be updated, but not."
+    );
 
-    // add_item
     pool.add_item(&list_id, problem_id).await.unwrap();
     let list = pool.get_single_list(&list_id).await.unwrap();
     assert_eq!(
@@ -44,10 +46,10 @@ async fn test_problem_list_manager() {
         vec![ListItem {
             problem_id: problem_id.to_string(),
             memo: "".to_string(),
-        }]
+        }],
+        "The item that has been added to the list is not found."
     );
 
-    // update_item
     pool.update_item(&list_id, problem_id, "memo_updated")
         .await
         .unwrap();
@@ -57,15 +59,20 @@ async fn test_problem_list_manager() {
         vec![ListItem {
             problem_id: problem_id.to_string(),
             memo: "memo_updated".to_string(),
-        }]
+        }],
+        "`memo` should be updated, but not."
     );
 
-    // delete_item
     pool.delete_item(&list_id, problem_id).await.unwrap();
     let list = pool.get_single_list(&list_id).await.unwrap();
-    assert!(list.items.is_empty());
+    assert!(
+        list.items.is_empty(),
+        "The list still has its item unexpectedly."
+    );
 
-    // delete_list
     pool.delete_list(&list_id).await.unwrap();
-    assert!(pool.get_list(internal_user_id).await.unwrap().is_empty());
+    assert!(
+        pool.get_list(internal_user_id).await.unwrap().is_empty(),
+        "The list should be deleted, but still exists."
+    );
 }

--- a/atcoder-problems-backend/sql-client/tests/test_progress_reset_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_progress_reset_manager.rs
@@ -13,14 +13,15 @@ async fn test_progress_reset_manager() {
     let pool = utils::initialize_and_connect_to_test_sql().await;
     utils::setup_internal_user(&pool, internal_user_id, atcoder_user_id).await;
 
-    // get_progress_reset_list (empty)
     let list = pool
         .get_progress_reset_list(internal_user_id)
         .await
         .unwrap();
-    assert!(list.items.is_empty());
+    assert!(
+        list.items.is_empty(),
+        "`get_progress_reset_list` here should return an empty list, but got not empty."
+    );
 
-    // add_item
     pool.add_item(internal_user_id, problem_id, reset_epoch_second)
         .await
         .unwrap();
@@ -35,11 +36,10 @@ async fn test_progress_reset_manager() {
                 problem_id: problem_id.to_string(),
                 reset_epoch_second,
             }],
-        }
+        },
+        "The item that has been added to the list is not found."
     );
 
-    // Checks that calling `add_item` on the same `internal_user_id` and `problem_id`
-    // causes updating `reset_epoch_second`
     let updated_reset_epoch_second = 334;
     pool.add_item(internal_user_id, problem_id, updated_reset_epoch_second)
         .await
@@ -55,10 +55,10 @@ async fn test_progress_reset_manager() {
                 problem_id: problem_id.to_string(),
                 reset_epoch_second: updated_reset_epoch_second,
             }],
-        }
+        },
+        "`reset_epoch_second` should be updated, but not."
     );
 
-    // remove_item
     pool.remove_item(internal_user_id, problem_id)
         .await
         .unwrap();
@@ -66,5 +66,8 @@ async fn test_progress_reset_manager() {
         .get_progress_reset_list(internal_user_id)
         .await
         .unwrap();
-    assert!(list.items.is_empty());
+    assert!(
+        list.items.is_empty(),
+        "The list should not have any items, but still has."
+    );
 }

--- a/atcoder-problems-backend/sql-client/tests/test_user_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_user_manager.rs
@@ -1,0 +1,48 @@
+use sql_client::internal::user_manager::{InternalUserInfo, UserManager};
+
+mod utils;
+
+#[async_std::test]
+async fn test_user_manager() {
+    let internal_user_id = "user_id";
+    let atcoder_user_id = "atcoder_id";
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+
+    // try to get a user who has not yet been registered
+    let get_result = pool.get_internal_user_info(internal_user_id).await;
+    assert!(get_result.is_err());
+
+    // register_user
+    let register_result = pool.register_user(internal_user_id).await;
+    assert!(register_result.is_ok());
+
+    // calling `register_user` twice has no effect
+    let register_result = pool.register_user(internal_user_id).await;
+    assert!(register_result.is_ok());
+
+    // get_internal_user_info (a user whose atcoder_user_id has not been set)
+    let get_result = pool.get_internal_user_info(internal_user_id).await.unwrap();
+    assert_eq!(
+        get_result,
+        InternalUserInfo {
+            internal_user_id: internal_user_id.to_string(),
+            atcoder_user_id: None,
+        }
+    );
+
+    // update_internal_user_info (set atcoder_user_id)
+    let update_result = pool
+        .update_internal_user_info(internal_user_id, atcoder_user_id)
+        .await;
+    assert!(update_result.is_ok());
+
+    // get_internal_user_info (atcoder_user_id is set now)
+    let get_result = pool.get_internal_user_info(internal_user_id).await.unwrap();
+    assert_eq!(
+        get_result,
+        InternalUserInfo {
+            internal_user_id: internal_user_id.to_string(),
+            atcoder_user_id: Some(atcoder_user_id.to_string()),
+        }
+    );
+}

--- a/atcoder-problems-backend/sql-client/tests/test_user_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_user_manager.rs
@@ -8,41 +8,49 @@ async fn test_user_manager() {
     let atcoder_user_id = "atcoder_id";
     let pool = utils::initialize_and_connect_to_test_sql().await;
 
-    // try to get a user who has not yet been registered
     let get_result = pool.get_internal_user_info(internal_user_id).await;
-    assert!(get_result.is_err());
+    assert!(
+        get_result.is_err(),
+        "`get_result` for a user who has not yet been registered should be `Err`, but got `Ok`."
+    );
 
-    // register_user
     let register_result = pool.register_user(internal_user_id).await;
-    assert!(register_result.is_ok());
+    assert!(
+        register_result.is_ok(),
+        "`register_user` failed unexpectedly."
+    );
 
-    // calling `register_user` twice has no effect
     let register_result = pool.register_user(internal_user_id).await;
-    assert!(register_result.is_ok());
+    assert!(
+        register_result.is_ok(),
+        "Calling `register_user` twice should return `Ok`, but got `Err`."
+    );
 
-    // get_internal_user_info (a user whose atcoder_user_id has not been set)
     let get_result = pool.get_internal_user_info(internal_user_id).await.unwrap();
     assert_eq!(
         get_result,
         InternalUserInfo {
             internal_user_id: internal_user_id.to_string(),
             atcoder_user_id: None,
-        }
+        },
+        "`get_internal_user_info` for a user whose `atcoder_user_id` is not set returned an unexpected value."
     );
 
-    // update_internal_user_info (set atcoder_user_id)
     let update_result = pool
         .update_internal_user_info(internal_user_id, atcoder_user_id)
         .await;
-    assert!(update_result.is_ok());
+    assert!(
+        update_result.is_ok(),
+        "`update_internal_user_info` failed unexpectedly."
+    );
 
-    // get_internal_user_info (atcoder_user_id is set now)
     let get_result = pool.get_internal_user_info(internal_user_id).await.unwrap();
     assert_eq!(
         get_result,
         InternalUserInfo {
             internal_user_id: internal_user_id.to_string(),
             atcoder_user_id: Some(atcoder_user_id.to_string()),
-        }
+        },
+        "`get_internal_user_info` after `atcoder_user_id` was set returned an unexpected value."
     );
 }


### PR DESCRIPTION
Related issue: #701

`UserManager` の sqlx 版です。

#### やったこと

- 非同期対応の `UserManager` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `UserManager` のテストを作成

