### PR TITLE
 [replacement with sqlx]  VirtualContestManager

### DIFF
--- a/atcoder-problems-backend/sql-client/src/internal/mod.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/mod.rs
@@ -1,3 +1,4 @@
 pub mod problem_list_manager;
 pub mod progress_reset_manager;
 pub mod user_manager;
+pub mod virtual_contest_manager;

--- a/atcoder-problems-backend/sql-client/src/internal/virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/virtual_contest_manager.rs
@@ -1,0 +1,453 @@
+use crate::PgPool;
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use serde::Serialize;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::result::Result as StdResult;
+use uuid::Uuid;
+
+const MAX_PROBLEM_NUM_PER_CONTEST: usize = 100;
+const RECENT_CONTEST_NUM: i64 = 1000;
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct VirtualContestInfo {
+    pub id: String,
+    pub title: String,
+    pub memo: String,
+    pub owner_user_id: String, // field name is `internal_user_id`
+    pub start_epoch_second: i64,
+    pub duration_second: i64,
+    pub mode: Option<String>,
+    pub is_public: bool,
+    pub penalty_second: i64,
+}
+
+fn virtual_contest_info_mapper(row: PgRow) -> StdResult<VirtualContestInfo, sqlx::Error> {
+    let id: String = row.try_get("id")?;
+    let title: String = row.try_get("title")?;
+    let memo: String = row.try_get("memo")?;
+    let owner_user_id: String = row.try_get("internal_user_id")?;
+    let start_epoch_second: i64 = row.try_get("start_epoch_second")?;
+    let duration_second: i64 = row.try_get("duration_second")?;
+    let mode: Option<String> = row.try_get("mode")?;
+    let is_public: bool = row.try_get("is_public")?;
+    let penalty_second: i64 = row.try_get("penalty_second")?;
+    Ok(VirtualContestInfo {
+        id,
+        title,
+        memo,
+        owner_user_id,
+        start_epoch_second,
+        duration_second,
+        mode,
+        is_public,
+        penalty_second,
+    })
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct VirtualContestItem {
+    pub id: String,
+    pub point: Option<i64>,
+    pub order: Option<i64>,
+}
+
+#[async_trait]
+pub trait VirtualContestManager {
+    async fn create_contest(
+        &self,
+        title: &str,
+        memo: &str,
+        internal_user_id: &str,
+        start_epoch_second: i64,
+        duration_second: i64,
+        mode: Option<&str>,
+        is_public: bool,
+        penalty_second: i64,
+    ) -> Result<String>;
+    async fn update_contest(
+        &self,
+        id: &str,
+        title: &str,
+        memo: &str,
+        start_epoch_second: i64,
+        duration_second: i64,
+        mode: Option<&str>,
+        is_public: bool,
+        penalty_second: i64,
+    ) -> Result<()>;
+
+    async fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>>;
+    async fn get_participated_contests(
+        &self,
+        internal_user_id: &str,
+    ) -> Result<Vec<VirtualContestInfo>>;
+    async fn get_single_contest_info(&self, contest_id: &str) -> Result<VirtualContestInfo>;
+    async fn get_single_contest_participants(&self, contest_id: &str) -> Result<Vec<String>>;
+    async fn get_single_contest_problems(
+        &self,
+        contest_id: &str,
+    ) -> Result<Vec<VirtualContestItem>>;
+    async fn get_recent_contest_info(&self) -> Result<Vec<VirtualContestInfo>>;
+    async fn get_running_contest_problems(&self, time: i64) -> Result<Vec<String>>;
+
+    async fn update_items(
+        &self,
+        contest_id: &str,
+        problems: &[VirtualContestItem],
+        user_id: &str,
+    ) -> Result<()>;
+
+    async fn join_contest(&self, contest_id: &str, internal_user_id: &str) -> Result<()>;
+    async fn leave_contest(&self, contest_id: &str, internal_user_id: &str) -> Result<()>;
+}
+
+#[async_trait]
+impl VirtualContestManager for PgPool {
+    async fn create_contest(
+        &self,
+        title: &str,
+        memo: &str,
+        internal_user_id: &str,
+        start_epoch_second: i64,
+        duration_second: i64,
+        mode: Option<&str>,
+        is_public: bool,
+        penalty_second: i64,
+    ) -> Result<String> {
+        let uuid = Uuid::new_v4().to_string();
+        sqlx::query(
+            r"
+            INSERT INTO internal_virtual_contests
+            VALUES (id, title, memo, internal_user_id, start_epoch_second, duration_second, mode, is_public, penalty_second)
+            ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ",
+        )
+        .bind(&uuid)
+        .bind(title)
+        .bind(memo)
+        .bind(internal_user_id)
+        .bind(start_epoch_second)
+        .bind(duration_second)
+        .bind(mode)
+        .bind(is_public)
+        .bind(penalty_second)
+        .execute(self).await?;
+        Ok(uuid)
+    }
+
+    async fn update_contest(
+        &self,
+        id: &str,
+        title: &str,
+        memo: &str,
+        start_epoch_second: i64,
+        duration_second: i64,
+        mode: Option<&str>,
+        is_public: bool,
+        penalty_second: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r"
+            UPDATE internal_virtual_contests
+            SET
+                title = $1,
+                memo = $2,
+                start_epoch_second = $3,
+                duration_second = $4,
+                mode = $5,
+                is_public = $6,
+                penalty_second = $7
+            WHERE id = $8
+            ",
+        )
+        .bind(title)
+        .bind(memo)
+        .bind(start_epoch_second)
+        .bind(duration_second)
+        .bind(mode)
+        .bind(is_public)
+        .bind(penalty_second)
+        .bind(id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>> {
+        let data = sqlx::query(
+            r"
+            SELECT 
+                id,
+                title,
+                memo,
+                internal_user_id,
+                start_epoch_second,
+                duration_second,
+                mode,
+                is_public,
+                penalty_second
+            FROM internal_virtual_contests
+            WHERE internal_user_id = $1
+            ",
+        )
+        .bind(internal_user_id)
+        .try_map(virtual_contest_info_mapper)
+        .fetch_all(self)
+        .await?;
+        Ok(data)
+    }
+
+    async fn get_participated_contests(
+        &self,
+        internal_user_id: &str,
+    ) -> Result<Vec<VirtualContestInfo>> {
+        let data = sqlx::query(
+            r"
+            SELECT 
+                a.id,
+                a.title,
+                a.memo,
+                a.internal_user_id,
+                a.start_epoch_second,
+                a.duration_second,
+                a.mode,
+                a.is_public,
+                a.penalty_second
+            FROM internal_virtual_contests AS a
+            LEFT JOIN internal_virtual_contest_participants AS b
+            ON a.id = b.internal_virtual_contest_id
+            WHERE b.internal_user_id = $1
+            ",
+        )
+        .bind(internal_user_id)
+        .try_map(virtual_contest_info_mapper)
+        .fetch_all(self)
+        .await?;
+        Ok(data)
+    }
+
+    async fn get_single_contest_info(&self, contest_id: &str) -> Result<VirtualContestInfo> {
+        sqlx::query(
+            r"
+            SELECT
+                id,
+                title,
+                memo,
+                internal_user_id,
+                start_epoch_second,
+                duration_second,
+                mode,
+                is_public,
+                penalty_second
+            FROM internal_virtual_contests
+            WHERE id = $1
+            ",
+        )
+        .bind(contest_id)
+        .try_map(virtual_contest_info_mapper)
+        .fetch_one(self)
+        .await
+        .map_err(|e| e.into())
+    }
+
+    async fn get_single_contest_participants(&self, contest_id: &str) -> Result<Vec<String>> {
+        let participants = sqlx::query(
+            r"
+            SELECT 
+                b.atcoder_user_id
+            FROM (
+                SELECT internal_user_id
+                FROM internal_virtual_contest_participants
+                WHERE internal_virtual_contest_id = $1
+            ) AS a
+            LEFT JOIN internal_users AS b
+            ON a.internal_user_id = b.internal_user_id
+            WHERE b.atcoder_user_id IS NOT NULL
+            ORDER BY b.atcoder_user_id ASC
+            ",
+        )
+        .bind(contest_id)
+        .try_map(|row: PgRow| row.try_get::<Option<String>, _>("atcoder_user_id"))
+        .fetch_all(self)
+        .await?
+        .into_iter()
+        .filter_map(|participant| participant)
+        .collect::<Vec<String>>();
+
+        Ok(participants)
+    }
+
+    async fn get_single_contest_problems(
+        &self,
+        contest_id: &str,
+    ) -> Result<Vec<VirtualContestItem>> {
+        let problems = sqlx::query(
+            r"
+            SELECT problem_id, user_defined_point, user_defined_order
+            FROM internal_virtual_contest_items
+            WHERE internal_virtual_contest_id = $1
+            ORDER BY user_defined_order ASC, problem_id ASC
+            ",
+        )
+        .bind(contest_id)
+        .try_map(|row: PgRow| {
+            let id: String = row.try_get("problem_id")?;
+            let point: Option<i64> = row.try_get("user_defined_point")?;
+            let order: Option<i64> = row.try_get("user_defined_order")?;
+            Ok(VirtualContestItem { id, point, order })
+        })
+        .fetch_all(self)
+        .await?;
+
+        Ok(problems)
+    }
+
+    async fn get_recent_contest_info(&self) -> Result<Vec<VirtualContestInfo>> {
+        sqlx::query(
+            r"
+            SELECT 
+                id,
+                title,
+                memo,
+                internal_user_id,
+                start_epoch_second,
+                duration_second,
+                mode,
+                is_public,
+                penalty_second
+            FROM internal_virtual_contests
+            WHERE is_public IS TRUE
+            ORDER BY start_epoch_second + duration_second DESC
+            LIMIT $1
+            ",
+        )
+        .bind(RECENT_CONTEST_NUM)
+        .try_map(virtual_contest_info_mapper)
+        .fetch_all(self)
+        .await
+        .map_err(|e| e.into())
+    }
+
+    async fn get_running_contest_problems(&self, time: i64) -> Result<Vec<String>> {
+        sqlx::query(
+            r"
+            SELECT problem_id
+            FROM internal_virtual_contest_items AS a
+            LEFT JOIN internal_virtual_contests AS b
+            ON a.internal_virtual_contest_id = b.id
+            WHERE b.start_epoch_second <= $1
+            AND b.start_epoch_second + b.duration_second >= $1
+            ",
+        )
+        .bind(time)
+        .try_map(|row: PgRow| row.try_get::<String, _>("problem_id"))
+        .fetch_all(self)
+        .await
+        .map_err(|e| e.into())
+    }
+
+    async fn update_items(
+        &self,
+        contest_id: &str,
+        problems: &[VirtualContestItem],
+        user_id: &str,
+    ) -> Result<()> {
+        if problems.len() > MAX_PROBLEM_NUM_PER_CONTEST {
+            bail!("The number of problems exceeded.");
+        }
+
+        sqlx::query(
+            r"
+            SELECT COUNT(*) AS cnt
+            FROM internal_virtual_contests
+            WHERE internal_user_id = $1
+            AND id = $2
+            ",
+        )
+        .bind(user_id)
+        .bind(contest_id)
+        .try_map(|row: PgRow| row.try_get::<u32, _>("cnt"))
+        .fetch_one(self)
+        .await?;
+
+        let (contest_ids, problem_ids, points, orders) = problems.iter().fold(
+            (vec![], vec![], vec![], vec![]),
+            |(mut contest_ids, mut problem_ids, mut points, mut orders), cur| {
+                contest_ids.push(contest_id);
+                problem_ids.push(cur.id.as_str());
+                points.push(cur.point);
+                orders.push(cur.order);
+                (contest_ids, problem_ids, points, orders)
+            },
+        );
+
+        let mut tx = self.begin().await?;
+
+        sqlx::query(
+            r"
+            DELETE FROM internal_virtual_contest_items
+            WHERE internal_virtual_contest_id = $1
+            ",
+        )
+        .bind(contest_id)
+        .execute(&mut tx)
+        .await?;
+
+        // The following is a trick for bulk-inserting.
+        // See: https://github.com/launchbadge/sqlx/issues/571
+        sqlx::query(
+            r"
+            INSERT INTO internal_virtual_contest_items
+            (internal_virtual_contest_id, problem_id, user_defined_point, user_defined_order)
+            VALUES (
+                UNNEST($1::VARCHAR(255)[]),
+                UNNEST($2::VARCHAR(255)[]),
+                UNNEST($3::BIGINT[]}),
+                UNNEST($4::BIGINT[]}),
+            )
+            ",
+        )
+        .bind(contest_ids)
+        .bind(problem_ids)
+        .bind(points)
+        .bind(orders)
+        .execute(&mut tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+
+    async fn join_contest(&self, contest_id: &str, internal_user_id: &str) -> Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO internal_virtual_contest_participants
+            (internal_virtual_contest_id, internal_user_id)
+            VALUES ($1, $2)
+            ",
+        )
+        .bind(contest_id)
+        .bind(internal_user_id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn leave_contest(&self, contest_id: &str, internal_user_id: &str) -> Result<()> {
+        sqlx::query(
+            r"
+            DELETE FROM internal_virtual_contest_participants
+            WHERE internal_virtual_contest_id = $1
+            AND internal_user_id = $2
+            ",
+        )
+        .bind(contest_id)
+        .bind(internal_user_id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
@@ -1,0 +1,230 @@
+use sql_client::internal::virtual_contest_manager::{
+    VirtualContestInfo, VirtualContestItem, VirtualContestManager, MAX_PROBLEM_NUM_PER_CONTEST,
+};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+mod utils;
+
+const TIME_DELTA: i64 = 1000;
+
+fn current_timestamp() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[async_std::test]
+async fn test_virtual_contest_manager() {
+    let now = current_timestamp();
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    let user_id = "user_id";
+    let atcoder_id = "atcoder_id";
+    utils::setup_internal_user(&pool, user_id, atcoder_id).await;
+
+    let recent_contests = pool.get_recent_contest_info().await.unwrap();
+    assert!(
+        recent_contests.is_empty(),
+        "`get_recent_contest_info` here should return an empty list, but got not empty."
+    );
+
+    let running_problems = pool.get_running_contest_problems(now).await.unwrap();
+    assert!(
+        running_problems.is_empty(),
+        "`get_running_contest_problems` here should return an empty list, but got not empty."
+    );
+
+    let owned_contests = pool.get_own_contests(user_id).await.unwrap();
+    assert!(
+        owned_contests.is_empty(),
+        "`get_own_contests` here should return an empty list, but got not empty."
+    );
+
+    let participated_contests = pool.get_participated_contests(user_id).await.unwrap();
+    assert!(
+        participated_contests.is_empty(),
+        "`get_participated_contests` here should return an empty list, but got not empty."
+    );
+
+    let title = "title";
+    let memo = "memo";
+    let start_epoch_second = 0;
+    let duration_second = now.saturating_add(TIME_DELTA); // future
+    let mode = None;
+    let is_public = true;
+    let penalty_second = 42;
+    let contest_id = pool
+        .create_contest(
+            title,
+            memo,
+            user_id,
+            start_epoch_second,
+            duration_second,
+            mode.as_deref(),
+            is_public,
+            penalty_second,
+        )
+        .await
+        .unwrap();
+    let created_contest = VirtualContestInfo {
+        id: contest_id.clone(),
+        title: title.to_string(),
+        memo: memo.to_string(),
+        owner_user_id: user_id.to_string(),
+        start_epoch_second,
+        duration_second,
+        mode: mode.clone(),
+        is_public,
+        penalty_second,
+    };
+    let created_contests = vec![created_contest.clone()];
+
+    let owned_contests = pool.get_own_contests(user_id).await.unwrap();
+    assert_eq!(
+        &owned_contests, &created_contests,
+        "The user should own the contest that has just been created, but not."
+    );
+
+    let recent_contests = pool.get_recent_contest_info().await.unwrap();
+    assert_eq!(
+        &recent_contests, &created_contests,
+        "`get_recent_contest_info` should return the contest that has just been created, but not."
+    );
+
+    let contest_info = pool.get_single_contest_info(&contest_id).await.unwrap();
+    assert_eq!(
+        &contest_info,
+        &created_contest,
+        "There is a difference between the contest that we have just created and the actual saved data."
+    );
+
+    let participants = pool
+        .get_single_contest_participants(&contest_id)
+        .await
+        .unwrap();
+    assert!(
+        participants.is_empty(),
+        "There should be no participants now, but actually not."
+    );
+
+    let problems = pool.get_single_contest_problems(&contest_id).await.unwrap();
+    assert!(
+        problems.is_empty(),
+        "There should be no problems belonging to the contest, but actually not."
+    );
+
+    let added_problems = [
+        VirtualContestItem {
+            id: "0".to_string(),
+            point: Some(100),
+            order: Some(1),
+        },
+        VirtualContestItem {
+            id: "1".to_string(),
+            point: Some(200),
+            order: Some(2),
+        },
+    ];
+    pool.update_items(&contest_id, &added_problems, user_id)
+        .await
+        .unwrap();
+
+    let problems = pool.get_single_contest_problems(&contest_id).await.unwrap();
+    assert_eq!(
+        &problems, &added_problems,
+        "`update_items` failed to add items to the contest."
+    );
+
+    let running_problems = pool.get_running_contest_problems(now).await.unwrap();
+    assert_eq!(
+        running_problems,
+        ["0", "1"],
+        "Could not get the IDs of the running problems."
+    );
+
+    let too_many_problems = (0..=MAX_PROBLEM_NUM_PER_CONTEST)
+        .map(|i| VirtualContestItem {
+            id: i.to_string(),
+            point: Some(i as i64),
+            order: Some(i as i64),
+        })
+        .collect::<Vec<_>>();
+    let update_result = pool
+        .update_items(&contest_id, &too_many_problems, user_id)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        update_result.to_string(),
+        "The number of problems exceeded."
+    );
+
+    pool.join_contest(&contest_id, user_id).await.unwrap();
+
+    let participated_contests = pool.get_participated_contests(user_id).await.unwrap();
+    assert_eq!(
+        &participated_contests, &created_contests,
+        "The user should participate in the contest, but not."
+    );
+    let participants = pool
+        .get_single_contest_participants(&contest_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        participants,
+        [atcoder_id],
+        "Could not get the patticipant AtCoder ID."
+    );
+
+    pool.leave_contest(&contest_id, user_id).await.unwrap();
+
+    let participated_contests = pool.get_participated_contests(user_id).await.unwrap();
+    assert!(
+        participated_contests.is_empty(),
+        "`get_participated_contests` here should return an empty list, but got not empty."
+    );
+    let participants = pool
+        .get_single_contest_participants(&contest_id)
+        .await
+        .unwrap();
+    assert!(
+        participants.is_empty(),
+        "There should be no participants now, but actually not."
+    );
+
+    let updated_duration_second = now.saturating_sub(TIME_DELTA); // past
+    pool.update_contest(
+        &contest_id,
+        title,
+        memo,
+        start_epoch_second,
+        updated_duration_second,
+        mode.as_deref(),
+        is_public,
+        penalty_second,
+    )
+    .await
+    .unwrap();
+
+    let updated_contest_info = pool.get_single_contest_info(&contest_id).await.unwrap();
+    assert_eq!(
+        &updated_contest_info,
+        &VirtualContestInfo {
+            id: contest_id.to_string(),
+            title: title.to_string(),
+            memo: memo.to_string(),
+            owner_user_id: user_id.to_string(),
+            start_epoch_second,
+            duration_second: updated_duration_second,
+            mode: mode.clone(),
+            is_public,
+            penalty_second,
+        },
+        "There is a difference between the contest that we have just updated and the actual saved data."
+    );
+
+    let running_problems = pool.get_running_contest_problems(now).await.unwrap();
+    assert!(
+        running_problems.is_empty(),
+        "`get_running_contest_problems` here should return an empty list, but got not empty."
+    );
+}

--- a/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
@@ -46,15 +46,10 @@ async fn test_virtual_contest_manager() {
         "`get_participated_contests` here should return an empty list, but got not empty."
     );
 
-    let update_err = pool
+    let update_result = pool
         .update_items("THIS_IS_FAKE_CONTEST_ID", &[], user_id)
-        .await
-        .unwrap_err();
-    assert_eq!(
-        update_err.to_string(),
-        "The target contest does not exist.",
-        "The error message is different from what we expect."
-    );
+        .await;
+    assert!(update_result.is_err(), "`update_items` should fail because the wrong contest id was passed, but actually it succeeded.");
 
     let title = "title";
     let memo = "memo";
@@ -123,15 +118,10 @@ async fn test_virtual_contest_manager() {
         "There should be no problems belonging to the contest, but actually not."
     );
 
-    let update_err = pool
+    let update_result = pool
         .update_items(&contest_id, &[], "THIS_IS_ANOTHER_USER")
-        .await
-        .unwrap_err();
-    assert_eq!(
-        update_err.to_string(),
-        "The target contest does not exist.",
-        "The error message is different from what we expect."
-    );
+        .await;
+    assert!(update_result.is_err(), "`update_items` should fail because the wrong user id was passed, but actually it succeeded.");
 
     let added_problems = [
         VirtualContestItem {
@@ -169,11 +159,10 @@ async fn test_virtual_contest_manager() {
             order: Some(i as i64),
         })
         .collect::<Vec<_>>();
-    let update_err = pool
+    let update_result = pool
         .update_items(&contest_id, &too_many_problems, user_id)
-        .await
-        .unwrap_err();
-    assert_eq!(update_err.to_string(), "The number of problems exceeded.");
+        .await;
+    assert!(update_result.is_err(), "`update_items` should fail because too many problems were passed, but actually it succeeded.");
 
     pool.join_contest(&contest_id, user_id).await.unwrap();
 

--- a/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
@@ -215,15 +215,8 @@ async fn test_virtual_contest_manager() {
     assert_eq!(
         &updated_contest_info,
         &VirtualContestInfo {
-            id: contest_id.to_string(),
-            title: title.to_string(),
-            memo: memo.to_string(),
-            owner_user_id: user_id.to_string(),
-            start_epoch_second,
             duration_second: updated_duration_second,
-            mode: mode.clone(),
-            is_public,
-            penalty_second,
+            ..created_contest
         },
         "There is a difference between the contest that we have just updated and the actual saved data."
     );

--- a/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_virtual_contest_manager.rs
@@ -46,6 +46,16 @@ async fn test_virtual_contest_manager() {
         "`get_participated_contests` here should return an empty list, but got not empty."
     );
 
+    let update_err = pool
+        .update_items("THIS_IS_FAKE_CONTEST_ID", &[], user_id)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        update_err.to_string(),
+        "The target contest does not exist.",
+        "The error message is different from what we expect."
+    );
+
     let title = "title";
     let memo = "memo";
     let start_epoch_second = 0;
@@ -113,6 +123,16 @@ async fn test_virtual_contest_manager() {
         "There should be no problems belonging to the contest, but actually not."
     );
 
+    let update_err = pool
+        .update_items(&contest_id, &[], "THIS_IS_ANOTHER_USER")
+        .await
+        .unwrap_err();
+    assert_eq!(
+        update_err.to_string(),
+        "The target contest does not exist.",
+        "The error message is different from what we expect."
+    );
+
     let added_problems = [
         VirtualContestItem {
             id: "0".to_string(),
@@ -149,14 +169,11 @@ async fn test_virtual_contest_manager() {
             order: Some(i as i64),
         })
         .collect::<Vec<_>>();
-    let update_result = pool
+    let update_err = pool
         .update_items(&contest_id, &too_many_problems, user_id)
         .await
         .unwrap_err();
-    assert_eq!(
-        update_result.to_string(),
-        "The number of problems exceeded."
-    );
+    assert_eq!(update_err.to_string(), "The number of problems exceeded.");
 
     pool.join_contest(&contest_id, user_id).await.unwrap();
 


### PR DESCRIPTION
Related issue: #701

`VirtualContestManager` の sqlx 版です。

#### やったこと

- 非同期対応の `VirtualContestManager` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `VirtualContestManager` のテストを作成