### PR TITLE
[replacement with sqlx] LanguageCountClient 

### DIFF
--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -2904,8 +2904,10 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
+ "regex",
  "serde",
  "sqlx",
+ "unzip-n",
  "uuid 0.8.1",
 ]
 
@@ -3617,6 +3619,17 @@ checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
 dependencies = [
  "generic-array 0.12.3",
  "subtle 2.2.3",
+]
+
+[[package]]
+name = "unzip-n"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/atcoder-problems-backend/sql-client/Cargo.toml
+++ b/atcoder-problems-backend/sql-client/Cargo.toml
@@ -14,3 +14,5 @@ serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 anyhow = "1.0.32"
 async-std = { version = "1.6", features = ["attributes"] }
+regex = "1"
+unzip-n = "0.1.2"

--- a/atcoder-problems-backend/sql-client/src/language_count.rs
+++ b/atcoder-problems-backend/sql-client/src/language_count.rs
@@ -1,0 +1,99 @@
+use crate::models::{Submission, UserLanguageCount};
+use crate::{PgPool, MAX_INSERT_ROWS};
+use anyhow::Result;
+use async_trait::async_trait;
+use regex::Regex;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[async_trait]
+pub trait LanguageCountClient {
+    async fn update_language_count(&self, submissions: &[Submission]) -> Result<()>;
+    async fn load_language_count(&self) -> Result<Vec<UserLanguageCount>>;
+}
+
+#[async_trait]
+impl LanguageCountClient for PgPool {
+    async fn update_language_count(&self, submissions: &[Submission]) -> Result<()> {
+        let re = Regex::new(r"\d* \(.*\)").unwrap();
+        let language_count = submissions
+            .iter()
+            .map(|s| {
+                (
+                    s.user_id.as_str(),
+                    s.problem_id.as_str(),
+                    s.language.as_str(),
+                )
+            })
+            .fold(
+                BTreeMap::new(),
+                |mut map, (user_id, problem_id, language)| {
+                    let simplified_language = if language.len() >= 5 && &language[..5] == "Perl6" {
+                        "Perl6".to_string()
+                    } else {
+                        re.replace(&language, "").to_string()
+                    };
+                    map.entry((user_id, simplified_language))
+                        .or_insert_with(BTreeSet::new)
+                        .insert(problem_id);
+                    map
+                },
+            )
+            .into_iter()
+            .map(|((user_id, language), set)| (user_id, language, set.len() as i32))
+            .collect::<Vec<_>>();
+
+        unzip_n::unzip_n!(3);
+
+        for chunk in language_count.chunks(MAX_INSERT_ROWS) {
+            let (user_ids, languages, counts): (Vec<&str>, Vec<String>, Vec<i32>) =
+                chunk.iter().cloned().unzip_n_vec();
+
+            sqlx::query(
+                r"
+                INSERT INTO language_count (user_id, simplified_language, problem_count)
+                VALUES (
+                    UNNEST($1::VARCHAR(255)[]),
+                    UNNEST($2::VARCHAR(255)[]),
+                    UNNEST($3::INTEGER[])
+                )
+                ON CONFLICT (user_id, simplified_language)
+                DO UPDATE SET problem_count = EXCLUDED.problem_count
+                ",
+            )
+            .bind(user_ids)
+            .bind(languages)
+            .bind(counts)
+            .execute(self)
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn load_language_count(&self) -> Result<Vec<UserLanguageCount>> {
+        let count = sqlx::query(
+            r"
+            SELECT 
+                user_id,
+                simplified_language,
+                problem_count
+            FROM language_count
+            ORDER BY user_id
+            ",
+        )
+        .try_map(|row: PgRow| {
+            let user_id: String = row.try_get("user_id")?;
+            let simplified_language: String = row.try_get("simplified_language")?;
+            let problem_count: i32 = row.try_get("problem_count")?;
+            Ok(UserLanguageCount {
+                user_id,
+                simplified_language,
+                problem_count,
+            })
+        })
+        .fetch_all(self)
+        .await?;
+        Ok(count)
+    }
+}

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 pub mod accepted_count;
 pub mod contest_problem;
 pub mod internal;
+pub mod language_count;
 pub mod models;
 
 pub type PgPool = sqlx::postgres::PgPool;

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -15,6 +15,17 @@ pub struct Submission {
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct UserLanguageCount {
+    pub user_id: String,
+
+    #[serde(rename = "language")]
+    pub simplified_language: String,
+
+    #[serde(rename = "count")]
+    pub problem_count: i32,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct UserProblemCount {
     pub user_id: String,
     pub problem_count: i32,

--- a/atcoder-problems-backend/sql-client/tests/test_language_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_language_count.rs
@@ -1,0 +1,94 @@
+use sql_client::language_count::LanguageCountClient;
+use sql_client::models::{Submission, UserLanguageCount};
+
+mod utils;
+
+#[async_std::test]
+async fn test_language_count() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    let submissions = [
+        Submission {
+            id: 1,
+            problem_id: "problem1".to_owned(),
+            user_id: "user1".to_owned(),
+            language: "language1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 2,
+            problem_id: "problem2".to_owned(),
+            user_id: "user1".to_owned(),
+            language: "language1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 3,
+            problem_id: "problem1".to_owned(),
+            user_id: "user1".to_owned(),
+            language: "language1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 4,
+            problem_id: "problem1".to_owned(),
+            user_id: "user1".to_owned(),
+            language: "language2".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 5,
+            problem_id: "problem1".to_owned(),
+            user_id: "user2".to_owned(),
+            language: "language1".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 6,
+            problem_id: "problem1".to_owned(),
+            user_id: "user3".to_owned(),
+            language: "Perl (5)".to_owned(),
+            ..Default::default()
+        },
+        Submission {
+            id: 7,
+            problem_id: "problem1".to_owned(),
+            user_id: "user3".to_owned(),
+            language: "Perl6".to_owned(),
+            ..Default::default()
+        },
+    ];
+    pool.update_language_count(&submissions).await.unwrap();
+
+    let language_count = pool.load_language_count().await.unwrap();
+    assert_eq!(
+        language_count,
+        vec![
+            UserLanguageCount {
+                user_id: "user1".to_owned(),
+                simplified_language: "language1".to_owned(),
+                problem_count: 2
+            },
+            UserLanguageCount {
+                user_id: "user1".to_owned(),
+                simplified_language: "language2".to_owned(),
+                problem_count: 1
+            },
+            UserLanguageCount {
+                user_id: "user2".to_owned(),
+                simplified_language: "language1".to_owned(),
+                problem_count: 1
+            },
+            UserLanguageCount {
+                user_id: "user3".to_owned(),
+                simplified_language: "Perl".to_owned(),
+                problem_count: 1
+            },
+            UserLanguageCount {
+                user_id: "user3".to_owned(),
+                simplified_language: "Perl6".to_owned(),
+                problem_count: 1
+            }
+        ]
+    );
+}
+


### PR DESCRIPTION
Related issue: #701

`LanguageCountClient` の sqlx 版です。

#### やったこと

- 非同期対応の `LanguageCountClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `LanguageCountClient` のテストを作成（もとのテストを移植）