### PR TITLE
fix(frontend): remove container around table page options

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
@@ -4,7 +4,6 @@ import {
   FormGroup,
   Input,
   Label,
-  Container,
   Row,
   Col,
   UncontrolledDropdown,
@@ -33,7 +32,7 @@ interface Props {
 
 export const Options: React.FC<Props> = (props) => {
   return (
-    <Container>
+    <>
       <Row className="my-4">
         <FormGroup check inline>
           <Label check>
@@ -56,6 +55,7 @@ export const Options: React.FC<Props> = (props) => {
               onChange={props.toggleShowDifficulties}
             />
           </Label>
+          &nbsp;
           <HelpBadgeTooltip id="difficulty">
             Internal rating to have 50% Solve Probability
           </HelpBadgeTooltip>
@@ -131,6 +131,6 @@ export const Options: React.FC<Props> = (props) => {
             </Col>
           </Row>
         )}
-    </Container>
+    </>
   );
 };


### PR DESCRIPTION
Table ページに、Options の左にスペース（赤の部分）がワイドスクリーンで見るとちょっとおかしいですので、Container を除きました。

## Before
![image](https://user-images.githubusercontent.com/6523469/89433138-883b7e80-d774-11ea-912c-7c12b557383e.png)

## After
![image](https://user-images.githubusercontent.com/6523469/89433302-bf119480-d774-11ea-9a41-4eed36c5471d.png)

