### PR TITLE
feat(frontend): group trophies of the same type together

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACCountTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACCountTrophyGenerator.ts
@@ -27,15 +27,32 @@ const generateACCountTrophiesByTag = (
     ["You're tourist of Solving.", 3500],
   ];
 
-  return milestones.map(([draftTitle, milestoneCount]) => {
+  return milestones.map(([draftTitle, milestoneCount], index) => {
     const header = tag ? `[${tag}] ` : "";
     const title = header + draftTitle;
     const reason = header + `AC count >= ${milestoneCount}`;
     const achieved = count >= milestoneCount;
+    const subgroup = header + "AC Count";
     const sortId = `ac-count-${idPrefix}-${milestoneCount
       .toString()
       .padStart(5, "0")}`;
-    return { title, reason, achieved, sortId, group: "AC Count" };
+    const dependsOn =
+      index > 0
+        ? [
+            `ac-count-${idPrefix}-${milestones[index - 1][1]
+              .toString()
+              .padStart(5, "0")}`,
+          ]
+        : [];
+    return {
+      title,
+      reason,
+      achieved,
+      sortId,
+      group: "AC Count",
+      subgroup,
+      dependsOn,
+    };
   });
 };
 

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACProblemsTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/ACProblemsTrophyGenerator.ts
@@ -10,7 +10,15 @@ const generateACTrophiesWithOneProblem = (
   return milestones.map(([title, reason, problem_id]) => {
     const achieved = acProblemIds.has(problem_id);
     const sortId = `accepted-problem-${problem_id}`;
-    return { title, reason, achieved, sortId, group: "Problems" };
+    return {
+      title,
+      reason,
+      achieved,
+      sortId,
+      group: "Problems",
+      subgroup: "Problems",
+      dependsOn: [],
+    };
   });
 };
 

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/CompleteContestTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/CompleteContestTrophyGenerator.ts
@@ -30,7 +30,15 @@ const generateCompleteContestTrophy = (
     solvedProblemIdSet
   );
   const sortId = `complete-contest-${contestId}`;
-  return { title, reason, achieved, sortId, group: "Contests" };
+  return {
+    title,
+    reason,
+    achieved,
+    sortId,
+    group: "Contests",
+    subgroup: "Completed Contests",
+    dependsOn: [],
+  };
 };
 
 const uniqueACProblemIds = (submissions: TrophySubmission[]): Set<string> => {

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
@@ -32,16 +32,27 @@ const generateStreakTrophiesByTag = (
     mileStones.push([`Keep solving problems for ${i} days`, i]);
   }
 
-  return mileStones.map(([draftTitle, days]) => {
-    const header = tag ? `[${tag}] ` : "";
-    const title = header + draftTitle;
-    const reason = header + `Longest Streak >= ${days} days`;
-    const achieved = longestStreak >= days;
-    const sortId = `longest-streak-${idPrefix}-${days
-      .toString()
-      .padStart(4, "0")}`;
-    return { title, reason, achieved, sortId, group: "Streak" };
-  });
+  return mileStones
+    .sort(([, daysA], [, daysB]) => daysB - daysA)
+    .map(([draftTitle, days]) => {
+      const header = tag ? `[${tag}] ` : "";
+      const title = header + draftTitle;
+      const reason = header + `Longest Streak >= ${days} days`;
+      const achieved = longestStreak >= days;
+      const subgroup = header + "Longest Streak";
+      const sortId = `longest-streak-${idPrefix}-${days
+        .toString()
+        .padStart(4, "0")}`;
+      return {
+        title,
+        reason,
+        achieved,
+        sortId,
+        group: "Streak",
+        subgroup,
+        dependsOn: [],
+      };
+    });
 };
 
 const calcSubmissionsStreak = (

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
@@ -33,8 +33,9 @@ const generateStreakTrophiesByTag = (
   }
 
   return mileStones
-    .sort(([, daysA], [, daysB]) => daysB - daysA)
+    .sort(([, daysA], [, daysB]) => daysA - daysB)
     .map(([draftTitle, days], index, mileStones) => {
+      console.log(mileStones);
       const header = tag ? `[${tag}] ` : "";
       const title = header + draftTitle;
       const reason = header + `Longest Streak >= ${days} days`;
@@ -48,7 +49,7 @@ const generateStreakTrophiesByTag = (
           ? [
               `longest-streak-${idPrefix}-${mileStones[index - 1][1]
                 .toString()
-                .padStart(5, "0")}`,
+                .padStart(4, "0")}`,
             ]
           : [];
       return {

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/StreakTrophyGenerator.ts
@@ -34,7 +34,7 @@ const generateStreakTrophiesByTag = (
 
   return mileStones
     .sort(([, daysA], [, daysB]) => daysB - daysA)
-    .map(([draftTitle, days]) => {
+    .map(([draftTitle, days], index, mileStones) => {
       const header = tag ? `[${tag}] ` : "";
       const title = header + draftTitle;
       const reason = header + `Longest Streak >= ${days} days`;
@@ -43,6 +43,14 @@ const generateStreakTrophiesByTag = (
       const sortId = `longest-streak-${idPrefix}-${days
         .toString()
         .padStart(4, "0")}`;
+      const dependsOn =
+        index > 0
+          ? [
+              `longest-streak-${idPrefix}-${mileStones[index - 1][1]
+                .toString()
+                .padStart(5, "0")}`,
+            ]
+          : [];
       return {
         title,
         reason,
@@ -50,7 +58,7 @@ const generateStreakTrophiesByTag = (
         sortId,
         group: "Streak",
         subgroup,
-        dependsOn: [],
+        dependsOn,
       };
     });
 };

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/Trophy.ts
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/Trophy.ts
@@ -6,7 +6,9 @@ export interface Trophy {
   reason: string;
   achieved: boolean;
   sortId: string;
+  dependsOn: string[];
   group: TrophyGroup;
+  subgroup: string;
 }
 
 export const TrophyGroups = [

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
@@ -1,16 +1,17 @@
-import Octicon, { Verified } from "@primer/octicons-react";
 import React, { useState } from "react";
-import { Table, Row, Col, ListGroup, ListGroupItem, Badge } from "reactstrap";
+import { Row, Col, ListGroup, ListGroupItem, Badge } from "reactstrap";
 import Contest from "../../../interfaces/Contest";
 import Problem from "../../../interfaces/Problem";
 import ProblemModel from "../../../interfaces/ProblemModel";
 import { ContestId, ProblemId } from "../../../interfaces/Status";
 import Submission from "../../../interfaces/Submission";
+import { groupBy } from "../../../utils/GroupBy";
 import { generateACCountTrophies } from "./ACCountTrophyGenerator";
 import { generateACProblemsTrophies } from "./ACProblemsTrophyGenerator";
 import { generateStreakTrophies } from "./StreakTrophyGenerator";
 import { generateCompleteContestTrophies } from "./CompleteContestTrophyGenerator";
 import { Trophy, TrophyGroup, TrophyGroups } from "./Trophy";
+import { TrophySubgroup } from "./TrophySubgroup";
 
 interface Props {
   submissions: Submission[];
@@ -42,6 +43,11 @@ export const TrophyBlock = (props: Props): JSX.Element => {
   const filteredTrophies = trophies
     .sort((a, b) => a.sortId.localeCompare(b.sortId))
     .filter((t) => filterGroup === "All" || t.group === filterGroup);
+  const subgroupedTrophies = groupBy(filteredTrophies, (t) => t.subgroup);
+
+  const achievedIds = new Set(
+    trophies.filter((t) => t.achieved).map((t) => t.sortId)
+  );
 
   const groupChoices: [TrophyGroup | "All", number][] = [
     ["All", trophies.filter((t) => t.achieved).length],
@@ -57,7 +63,7 @@ export const TrophyBlock = (props: Props): JSX.Element => {
   return (
     <>
       <Row className="my-2">
-        <h2>{trophies.length} Trophies</h2>
+        <h2>{achievedIds.size} Trophies</h2>
       </Row>
       <Row>
         <Col md="12" lg="3" className="mb-3">
@@ -76,21 +82,16 @@ export const TrophyBlock = (props: Props): JSX.Element => {
           </ListGroup>
         </Col>
         <Col md="12" lg="9">
-          <Table striped hover>
-            <tbody>
-              {filteredTrophies.map(({ sortId, title, reason, achieved }) => (
-                <tr key={sortId}>
-                  <th className="text-success">
-                    {achieved && <Octicon icon={Verified} />}
-                  </th>
-                  <td>
-                    <b>{achieved ? title : "???"}</b>
-                  </td>
-                  <td>{reason}</td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
+          {Array.from(subgroupedTrophies.entries()).map(
+            ([subgroup, trophies]) => (
+              <TrophySubgroup
+                key={`trophy-subgroup-${subgroup.replace(/[ #]/g, "-")}`}
+                achievedIds={achievedIds}
+                title={subgroup}
+                trophies={trophies}
+              />
+            )
+          )}
         </Col>
       </Row>
     </>

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophyBlock.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Row, Col, ListGroup, ListGroupItem, Badge } from "reactstrap";
+import React from "react";
+import { Row, Col } from "reactstrap";
 import Contest from "../../../interfaces/Contest";
 import Problem from "../../../interfaces/Problem";
 import ProblemModel from "../../../interfaces/ProblemModel";
@@ -10,7 +10,7 @@ import { generateACCountTrophies } from "./ACCountTrophyGenerator";
 import { generateACProblemsTrophies } from "./ACProblemsTrophyGenerator";
 import { generateStreakTrophies } from "./StreakTrophyGenerator";
 import { generateCompleteContestTrophies } from "./CompleteContestTrophyGenerator";
-import { Trophy, TrophyGroup, TrophyGroups } from "./Trophy";
+import { Trophy, TrophyGroup } from "./Trophy";
 import { TrophySubgroup } from "./TrophySubgroup";
 
 interface Props {
@@ -39,61 +39,40 @@ export const TrophyBlock = (props: Props): JSX.Element => {
     )
   );
 
-  const [filterGroup, setFilterGroup] = useState<TrophyGroup | "All">("All");
-  const filteredTrophies = trophies
-    .sort((a, b) => a.sortId.localeCompare(b.sortId))
-    .filter((t) => filterGroup === "All" || t.group === filterGroup);
-  const subgroupedTrophies = groupBy(filteredTrophies, (t) => t.subgroup);
+  const sortedTrophies = trophies.sort((a, b) =>
+    a.sortId.localeCompare(b.sortId)
+  );
+  const groupedTrophies: [TrophyGroup, [string, Trophy[]][]][] = Array.from(
+    groupBy(sortedTrophies, (t) => t.group).entries()
+  ).map(([group, trophies]) => [
+    group,
+    Array.from(groupBy(trophies, (t) => t.subgroup).entries()),
+  ]);
 
   const achievedIds = new Set(
     trophies.filter((t) => t.achieved).map((t) => t.sortId)
   );
-
-  const groupChoices: [TrophyGroup | "All", number][] = [
-    ["All", trophies.filter((t) => t.achieved).length],
-    ...TrophyGroups.map(
-      (group) =>
-        [
-          group,
-          trophies.filter((t) => t.group === group && t.achieved).length,
-        ] as [TrophyGroup, number]
-    ),
-  ];
 
   return (
     <>
       <Row className="my-2">
         <h2>{achievedIds.size} Trophies</h2>
       </Row>
-      <Row>
-        <Col md="12" lg="3" className="mb-3">
-          <ListGroup>
-            {groupChoices.map(([group, count]) => (
-              <ListGroupItem
-                key={group}
-                tag="button"
-                action
-                active={filterGroup === group}
-                onClick={() => setFilterGroup(group)}
-              >
-                {group} <Badge pill>{count}</Badge>
-              </ListGroupItem>
-            ))}
-          </ListGroup>
-        </Col>
-        <Col md="12" lg="9">
-          {Array.from(subgroupedTrophies.entries()).map(
-            ([subgroup, trophies]) => (
+      {groupedTrophies.map(([group, subgroupedTrophies]) => (
+        <Row key={`trophy-group-${group.replace(/[ #]/g, "-")}`}>
+          <Col>
+            <h3>{group}</h3>
+            {subgroupedTrophies.map(([subgroup, trophies]) => (
               <TrophySubgroup
                 key={`trophy-subgroup-${subgroup.replace(/[ #]/g, "-")}`}
                 achievedIds={achievedIds}
                 title={subgroup}
                 trophies={trophies}
               />
-            )
-          )}
-        </Col>
-      </Row>
+            ))}
+          </Col>
+        </Row>
+      ))}
     </>
   );
 };

--- a/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophySubgroup.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/TrophyBlock/TrophySubgroup.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { Table, Badge } from "reactstrap";
+import Octicon, {
+  Verified,
+  TriangleDown,
+  TriangleRight,
+} from "@primer/octicons-react";
+import { Trophy } from "./Trophy";
+
+interface Props {
+  achievedIds: Set<string>;
+  title: string;
+  trophies: Trophy[];
+}
+
+export const TrophySubgroup = (props: Props) => {
+  const { achievedIds, title, trophies } = props;
+  const [showTrophies, setShowTrophies] = useState(false);
+
+  const achievedTrophies = trophies.filter((t) => t.achieved);
+  const displayedTrophies = trophies.filter(
+    (t) =>
+      t.achieved ||
+      t.dependsOn.every((dependency) => achievedIds.has(dependency))
+  );
+
+  return (
+    <>
+      <h5
+        onClick={() => setShowTrophies(!showTrophies)}
+        style={{ cursor: "pointer" }}
+      >
+        <Octicon
+          size="small"
+          icon={showTrophies ? TriangleDown : TriangleRight}
+          verticalAlign="middle"
+        />{" "}
+        <Badge
+          pill
+          color={
+            achievedTrophies.length === trophies.length ? "success" : "primary"
+          }
+        >
+          {achievedTrophies.length}
+        </Badge>{" "}
+        {title}
+      </h5>
+
+      {showTrophies ? (
+        <Table striped hover>
+          <tbody>
+            {displayedTrophies.map(({ sortId, title, reason, achieved }) => (
+              <tr key={sortId}>
+                <th className="text-success">
+                  {achieved && <Octicon icon={Verified} />}
+                </th>
+                <td>
+                  <b>{achieved ? title : "???"}</b>
+                </td>
+                <td>{reason}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      ) : null}
+    </>
+  );
+};


### PR DESCRIPTION
## Motivation

The "Trophy" feature in the user page is a source of motivation for AtCoder users. However, too many unachieved trophies are displayed when the user tries to read the Trophy page, and it is difficult to see an overview of all the trophies achieved.

## Modifications

- Added `subgroup` field to `Trophy`, which allows us to group together trophies of the same type (e.g. [C++] Longest Streak)
  - The naming of this field might not be clear, and could be changed.
- Added `dependsOn` field to `Trophy`, which allows us to show only trophies that can be achieved next.

I look forward to your review.

## Preview

![image](https://user-images.githubusercontent.com/6523469/89882090-e646e680-dbf8-11ea-9510-5f4c9c665585.png)