### PR TITLE
fix(frontend): change wrongly sanitized IDs in training mode tooltips

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
@@ -23,7 +23,7 @@ export const SmallScoreCell: React.FC<Props> = (props) => {
   const { maxPoint, trials, problem, time, id } = props;
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const sanitizedId = id.replace(/[^A-Za-z_-]/g, "");
+  const sanitizedId = id.replace(/[^A-Za-z0-9_-]/g, "");
   const cellId = `small-score-cell-${sanitizedId}`;
   const classes =
     "small-score-cell " +

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
@@ -23,7 +23,7 @@ export const SmallScoreCell: React.FC<Props> = (props) => {
   const { maxPoint, trials, problem, time, id } = props;
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const sanitizedId = id.replace(/[^A-Za-z0-9_-]/g, "");
+  const sanitizedId = id.replace(/[ #]/g, "");
   const cellId = `small-score-cell-${sanitizedId}`;
   const classes =
     "small-score-cell " +


### PR DESCRIPTION
Fixes #742, introduced by #721.

忘れてしまいまして、数字も削除されました。数字が残るようにしました。

![image](https://user-images.githubusercontent.com/6523469/89524640-7ced5f00-d817-11ea-81c3-8dc5871168ec.png)
