### PR TITLE
[replacement with sqlx] ContestProblemClient

### DIFF
--- a/atcoder-problems-backend/sql-client/src/contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/src/contest_problem.rs
@@ -7,19 +7,19 @@ use sqlx::Row;
 
 #[async_trait]
 pub trait ContestProblemClient {
-    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<usize>;
+    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<()>;
     async fn load_contest_problem(&self) -> Result<Vec<ContestProblem>>;
 }
 
 #[async_trait]
 impl ContestProblemClient for PgPool {
-    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<usize> {
+    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<()> {
         let (contest_ids, problem_ids): (Vec<&str>, Vec<&str>) = contest_problems
             .iter()
             .map(|c| (c.contest_id.as_str(), c.problem_id.as_str()))
             .unzip();
 
-        let result = sqlx::query(
+        sqlx::query(
             r"
             INSERT INTO contest_problem (contest_id, problem_id)
             VALUES (
@@ -34,7 +34,7 @@ impl ContestProblemClient for PgPool {
         .execute(self)
         .await?;
 
-        Ok(result as usize)
+        Ok(())
     }
 
     async fn load_contest_problem(&self) -> Result<Vec<ContestProblem>> {

--- a/atcoder-problems-backend/sql-client/src/contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/src/contest_problem.rs
@@ -1,0 +1,55 @@
+use crate::models::ContestProblem;
+use crate::PgPool;
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+#[async_trait]
+pub trait ContestProblemClient {
+    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<usize>;
+    async fn load_contest_problem(&self) -> Result<Vec<ContestProblem>>;
+}
+
+#[async_trait]
+impl ContestProblemClient for PgPool {
+    async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<usize> {
+        let (contest_ids, problem_ids): (Vec<&str>, Vec<&str>) = contest_problems
+            .iter()
+            .map(|c| (c.contest_id.as_str(), c.problem_id.as_str()))
+            .unzip();
+
+        let result = sqlx::query(
+            r"
+            INSERT INTO contest_problem (contest_id, problem_id)
+            VALUES (
+                UNNEST($1::VARCHAR(255)[]),
+                UNNEST($2::VARCHAR(255)[])
+            )
+            ON CONFLICT DO NOTHING
+            ",
+        )
+        .bind(contest_ids)
+        .bind(problem_ids)
+        .execute(self)
+        .await?;
+
+        Ok(result as usize)
+    }
+
+    async fn load_contest_problem(&self) -> Result<Vec<ContestProblem>> {
+        let problems = sqlx::query("SELECT contest_id, problem_id FROM contest_problem")
+            .try_map(|row: PgRow| {
+                let contest_id: String = row.try_get("contest_id")?;
+                let problem_id: String = row.try_get("problem_id")?;
+                Ok(ContestProblem {
+                    contest_id,
+                    problem_id,
+                })
+            })
+            .fetch_all(self)
+            .await?;
+
+        Ok(problems)
+    }
+}

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::time::Duration;
 
 pub mod accepted_count;
+pub mod contest_problem;
 pub mod internal;
 pub mod models;
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -19,3 +19,9 @@ pub struct UserProblemCount {
     pub user_id: String,
     pub problem_count: i32,
 }
+
+#[derive(PartialEq, Debug, Serialize)]
+pub struct ContestProblem {
+    pub contest_id: String,
+    pub problem_id: String,
+}

--- a/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
@@ -1,0 +1,36 @@
+use sql_client::contest_problem::ContestProblemClient;
+use sql_client::models::ContestProblem;
+
+mod utils;
+
+fn create_problem(id: i32) -> ContestProblem {
+    ContestProblem {
+        contest_id: format!("contest{}", id),
+        problem_id: format!("problem{}", id),
+    }
+}
+
+#[async_std::test]
+async fn test_contest_problem() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    assert!(pool.load_contest_problem().await.unwrap().is_empty());
+
+    let inserted_rows = pool
+        .insert_contest_problem(&vec![create_problem(1), create_problem(2)])
+        .await
+        .unwrap();
+    assert_eq!(inserted_rows, 2);
+    assert_eq!(
+        pool.load_contest_problem().await.unwrap(),
+        vec![create_problem(1), create_problem(2)]
+    );
+    let inserted_rows = pool
+        .insert_contest_problem(&vec![create_problem(1)])
+        .await
+        .unwrap();
+    assert_eq!(inserted_rows, 0);
+    assert_eq!(
+        pool.load_contest_problem().await.unwrap(),
+        vec![create_problem(1), create_problem(2)]
+    );
+}

--- a/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
@@ -15,20 +15,16 @@ async fn test_contest_problem() {
     let pool = utils::initialize_and_connect_to_test_sql().await;
     assert!(pool.load_contest_problem().await.unwrap().is_empty());
 
-    let inserted_rows = pool
-        .insert_contest_problem(&vec![create_problem(1), create_problem(2)])
+    pool.insert_contest_problem(&vec![create_problem(1), create_problem(2)])
         .await
         .unwrap();
-    assert_eq!(inserted_rows, 2);
     assert_eq!(
         pool.load_contest_problem().await.unwrap(),
         vec![create_problem(1), create_problem(2)]
     );
-    let inserted_rows = pool
-        .insert_contest_problem(&vec![create_problem(1)])
+    pool.insert_contest_problem(&vec![create_problem(1)])
         .await
         .unwrap();
-    assert_eq!(inserted_rows, 0);
     assert_eq!(
         pool.load_contest_problem().await.unwrap(),
         vec![create_problem(1), create_problem(2)]


### PR DESCRIPTION
Related issue: #701

`ContestProblemClient` の sqlx 版です。

#### やったこと

- 非同期対応の `ContestProblemClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `ContestProblemClient` のテストを作成（もとのテストをだいたい踏襲。`insert_contest_problems` の戻り値に対するアサーションを追加）
