### PR TITLE
Color in status table cells for completed categories

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/DifficultyTable.tsx
@@ -3,6 +3,7 @@ import Table from "reactstrap/lib/Table";
 import { List, Map as ImmutableMap, Range } from "immutable";
 import { Button, ButtonGroup } from "reactstrap";
 import { isAccepted } from "../../utils";
+import { TableColor } from "../../utils/TableColor";
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
 import ProblemModel from "../../interfaces/ProblemModel";
@@ -154,8 +155,15 @@ export const DifficultyTable: React.FC<Props> = (props) => {
           {userDiffCount.map(({ userId, diffCount }) => (
             <tr key={userId}>
               <td>{userId}</td>
-              {totalCount.map(({ difficultyLevel }) => (
-                <td key={difficultyLevel}>
+              {totalCount.map(({ difficultyLevel, count }) => (
+                <td
+                  key={difficultyLevel}
+                  className={
+                    diffCount.get(difficultyLevel) === count
+                      ? TableColor.Success
+                      : TableColor.None
+                  }
+                >
                   {diffCount.get(difficultyLevel) ?? 0}
                 </td>
               ))}

--- a/atcoder-problems-frontend/src/pages/ListPage/SmallTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/SmallTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Table from "reactstrap/lib/Table";
 import { Map as ImmutableMap } from "immutable";
 import { isAccepted } from "../../utils";
+import { TableColor } from "../../utils/TableColor";
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
 
@@ -78,8 +79,17 @@ export const SmallTable: React.FC<Props> = ({
         {userPointCountMap.map(({ userId, pointCountMap }) => (
           <tr key={userId}>
             <td>{userId}</td>
-            {totalCount.map(({ point }) => (
-              <td key={point}>{pointCountMap.get(point) ?? 0}</td>
+            {totalCount.map(({ point, count }) => (
+              <td
+                key={point}
+                className={
+                  pointCountMap.get(point) === count
+                    ? TableColor.Success
+                    : TableColor.None
+                }
+              >
+                {pointCountMap.get(point) ?? 0}
+              </td>
             ))}
           </tr>
         ))}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59337901/89752327-e9fe3e80-db0e-11ea-8cc7-1bab9b175fb4.png)

- Point Status, Difficulty Status のテーブルで，埋め終わっているところのセルは背景を塗るようにしました．
  - 塗られて困る人もいないだろうということで，on/off 機能は付けていません．UIもごちゃごちゃしそうですし．
- Difficulty Pie 登場以後も，こちらのテーブルで埋め進捗が共有されている場面をそれなりに目にするので，塗られたほうが嬉しい人はそれなりにいるのではないかと踏んでいます．