### PR TITLE
frontend: style changes to ShowContest

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -120,7 +120,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
   });
   return (
     <>
-      <Row>
+      <Row className="mb-2">
         <Col md="auto">
           <h1>{contestInfo.title}</h1>
         </Col>
@@ -137,8 +137,8 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
         </Col>
       </Row>
       <Row className="my-2">
-        <Col>
-          <Table>
+        <Col lg="6" md="12">
+          <Table className="mb-0">
             <tbody>
               <tr>
                 <th>Time</th>
@@ -163,8 +163,8 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
             </tbody>
           </Table>
         </Col>
-        <Col>
-          <Table>
+        <Col lg="6" md="12">
+          <Table className="mb-0">
             <tbody>
               {start < now && now < end ? (
                 <tr>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -151,15 +151,6 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                 <th>Penalty</th>
                 <td>{penaltySecond} seconds for each wrong submission</td>
               </tr>
-
-              {start < now && now < end ? (
-                <tr>
-                  <th>Remaining</th>
-                  <td>
-                    <Timer end={end} />
-                  </td>
-                </tr>
-              ) : null}
             </tbody>
           </Table>
         </Col>


### PR DESCRIPTION
## 変わったこと

* モバイルで読みにくい部分があるので、少し変わって読みやすいようにしました。
  * 変わったこと：Column の breakpoint、タイトルの margin
  * 今は `md="12" lg="6"` が、デフォルトは `sm="12" md="6"` だと思います。
* 二つの "Remaining" があるが、多分想定外の動作なので、一つの "Remaining" を消しました。

## プレビュー

### デスクトップ

Before
![image](https://user-images.githubusercontent.com/6523469/90229896-3e752700-de4b-11ea-8111-5f0c9f1cc95a.png)

After
![image](https://user-images.githubusercontent.com/6523469/90229880-37e6af80-de4b-11ea-81ac-e1df6e85bf14.png)


### モバイル

Before
![image](https://user-images.githubusercontent.com/6523469/90229806-1c7ba480-de4b-11ea-97e8-5c4a0658923f.png)

After
![image](https://user-images.githubusercontent.com/6523469/90229823-23a2b280-de4b-11ea-97bf-9c50c2ff5284.png)
