### PR TITLE
feat(frontend): add language streaks

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/LanguageCount.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/LanguageCount.tsx
@@ -39,7 +39,6 @@ export const LanguageCount: React.FC<Props> = ({ submissions }) => {
     }
   });
 
-  console.log(languageMap);
   const languageCountStreak = Array.from(languageMap)
     .map(([language, elm]) => ({
       language,

--- a/atcoder-problems-frontend/src/pages/UserPage/LanguageCount.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/LanguageCount.tsx
@@ -3,35 +3,72 @@ import { Row, Col } from "reactstrap";
 import Submission from "../../interfaces/Submission";
 import { isAccepted } from "../../utils";
 import { normalizeLanguage } from "../../utils/LanguageNormalizer";
+import { groupBy } from "../../utils/GroupBy";
+import { ProblemId } from "../../interfaces/Status";
+import { countUniqueAcByDate, calcStreak } from "../../utils/StreakCounter";
+import { formatMomentDate, getToday } from "../../utils/DateUtil";
 
 interface Props {
   submissions: Submission[];
 }
 
 export const LanguageCount: React.FC<Props> = ({ submissions }) => {
-  const languageMap = submissions
-    .filter((s) => isAccepted(s.result))
-    .reduce((map, submission) => {
-      const language = normalizeLanguage(submission.language);
-      const problems = map.get(language);
-      if (problems) {
-        problems.add(submission.problem_id);
-      } else {
-        map.set(language, new Set([submission.problem_id]));
-      }
-      return map;
-    }, new Map<string, Set<string>>());
-  const languageCount = Array.from(languageMap)
-    .map(([language, set]) => ({ language, count: set.size }))
+  const submissionsByLanguage = groupBy(submissions, (s) =>
+    normalizeLanguage(s.language)
+  );
+
+  const languageMap = new Map<
+    string,
+    {
+      problems: Set<ProblemId>;
+      dailyCount: { dateLabel: string; count: number }[];
+    }
+  >();
+  Array.from(submissionsByLanguage).forEach(([language, submissions]) => {
+    const acceptedSet = submissions
+      .filter((s) => isAccepted(s.result))
+      .reduce((set, submission) => {
+        set.add(submission.problem_id);
+        return set;
+      }, new Set<ProblemId>());
+    if (acceptedSet.size > 0) {
+      languageMap.set(language, {
+        problems: acceptedSet,
+        dailyCount: countUniqueAcByDate(submissions),
+      });
+    }
+  });
+
+  console.log(languageMap);
+  const languageCountStreak = Array.from(languageMap)
+    .map(([language, elm]) => ({
+      language,
+      count: elm.problems.size,
+      ...calcStreak(elm.dailyCount),
+    }))
     .sort((a, b) => a.language.localeCompare(b.language));
+  const yesterdayLabel = formatMomentDate(getToday().add(-1, "day"));
+
   return (
     <Row>
-      {languageCount.map(({ language, count }) => (
-        <Col key={language} className="text-center my-3" md="3" xs="6">
-          <h6>{language}</h6>
-          <h3>{count}</h3>
-        </Col>
-      ))}
+      {languageCountStreak.map(
+        ({ language, count, longestStreak, currentStreak, prevDateLabel }) => {
+          const isIncreasing = prevDateLabel >= yesterdayLabel;
+          return (
+            <Col key={language} className="text-center my-3" md="3" xs="6">
+              <h6>{language}</h6>
+              <h3>{count}</h3>
+              <h6 className="text-muted">
+                Longest Streak: {longestStreak} days
+              </h6>
+              <h6 className="text-muted">
+                Current Streak: {isIncreasing ? currentStreak : 0} days
+              </h6>
+              <h6 className="text-muted">Last AC: {prevDateLabel}</h6>
+            </Col>
+          );
+        }
+      )}
     </Row>
   );
 };


### PR DESCRIPTION
Resolves #661.

言語ごとのLongest Streak, Current Streak, Last ACを UserPage -> languages に実装しました.

# Preview
![コメント 2020-08-03 164812](https://user-images.githubusercontent.com/25875917/89160758-8b840e00-d5ac-11ea-82b7-f6dbc02f6d9a.jpg)
