### PR TITLE
 [replacement with sqlx] AcceptedCountClient

### DIFF
--- a/atcoder-problems-backend/sql-client/src/accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/accepted_count.rs
@@ -1,0 +1,107 @@
+use crate::models::{Submission, UserProblemCount};
+use crate::{PgPool, MAX_INSERT_ROWS};
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[async_trait]
+pub trait AcceptedCountClient {
+    async fn load_accepted_count(&self) -> Result<Vec<UserProblemCount>>;
+    async fn get_users_accepted_count(&self, user_id: &str) -> Option<i32>;
+    async fn get_accepted_count_rank(&self, accepted_count: i32) -> Result<i64>;
+    async fn update_accepted_count(&self, submissions: &[Submission]) -> Result<()>;
+}
+
+#[async_trait]
+impl AcceptedCountClient for PgPool {
+    async fn load_accepted_count(&self) -> Result<Vec<UserProblemCount>> {
+        let count = sqlx::query(
+            r"
+            SELECT user_id, problem_count FROM accepted_count
+            ORDER BY problem_count DESC, user_id ASC
+            ",
+        )
+        .try_map(|row: PgRow| {
+            let user_id: String = row.try_get("user_id")?;
+            let problem_count: i32 = row.try_get("problem_count")?;
+            Ok(UserProblemCount {
+                user_id,
+                problem_count,
+            })
+        })
+        .fetch_all(self)
+        .await?;
+
+        Ok(count)
+    }
+
+    async fn get_users_accepted_count(&self, user_id: &str) -> Option<i32> {
+        let count = sqlx::query(
+            r"
+            SELECT problem_count FROM accepted_count
+            WHERE user_id = $1
+            ",
+        )
+        .bind(user_id)
+        .try_map(|row: PgRow| row.try_get::<i32, _>("problem_count"))
+        .fetch_one(self)
+        .await
+        .ok()?;
+
+        Some(count)
+    }
+
+    async fn get_accepted_count_rank(&self, accepted_count: i32) -> Result<i64> {
+        let rank = sqlx::query(
+            r"
+            SELECT COUNT(*) AS rank
+            FROM accepted_count
+            WHERE problem_count > $1
+            ",
+        )
+        .bind(accepted_count)
+        .try_map(|row: PgRow| row.try_get::<i64, _>("rank"))
+        .fetch_one(self)
+        .await?;
+
+        Ok(rank)
+    }
+
+    async fn update_accepted_count(&self, submissions: &[Submission]) -> Result<()> {
+        let accepted_count = submissions
+            .iter()
+            .map(|s| (s.user_id.as_str(), s.problem_id.as_str()))
+            .fold(BTreeMap::new(), |mut map, (user_id, problem_id)| {
+                map.entry(user_id)
+                    .or_insert_with(BTreeSet::new)
+                    .insert(problem_id);
+                map
+            })
+            .into_iter()
+            .map(|(user_id, set)| (user_id, set.len() as i32))
+            .collect::<Vec<_>>();
+
+        for chunk in accepted_count.chunks(MAX_INSERT_ROWS) {
+            let (user_ids, ac_counts): (Vec<&str>, Vec<i32>) = chunk.iter().copied().unzip();
+            sqlx::query(
+                r"
+                INSERT INTO accepted_count (user_id, problem_count)
+                VALUES (
+                    UNNEST($1::VARCHAR(255)[]),
+                    UNNEST($2::INTEGER[])
+                )
+                ON CONFLICT (user_id)
+                DO UPDATE SET problem_count = EXCLUDED.problem_count
+                ",
+            )
+            .bind(user_ids)
+            .bind(ac_counts)
+            .execute(self)
+            .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -1,9 +1,15 @@
 use anyhow::Result;
 use std::time::Duration;
 
+pub mod accepted_count;
 pub mod internal;
+pub mod models;
 
 pub type PgPool = sqlx::postgres::PgPool;
+
+const FIRST_AGC_EPOCH_SECOND: i64 = 1_468_670_400;
+const UNRATED_STATE: &str = "-";
+const MAX_INSERT_ROWS: usize = 10_000;
 
 pub async fn initialize_pool<S: AsRef<str>>(database_url: S) -> Result<PgPool> {
     let pool = PgPool::builder()

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
+pub struct Submission {
+    pub id: i64,
+    pub epoch_second: i64,
+    pub problem_id: String,
+    pub contest_id: String,
+    pub user_id: String,
+    pub language: String,
+    pub point: f64,
+    pub length: i32,
+    pub result: String,
+    pub execution_time: Option<i32>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct UserProblemCount {
+    pub user_id: String,
+    pub problem_count: i32,
+}

--- a/atcoder-problems-backend/sql-client/tests/test_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_accepted_count.rs
@@ -1,0 +1,73 @@
+use sql_client::accepted_count::AcceptedCountClient;
+use sql_client::models::{Submission, UserProblemCount};
+
+mod utils;
+
+#[async_std::test]
+async fn test_accepted_count() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    let submissions = [
+        Submission {
+            id: 1,
+            user_id: "user1".to_owned(),
+            problem_id: "problem1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 2,
+            user_id: "user1".to_owned(),
+            problem_id: "problem1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 3,
+            user_id: "user1".to_owned(),
+            problem_id: "problem2".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 4,
+            user_id: "user2".to_owned(),
+            problem_id: "problem1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 5,
+            user_id: "user2".to_owned(),
+            problem_id: "problem2".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 6,
+            user_id: "user2".to_owned(),
+            problem_id: "problem3".to_owned(),
+            ..Default::default()
+        },
+    ];
+    pool.update_accepted_count(&submissions).await.unwrap();
+
+    let accepted_count = pool.load_accepted_count().await.unwrap();
+    assert_eq!(
+        accepted_count,
+        vec![
+            UserProblemCount {
+                user_id: "user2".to_owned(),
+                problem_count: 3
+            },
+            UserProblemCount {
+                user_id: "user1".to_owned(),
+                problem_count: 2
+            }
+        ]
+    );
+
+    assert_eq!(pool.get_users_accepted_count("user1").await.unwrap(), 2);
+    assert_eq!(pool.get_users_accepted_count("user2").await.unwrap(), 3);
+    assert_eq!(pool.get_accepted_count_rank(3).await.unwrap(), 0);
+    assert_eq!(pool.get_accepted_count_rank(2).await.unwrap(), 1);
+
+    assert!(pool
+        .get_users_accepted_count("non_existing_user")
+        .await
+        .is_none());
+}


### PR DESCRIPTION
Related issue: #701

`AcceptedCountClient` の sqlx 版です。

#### やったこと

- 非同期対応の `AcceptedCountClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `AcceptedCountClient` のテストを作成（もとのテストを踏襲）