### PR TITLE
feat(frontend): add public/private contest display for virtual contests

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -26,11 +26,17 @@ import {
   formatMomentDateTimeDay,
   parseSecond,
 } from "../../../../utils/DateUtil";
-import { formatMode, UserResponse, VirtualContestDetails } from "../../types";
+import {
+  formatMode,
+  UserResponse,
+  VirtualContestDetails,
+  formatPublicState,
+} from "../../types";
 import { TweetButton } from "../../../../components/TweetButton";
 import { GITHUB_LOGIN_LINK } from "../../../../utils/Url";
 import { Timer } from "../../../../components/Timer";
 import { ACCOUNT_INFO } from "../../../../utils/RouterPath";
+import { HelpBadgeTooltip } from "../../../../components/HelpBadgeTooltip";
 import { ContestTable } from "./ContestTable";
 import { LockoutContestTable } from "./LockoutContestTable";
 import { TrainingContestTable } from "./TrainingContestTable";
@@ -127,6 +133,16 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                     ? null
                     : "(Performance estimation is disabled)"}
                 </td>
+              </tr>
+              <tr>
+                <th>
+                  Public State{" "}
+                  <HelpBadgeTooltip id="public-state-explanation">
+                    If the contest is private, it is hidden from the Virtual
+                    Contests page and can only be accessed from the URL.
+                  </HelpBadgeTooltip>
+                </th>
+                <td>{formatPublicState(contestInfo.is_public)}</td>
               </tr>
               <tr>
                 <th>Time</th>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -9,6 +9,7 @@ import {
   Row,
   Spinner,
   Table,
+  Badge,
 } from "reactstrap";
 import Octicon, { Check, Sync, Pin } from "@primer/octicons-react";
 import { Map as ImmutableMap } from "immutable";
@@ -36,7 +37,6 @@ import { TweetButton } from "../../../../components/TweetButton";
 import { GITHUB_LOGIN_LINK } from "../../../../utils/Url";
 import { Timer } from "../../../../components/Timer";
 import { ACCOUNT_INFO } from "../../../../utils/RouterPath";
-import { HelpBadgeTooltip } from "../../../../components/HelpBadgeTooltip";
 import { ContestTable } from "./ContestTable";
 import { LockoutContestTable } from "./LockoutContestTable";
 import { TrainingContestTable } from "./TrainingContestTable";
@@ -117,7 +117,12 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
     <>
       <Row className="my-2">
         <Col sm="12">
-          <h1>{contestInfo.title}</h1>
+          <h1>
+            <Badge pill color={contestInfo.is_public ? "success" : "danger"}>
+              {formatPublicState(contestInfo.is_public)}
+            </Badge>{" "}
+            {contestInfo.title}
+          </h1>
           <h4>{contestInfo.memo}</h4>
         </Col>
       </Row>
@@ -133,16 +138,6 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                     ? null
                     : "(Performance estimation is disabled)"}
                 </td>
-              </tr>
-              <tr>
-                <th>
-                  Public State{" "}
-                  <HelpBadgeTooltip id="public-state-explanation">
-                    If the contest is private, it is hidden from the Virtual
-                    Contests page and can only be accessed from the URL.
-                  </HelpBadgeTooltip>
-                </th>
-                <td>{formatPublicState(contestInfo.is_public)}</td>
               </tr>
               <tr>
                 <th>Time</th>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContestTable.tsx
@@ -1,9 +1,15 @@
 import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
 import { Link } from "react-router-dom";
 import React from "react";
+import { Badge } from "reactstrap";
 import * as DateUtil from "../../utils/DateUtil";
 import { Timer } from "../../components/Timer";
-import { formatMode, VirtualContestInfo, VirtualContestMode } from "./types";
+import {
+  formatMode,
+  VirtualContestInfo,
+  VirtualContestMode,
+  formatPublicState,
+} from "./types";
 
 const formatContestDuration = (
   start: number,
@@ -67,7 +73,12 @@ export const VirtualContestTable: React.FC<Props> = (props) => {
           title: string,
           contest: VirtualContestInfo
         ): React.ReactElement => (
-          <Link to={`/contest/show/${contest.id}`}>{title}</Link>
+          <Link to={`/contest/show/${contest.id}`}>
+            <Badge pill color={contest.is_public ? "success" : "danger"}>
+              {formatPublicState(contest.is_public)}
+            </Badge>{" "}
+            {title}
+          </Link>
         )}
       >
         Title


### PR DESCRIPTION
Resolves #733.

Contest Page（`ShowContest`）、Virtual Contests と My Contests にコンテストは Public か Private を示す機能を作りました。

# プレビュー

## Contest Page

![image](https://user-images.githubusercontent.com/6523469/89154776-26bfb800-d59a-11ea-9701-a4b30d43acad.png)

## Virtual Contests

![image](https://user-images.githubusercontent.com/6523469/89154650-d9434b00-d599-11ea-8d98-a511ba6ad476.png)

## My Contests

![image](https://user-images.githubusercontent.com/6523469/89154661-df392c00-d599-11ea-98d3-13469fd931d8.png)
