### PR TITLE
Make style of cell of VirtualContest standings compact.

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ScoreCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ScoreCell.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export const ScoreCell: React.FC<Props> = (props) => (
   <>
-    <p style={{ textAlign: "center" }}>
+    <p style={{ textAlign: "center", margin: 0 }}>
       <span style={{ color: "limegreen", fontWeight: "bold" }}>
         {props.maxPoint}
       </span>{" "}
@@ -17,7 +17,7 @@ export const ScoreCell: React.FC<Props> = (props) => (
         {props.trials === 0 ? "" : `(${props.trials})`}
       </span>
     </p>
-    <p style={{ textAlign: "center" }}>
+    <p style={{ textAlign: "center", margin: 0 }}>
       <span style={{ color: "gray" }}>
         {props.maxPoint === 0 ? "-" : formatDuration(props.time)}
       </span>


### PR DESCRIPTION
Resolve problem (#761 B)

#### Before
![2020-08-12](https://user-images.githubusercontent.com/8394202/89941478-0953b380-dc56-11ea-8529-0e659f5f1ec8.png)

#### After
![2020-08-12 (1)](https://user-images.githubusercontent.com/8394202/89942249-305eb500-dc57-11ea-9662-e08d08645ddb.png)