### PR TITLE
fronted: List problems of virtual contest

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -234,6 +234,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
         <tr className="text-center">
           <th>#</th>
           <th>Participant</th>
+          <th>Score</th>
           {showProblems &&
             sortedItems.map((p, i) => (
               <th key={i}>
@@ -248,7 +249,6 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
                 )}
               </th>
             ))}
-          <th>Score</th>
           {showEstimatedPerformances && <th>Estimated Performance</th>}
         </tr>
       </thead>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -1,4 +1,4 @@
-import { Row, Table } from "reactstrap";
+import { Table } from "reactstrap";
 import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { useLocation } from "react-router-dom";
@@ -33,7 +33,11 @@ import {
   UserTotalResult,
 } from "./ResultCalcUtil";
 import { ContestTableRow } from "./ContestTableRow";
-import { getPointOverrideMap, getResultsByUserMap } from "./util";
+import {
+  compareProblem,
+  getPointOverrideMap,
+  getResultsByUserMap,
+} from "./util";
 
 interface OuterProps {
   readonly contestId: string;
@@ -59,16 +63,6 @@ interface InnerProps extends OuterProps {
   submissions: PromiseState<Submission[]>;
   problemModels: PromiseState<Map<ProblemId, ProblemModel>>;
   problemMap: PromiseState<Map<ProblemId, MergedProblem>>;
-}
-
-export function compareProblem<T extends { id: string; order: number | null }>(
-  a: T,
-  b: T
-): number {
-  if (a.order !== null && b.order !== null) {
-    return a.order - b.order;
-  }
-  return a.id.localeCompare(b.id);
 }
 
 const InnerContestTable: React.FC<InnerProps> = (props) => {
@@ -235,132 +229,71 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     ) : undefined;
 
   return (
-    <>
-      {showProblems && (
-        <>
-          <Row className="m-0">
-            <h3>Problems</h3>
-          </Row>
-          <Row className="m-0">
-            <Table striped size="sm">
-              <thead>
-                <tr>
-                  <th> </th>
-                  <th>Problem Name</th>
-                  <th className="text-center">Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedItems.map((p, i) => (
-                  <tr key={i}>
-                    <th className="text-center">
-                      {p.contestId && p.title ? (
-                        <ProblemLink
-                          problemId={p.id}
-                          contestId={p.contestId}
-                          problemTitle={`${i + 1}`}
-                        />
-                      ) : (
-                        i + 1
-                      )}
-                    </th>
-                    <td>
-                      {p.contestId && p.title ? (
-                        <ProblemLink
-                          problemId={p.id}
-                          contestId={p.contestId}
-                          problemTitle={p.title}
-                        />
-                      ) : (
-                        p.id
-                      )}
-                    </td>
-                    <td className="text-center">
-                      {p.point !== null && `(${p.point})`}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Row>
-        </>
-      )}
-
-      <Row className="m-0">
-        <h3>Standings</h3>
-      </Row>
-      <Row className="m-0">
-        <Table striped bordered size="sm">
-          <thead>
-            <tr className="text-center">
-              <th>#</th>
-              <th>Participant</th>
-              {showProblems &&
-                sortedItems.map((p, i) => (
-                  <th key={i}>
-                    {p.contestId && p.title ? (
-                      <ProblemLink
-                        problemId={p.id}
-                        contestId={p.contestId}
-                        problemTitle={`${i + 1}`}
-                      />
-                    ) : (
-                      i + 1
-                    )}
-                  </th>
-                ))}
-              <th>Score</th>
-              {showEstimatedPerformances ? (
-                <th>Estimated Performance</th>
-              ) : null}
-            </tr>
-          </thead>
-          <tbody>
-            {pinMe && loginUserIndex >= 0 ? (
-              <ContestTableRow
-                tweetButton={tweetButton}
-                userId={atCoderUserId}
-                rank={loginUserIndex}
-                sortedItems={sortedItems}
-                showRating={showRating}
-                showProblems={showProblems}
-                start={start}
-                estimatedPerformance={getPerformanceByUserId(atCoderUserId)}
-                reducedProblemResults={
-                  resultsByUser.get(atCoderUserId) ??
-                  new Map<ProblemId, ReducedProblemResult>()
-                }
-                userTotalResult={totalResultByUser.get(atCoderUserId)}
-                penaltySecond={penaltySecond}
-              />
-            ) : null}
-            {showingUserIds.map((userId, i) => {
-              return (
-                <ContestTableRow
-                  tweetButton={
-                    atCoderUserId === userId ? tweetButton : undefined
-                  }
-                  key={userId}
-                  userId={userId}
-                  rank={i}
-                  sortedItems={sortedItems}
-                  showRating={showRating}
-                  showProblems={showProblems}
-                  start={start}
-                  estimatedPerformance={getPerformanceByUserId(userId)}
-                  reducedProblemResults={
-                    resultsByUser.get(userId) ??
-                    new Map<ProblemId, ReducedProblemResult>()
-                  }
-                  userTotalResult={totalResultByUser.get(userId)}
-                  penaltySecond={penaltySecond}
-                />
-              );
-            })}
-          </tbody>
-        </Table>
-      </Row>
-    </>
+    <Table striped bordered size="sm">
+      <thead>
+        <tr className="text-center">
+          <th>#</th>
+          <th>Participant</th>
+          {showProblems &&
+            sortedItems.map((p, i) => (
+              <th key={i}>
+                {p.contestId && p.title ? (
+                  <ProblemLink
+                    problemId={p.id}
+                    contestId={p.contestId}
+                    problemTitle={`${i + 1}`}
+                  />
+                ) : (
+                  i + 1
+                )}
+              </th>
+            ))}
+          <th>Score</th>
+          {showEstimatedPerformances && <th>Estimated Performance</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {pinMe && loginUserIndex >= 0 ? (
+          <ContestTableRow
+            tweetButton={tweetButton}
+            userId={atCoderUserId}
+            rank={loginUserIndex}
+            sortedItems={sortedItems}
+            showRating={showRating}
+            showProblems={showProblems}
+            start={start}
+            estimatedPerformance={getPerformanceByUserId(atCoderUserId)}
+            reducedProblemResults={
+              resultsByUser.get(atCoderUserId) ??
+              new Map<ProblemId, ReducedProblemResult>()
+            }
+            userTotalResult={totalResultByUser.get(atCoderUserId)}
+            penaltySecond={penaltySecond}
+          />
+        ) : null}
+        {showingUserIds.map((userId, i) => {
+          return (
+            <ContestTableRow
+              tweetButton={atCoderUserId === userId ? tweetButton : undefined}
+              key={userId}
+              userId={userId}
+              rank={i}
+              sortedItems={sortedItems}
+              showRating={showRating}
+              showProblems={showProblems}
+              start={start}
+              estimatedPerformance={getPerformanceByUserId(userId)}
+              reducedProblemResults={
+                resultsByUser.get(userId) ??
+                new Map<ProblemId, ReducedProblemResult>()
+              }
+              userTotalResult={totalResultByUser.get(userId)}
+              penaltySecond={penaltySecond}
+            />
+          );
+        })}
+      </tbody>
+    </Table>
   );
 };
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -1,4 +1,4 @@
-import { Table } from "reactstrap";
+import { Row, Table } from "reactstrap";
 import React from "react";
 import { connect, PromiseState } from "react-refetch";
 import { useLocation } from "react-router-dom";
@@ -210,11 +210,13 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     (userId) => userId === atCoderUserId
   );
 
-  const items = problems.map((p) => ({
-    contestId: p.contestId,
-    title: p.title,
-    ...p.item,
-  }));
+  const sortedItems = problems
+    .map((p) => ({
+      contestId: p.contestId,
+      title: p.title,
+      ...p.item,
+    }))
+    .sort(compareProblem);
 
   const now = getNowMillis();
 
@@ -233,78 +235,132 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     ) : undefined;
 
   return (
-    <Table striped>
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Participant</th>
-          {showProblems
-            ? items.sort(compareProblem).map((p, i) => {
-                return (
+    <>
+      {showProblems && (
+        <>
+          <Row className="m-0">
+            <h3>Problems</h3>
+          </Row>
+          <Row className="m-0">
+            <Table striped size="sm">
+              <thead>
+                <tr>
+                  <th> </th>
+                  <th>Problem Name</th>
+                  <th className="text-center">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedItems.map((p, i) => (
+                  <tr key={i}>
+                    <th className="text-center">
+                      {p.contestId && p.title ? (
+                        <ProblemLink
+                          problemId={p.id}
+                          contestId={p.contestId}
+                          problemTitle={`${i + 1}`}
+                        />
+                      ) : (
+                        i + 1
+                      )}
+                    </th>
+                    <td>
+                      {p.contestId && p.title ? (
+                        <ProblemLink
+                          problemId={p.id}
+                          contestId={p.contestId}
+                          problemTitle={p.title}
+                        />
+                      ) : (
+                        p.id
+                      )}
+                    </td>
+                    <td className="text-center">
+                      {p.point !== null && `(${p.point})`}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Row>
+        </>
+      )}
+
+      <Row className="m-0">
+        <h3>Standings</h3>
+      </Row>
+      <Row className="m-0">
+        <Table striped bordered size="sm">
+          <thead>
+            <tr className="text-center">
+              <th>#</th>
+              <th>Participant</th>
+              {showProblems &&
+                sortedItems.map((p, i) => (
                   <th key={i}>
-                    {`${i + 1}. `}
                     {p.contestId && p.title ? (
                       <ProblemLink
                         problemId={p.id}
                         contestId={p.contestId}
-                        problemTitle={p.title}
+                        problemTitle={`${i + 1}`}
                       />
                     ) : (
-                      p.id
+                      i + 1
                     )}
-                    {p.point !== null ? ` (${p.point})` : null}
                   </th>
-                );
-              })
-            : null}
-          <th style={{ textAlign: "center" }}>Score</th>
-          {showEstimatedPerformances ? (
-            <th style={{ textAlign: "center" }}>Estimated Performance</th>
-          ) : null}
-        </tr>
-      </thead>
-      <tbody>
-        {pinMe && loginUserIndex >= 0 ? (
-          <ContestTableRow
-            tweetButton={tweetButton}
-            userId={atCoderUserId}
-            rank={loginUserIndex}
-            items={items}
-            showRating={showRating}
-            showProblems={showProblems}
-            start={start}
-            estimatedPerformance={getPerformanceByUserId(atCoderUserId)}
-            reducedProblemResults={
-              resultsByUser.get(atCoderUserId) ??
-              new Map<ProblemId, ReducedProblemResult>()
-            }
-            userTotalResult={totalResultByUser.get(atCoderUserId)}
-            penaltySecond={penaltySecond}
-          />
-        ) : null}
-        {showingUserIds.map((userId, i) => {
-          return (
-            <ContestTableRow
-              tweetButton={atCoderUserId === userId ? tweetButton : undefined}
-              key={userId}
-              userId={userId}
-              rank={i}
-              items={items}
-              showRating={showRating}
-              showProblems={showProblems}
-              start={start}
-              estimatedPerformance={getPerformanceByUserId(userId)}
-              reducedProblemResults={
-                resultsByUser.get(userId) ??
-                new Map<ProblemId, ReducedProblemResult>()
-              }
-              userTotalResult={totalResultByUser.get(userId)}
-              penaltySecond={penaltySecond}
-            />
-          );
-        })}
-      </tbody>
-    </Table>
+                ))}
+              <th>Score</th>
+              {showEstimatedPerformances ? (
+                <th>Estimated Performance</th>
+              ) : null}
+            </tr>
+          </thead>
+          <tbody>
+            {pinMe && loginUserIndex >= 0 ? (
+              <ContestTableRow
+                tweetButton={tweetButton}
+                userId={atCoderUserId}
+                rank={loginUserIndex}
+                sortedItems={sortedItems}
+                showRating={showRating}
+                showProblems={showProblems}
+                start={start}
+                estimatedPerformance={getPerformanceByUserId(atCoderUserId)}
+                reducedProblemResults={
+                  resultsByUser.get(atCoderUserId) ??
+                  new Map<ProblemId, ReducedProblemResult>()
+                }
+                userTotalResult={totalResultByUser.get(atCoderUserId)}
+                penaltySecond={penaltySecond}
+              />
+            ) : null}
+            {showingUserIds.map((userId, i) => {
+              return (
+                <ContestTableRow
+                  tweetButton={
+                    atCoderUserId === userId ? tweetButton : undefined
+                  }
+                  key={userId}
+                  userId={userId}
+                  rank={i}
+                  sortedItems={sortedItems}
+                  showRating={showRating}
+                  showProblems={showProblems}
+                  start={start}
+                  estimatedPerformance={getPerformanceByUserId(userId)}
+                  reducedProblemResults={
+                    resultsByUser.get(userId) ??
+                    new Map<ProblemId, ReducedProblemResult>()
+                  }
+                  userTotalResult={totalResultByUser.get(userId)}
+                  penaltySecond={penaltySecond}
+                />
+              );
+            })}
+          </tbody>
+        </Table>
+      </Row>
+    </>
   );
 };
 

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { ProblemId } from "../../../../interfaces/Status";
 import { clipDifficulty, getRatingColorClass } from "../../../../utils";
 import { UserNameLabel } from "../../../../components/UserNameLabel";
-import { compareProblem } from "./ContestTable";
 import { ReducedProblemResult, UserTotalResult } from "./ResultCalcUtil";
 import { ScoreCell } from "./ScoreCell";
 
@@ -26,7 +25,7 @@ interface ContestTableRowProps {
   tweetButton?: JSX.Element;
   userId: string;
   rank: number;
-  items: {
+  sortedItems: {
     id: string;
     point: number | null;
     order: number | null;
@@ -49,7 +48,7 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
     userId,
     showRating,
     showProblems,
-    items,
+    sortedItems,
     start,
     penaltySecond,
     reducedProblemResults,
@@ -65,18 +64,18 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
 
   return (
     <tr>
-      <th>{rank + 1}</th>
-      <th>
+      <th className="text-center align-middle">{rank + 1}</th>
+      <td className="text-left align-middle">
         <UserNameLabel userId={userId} showRating={showRating} />
         {tweetButton && <div className="text-right">{tweetButton}</div>}
-      </th>
+      </td>
       {!showProblems
         ? null
-        : items.sort(compareProblem).map((problem) => {
+        : sortedItems.map((problem) => {
             const result = reducedProblemResults.get(problem.id);
             if (!result) {
               return (
-                <td key={problem.id} style={{ textAlign: "center" }}>
+                <td key={problem.id} className="text-center">
                   -
                 </td>
               );
@@ -100,7 +99,7 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
         />
       </td>
       {estimatedPerformance !== undefined && (
-        <td>
+        <td className="align-middle">
           <EstimatedPerformance estimatedPerformance={estimatedPerformance} />
         </td>
       )}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
@@ -65,10 +65,10 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
   return (
     <tr>
       <th className="text-center align-middle">{rank + 1}</th>
-      <td className="text-left align-middle">
+      <th className="text-left align-middle">
         <UserNameLabel userId={userId} showRating={showRating} />
         {tweetButton && <div className="text-right">{tweetButton}</div>}
-      </td>
+      </th>
       {!showProblems
         ? null
         : sortedItems.map((problem) => {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTableRow.tsx
@@ -69,6 +69,13 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
         <UserNameLabel userId={userId} showRating={showRating} />
         {tweetButton && <div className="text-right">{tweetButton}</div>}
       </th>
+      <td>
+        <ScoreCell
+          trials={userTotalResult?.penalties ?? 0}
+          maxPoint={userTotalResult?.point ?? 0}
+          time={totalTime}
+        />
+      </td>
       {!showProblems
         ? null
         : sortedItems.map((problem) => {
@@ -91,13 +98,6 @@ export const ContestTableRow: React.FC<ContestTableRowProps> = (props) => {
               </td>
             );
           })}
-      <td>
-        <ScoreCell
-          trials={userTotalResult?.penalties ?? 0}
-          maxPoint={userTotalResult?.point ?? 0}
-          time={totalTime}
-        />
-      </td>
       {estimatedPerformance !== undefined && (
         <td className="align-middle">
           <EstimatedPerformance estimatedPerformance={estimatedPerformance} />

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/LockoutContestTable/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/LockoutContestTable/index.tsx
@@ -101,9 +101,9 @@ const InnerLockoutContestTable: React.FC<InnerProps> = (props) => {
         <tbody>
           {ranking.map(({ userId, point }) => (
             <tr key={userId}>
-              <td>
+              <th>
                 <UserNameLabel userId={userId} showRating={props.showRating} />
-              </td>
+              </th>
               <td>{point}</td>
             </tr>
           ))}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/index.tsx
@@ -55,16 +55,18 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     })
     .map(([userId]) => userId);
 
-  const items = problems.map((p) => ({
-    contestId: p.contestId,
-    title: p.title,
-    ...p.item,
-  }));
+  const sortedItems = problems
+    .map((p) => ({
+      contestId: p.contestId,
+      title: p.title,
+      ...p.item,
+    }))
+    .sort(compareProblem);
 
   return (
     <Table striped>
       <thead>
-        <tr>
+        <tr className="text-center">
           <th>#</th>
           <th>Participant</th>
           <th>Score</th>
@@ -74,17 +76,17 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
       <tbody>
         {sortedUserIds.map((userId, i) => {
           const userResult = resultsByUser.get(userId);
-          const totalProblemCount = items.length;
+          const totalProblemCount = sortedItems.length;
           const solvedProblemCount = Array.from(userResult ?? []).filter(
             ([, result]) => result.accepted
           ).length;
           return (
             <tr key={i}>
-              <th>{i + 1}</th>
-              <th>
-                <UserNameLabel userId={userId} showRating={showRating} />
-              </th>
+              <th className="text-center">{i + 1}</th>
               <td>
+                <UserNameLabel userId={userId} showRating={showRating} />
+              </td>
+              <td className="text-center">
                 <Badge>
                   {solvedProblemCount} / {totalProblemCount}
                 </Badge>
@@ -98,7 +100,7 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
               >
                 {!showProblems
                   ? null
-                  : items.sort(compareProblem).map((problem, index) => {
+                  : sortedItems.map((problem, index) => {
                       const result = userResult?.get(problem.id);
                       if (!result) {
                         return (

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/index.tsx
@@ -10,8 +10,7 @@ import {
   compareTotalResult,
   UserTotalResult,
 } from "../ResultCalcUtil";
-import { getResultsByUserMap } from "../util";
-import { compareProblem } from "../ContestTable";
+import { getResultsByUserMap, compareProblem } from "../util";
 import { UserNameLabel } from "../../../../../components/UserNameLabel";
 import { SmallScoreCell } from "./SmallScoreCell";
 
@@ -83,9 +82,9 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
           return (
             <tr key={i}>
               <th className="text-center">{i + 1}</th>
-              <td>
+              <th>
                 <UserNameLabel userId={userId} showRating={showRating} />
-              </td>
+              </th>
               <td className="text-center">
                 <Badge>
                   {solvedProblemCount} / {totalProblemCount}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -233,7 +233,11 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
         <div className="my-2">
           <Row>
             <Col>
-              <h3>Problems</h3>
+              <Form inline>
+                <h3>Problems</h3>
+                <Button
+                  color="secondary"
+              </Form>
             </Col>
           </Row>
           <Row>
@@ -272,7 +276,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                         )}
                       </td>
                       <td className="text-center">
-                        {p.point !== null && `(${p.point})`}
+                        {p.point !== null ? p.point : "Same as origin"}
                       </td>
                     </tr>
                   ))}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -151,15 +151,6 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                 <th>Penalty</th>
                 <td>{penaltySecond} seconds for each wrong submission</td>
               </tr>
-
-              {start < now && now < end ? (
-                <tr>
-                  <th>Remaining</th>
-                  <td>
-                    <Timer end={end} />
-                  </td>
-                </tr>
-              ) : null}
             </tbody>
           </Table>
         </Col>
@@ -178,6 +169,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
           </Table>
         </Col>
       </Row>
+
       <Row className="my-2">
         <Col sm="12">
           {!isLoggedIn ? (

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -10,9 +10,10 @@ import {
   Spinner,
   Table,
   Badge,
+  Form,
   FormGroup,
   CustomInput,
-  Form,
+  Collapse,
 } from "reactstrap";
 import { Map as ImmutableMap } from "immutable";
 import * as CachedApi from "../../../../utils/CachedApiClient";
@@ -67,6 +68,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [showRating, setShowRating] = useLocalStorage("showRating", false);
   const [pinMe, setPinMe] = useLocalStorage("pinMe", false);
+  const [showProblemTable, setShowProblemTable] = useState(true);
   const history = useHistory();
   const { contestInfoFetch, userInfoGet, problemMapFetch } = props;
 
@@ -233,55 +235,69 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
         <div className="my-2">
           <Row>
             <Col>
-              <Form inline>
+              <div
+                style={{
+                  display: "flex",
+                  flexFlow: "row wrap",
+                  alignItems: "center",
+                }}
+              >
                 <h3>Problems</h3>
                 <Button
                   color="secondary"
-              </Form>
+                  size="sm"
+                  onClick={() => setShowProblemTable(!showProblemTable)}
+                  className="mx-3"
+                >
+                  {showProblemTable ? "▲" : "▼"}
+                </Button>
+              </div>
             </Col>
           </Row>
           <Row>
             <Col>
-              <Table striped size="sm">
-                <thead>
-                  <tr>
-                    <th> </th>
-                    <th>Problem Name</th>
-                    <th className="text-center">Score</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedItems.map((p, i) => (
-                    <tr key={i}>
-                      <th className="text-center">
-                        {p.contestId && p.title ? (
-                          <ProblemLink
-                            problemId={p.id}
-                            contestId={p.contestId}
-                            problemTitle={`${i + 1}`}
-                          />
-                        ) : (
-                          i + 1
-                        )}
-                      </th>
-                      <td>
-                        {p.contestId && p.title ? (
-                          <ProblemLink
-                            problemId={p.id}
-                            contestId={p.contestId}
-                            problemTitle={p.title}
-                          />
-                        ) : (
-                          p.id
-                        )}
-                      </td>
-                      <td className="text-center">
-                        {p.point !== null ? p.point : "Same as origin"}
-                      </td>
+              <Collapse isOpen={showProblemTable}>
+                <Table striped size="sm">
+                  <thead>
+                    <tr>
+                      <th> </th>
+                      <th>Problem Name</th>
+                      <th className="text-center">Score</th>
                     </tr>
-                  ))}
-                </tbody>
-              </Table>
+                  </thead>
+                  <tbody>
+                    {sortedItems.map((p, i) => (
+                      <tr key={i}>
+                        <th className="text-center">
+                          {p.contestId && p.title ? (
+                            <ProblemLink
+                              problemId={p.id}
+                              contestId={p.contestId}
+                              problemTitle={`${i + 1}`}
+                            />
+                          ) : (
+                            i + 1
+                          )}
+                        </th>
+                        <td>
+                          {p.contestId && p.title ? (
+                            <ProblemLink
+                              problemId={p.id}
+                              contestId={p.contestId}
+                              problemTitle={p.title}
+                            />
+                          ) : (
+                            p.id
+                          )}
+                        </td>
+                        <td className="text-center">
+                          {p.point !== null ? p.point : "Same as origin"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </Collapse>
             </Col>
           </Row>
         </div>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -289,34 +289,32 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
             <Form inline>
               <h3>Standings</h3>
               <FormGroup inline className="ml-3">
-                <FormGroup check inline>
+                <CustomInput
+                  type="switch"
+                  id="autoRefresh"
+                  label="Auto Refresh"
+                  inline
+                  checked={autoRefresh}
+                  onChange={(): void => setAutoRefresh(!autoRefresh)}
+                />
+                <CustomInput
+                  type="switch"
+                  id="showRating"
+                  label="Show Rating"
+                  inline
+                  checked={showRating}
+                  onChange={(): void => setShowRating(!showRating)}
+                />
+                {alreadyJoined && (
                   <CustomInput
                     type="switch"
-                    id="autoRefresh"
-                    label="Auto Refresh"
+                    id="pinMe"
+                    label="Pin me"
                     inline
-                    checked={autoRefresh}
-                    onChange={(): void => setAutoRefresh(!autoRefresh)}
+                    checked={pinMe}
+                    onChange={(): void => setPinMe(!pinMe)}
                   />
-                  <CustomInput
-                    type="switch"
-                    id="showRating"
-                    label="Show Rating"
-                    inline
-                    checked={showRating}
-                    onChange={(): void => setShowRating(!showRating)}
-                  />
-                  {alreadyJoined && (
-                    <CustomInput
-                      type="switch"
-                      id="pinMe"
-                      label="Pin me"
-                      inline
-                      checked={pinMe}
-                      onChange={(): void => setPinMe(!pinMe)}
-                    />
-                  )}
-                </FormGroup>
+                )}
               </FormGroup>
             </Form>
           </Col>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -16,6 +16,7 @@ import {
   Collapse,
 } from "reactstrap";
 import { Map as ImmutableMap } from "immutable";
+import Octicon, { ChevronDown, ChevronUp } from "@primer/octicons-react";
 import * as CachedApi from "../../../../utils/CachedApiClient";
 import { ProblemId } from "../../../../interfaces/Status";
 import {
@@ -249,7 +250,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                   onClick={() => setShowProblemTable(!showProblemTable)}
                   className="mx-3"
                 >
-                  {showProblemTable ? "▲" : "▼"}
+                  <Octicon icon={showProblemTable ? ChevronUp : ChevronDown} />
                 </Button>
               </div>
             </Col>
@@ -291,7 +292,7 @@ const InnerShowContest: React.FC<InnerProps> = (props) => {
                           )}
                         </td>
                         <td className="text-center">
-                          {p.point !== null ? p.point : "Same as origin"}
+                          {p.point !== null && p.point}
                         </td>
                       </tr>
                     ))}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/util.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/util.ts
@@ -39,3 +39,13 @@ export const getResultsByUserMap = (
   });
   return resultsByUser;
 };
+
+export function compareProblem<T extends { id: string; order: number | null }>(
+  a: T,
+  b: T
+): number {
+  if (a.order !== null && b.order !== null) {
+    return a.order - b.order;
+  }
+  return a.id.localeCompare(b.id);
+}


### PR DESCRIPTION
![2020-08-16](https://user-images.githubusercontent.com/8394202/90315367-f42c9c80-df55-11ea-81f6-a6c21cf527ac.png)

Closes #761
バーチャルコンテストの問題一覧を順位表ヘッダから分離

## 仕様
* 問題タイトルを別で持つメリットが有るのはコンテストModeが`Normal`のときなので、`Normal`の場合のみ問題テーブルを表示
* 問題テーブルはトグルで非表示にできる
* 各問題のスコアは、任意のスコアが設定されていない場合は"Same as origin"と表示
 
## 変更点
* コンテンツタイトル"Problems", "Standings"を追加
* `Switch`の位置を"Standings"の右に移動
* 順位表
  * ヘッダの問題欄は問題番号のみ表示
  * 可読性のため、borderを追加（これは自分の好みです。カラムが多いのでこちらのほうが良いと思いました。）
  * セルの密度を上げたほうが可読性が高いと判断し，Table`size="sm"`を利用
  * 合計スコアはユーザ名右に配置(AtCoderに準拠。こちらのほうが判別しやすいと判断しました。)