### PR TITLE
[replacement with sqlx] SimpleClient

### DIFF
--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod contest_problem;
 pub mod internal;
 pub mod language_count;
 pub mod models;
+pub mod simple_client;
 
 pub type PgPool = sqlx::postgres::PgPool;
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -1,4 +1,27 @@
+use crate::{FIRST_AGC_EPOCH_SECOND, UNRATED_STATE};
 use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Eq, PartialEq, Serialize)]
+pub struct Contest {
+    pub id: String,
+    pub start_epoch_second: i64,
+    pub duration_second: i64,
+    pub title: String,
+    pub rate_change: String,
+}
+
+impl Contest {
+    pub fn is_rated(&self) -> bool {
+        self.start_epoch_second >= FIRST_AGC_EPOCH_SECOND && self.rate_change != UNRATED_STATE
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct Problem {
+    pub id: String,
+    pub contest_id: String,
+    pub title: String,
+}
 
 #[derive(Debug, Clone, Serialize, Default, Deserialize)]
 pub struct Submission {

--- a/atcoder-problems-backend/sql-client/src/simple_client.rs
+++ b/atcoder-problems-backend/sql-client/src/simple_client.rs
@@ -1,0 +1,149 @@
+use crate::models::{Contest, Problem};
+use crate::PgPool;
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+#[async_trait]
+pub trait SimpleClient {
+    async fn insert_contests(&self, values: &[Contest]) -> Result<usize>;
+    async fn insert_problems(&self, values: &[Problem]) -> Result<usize>;
+    async fn load_problems(&self) -> Result<Vec<Problem>>;
+    async fn load_contests(&self) -> Result<Vec<Contest>>;
+}
+
+#[async_trait]
+impl SimpleClient for PgPool {
+    async fn insert_contests(&self, values: &[Contest]) -> Result<usize> {
+        let (ids, start_epoch_seconds, duration_seconds, titles, rate_changes) =
+            values.iter().fold(
+                (vec![], vec![], vec![], vec![], vec![]),
+                |(
+                    mut ids,
+                    mut start_epoch_seconds,
+                    mut duration_seconds,
+                    mut titles,
+                    mut rate_changes,
+                ),
+                 cur| {
+                    ids.push(cur.id.clone());
+                    start_epoch_seconds.push(cur.start_epoch_second);
+                    duration_seconds.push(cur.duration_second);
+                    titles.push(cur.title.clone());
+                    rate_changes.push(cur.rate_change.clone());
+                    (
+                        ids,
+                        start_epoch_seconds,
+                        duration_seconds,
+                        titles,
+                        rate_changes,
+                    )
+                },
+            );
+
+        let result = sqlx::query(
+            r"
+            INSERT INTO contests
+            (id, start_epoch_second, duration_second, title, rate_change)
+            VALUES (
+                UNNEST($1::VARCHAR(255)[]),
+                UNNEST($2::BIGINT[]),
+                UNNEST($3::BIGINT[]),
+                UNNEST($4::VARCHAR(255)[]),
+                UNNEST($5::VARCHAR(255)[])
+            )
+            ON CONFLICT DO NOTHING
+            ",
+        )
+        .bind(ids)
+        .bind(start_epoch_seconds)
+        .bind(duration_seconds)
+        .bind(titles)
+        .bind(rate_changes)
+        .execute(self)
+        .await?;
+
+        Ok(result as usize)
+    }
+
+    async fn insert_problems(&self, values: &[Problem]) -> Result<usize> {
+        let (ids, contest_ids, titles) = values.iter().fold(
+            (vec![], vec![], vec![]),
+            |(mut ids, mut contest_ids, mut titles), cur| {
+                ids.push(cur.id.clone());
+                contest_ids.push(cur.contest_id.clone());
+                titles.push(cur.title.clone());
+                (ids, contest_ids, titles)
+            },
+        );
+
+        let result = sqlx::query(
+            r"
+            INSERT INTO problems
+            (id, contest_id, title)
+            VALUES (
+                UNNEST($1::VARCHAR(255)[]),
+                UNNEST($2::VARCHAR(255)[]),
+                UNNEST($3::VARCHAR(255)[])
+            )
+            ON CONFLICT DO NOTHING
+            ",
+        )
+        .bind(ids)
+        .bind(contest_ids)
+        .bind(titles)
+        .execute(self)
+        .await?;
+
+        Ok(result as usize)
+    }
+
+    async fn load_problems(&self) -> Result<Vec<Problem>> {
+        let problems = sqlx::query("SELECT id, contest_id, title FROM problems")
+            .try_map(|row: PgRow| {
+                let id: String = row.try_get("id")?;
+                let contest_id: String = row.try_get("contest_id")?;
+                let title: String = row.try_get("title")?;
+                Ok(Problem {
+                    id,
+                    contest_id,
+                    title,
+                })
+            })
+            .fetch_all(self)
+            .await?;
+        Ok(problems)
+    }
+
+    async fn load_contests(&self) -> Result<Vec<Contest>> {
+        let contests = sqlx::query(
+            r"
+                 SELECT 
+                    id,
+                    start_epoch_second,
+                    duration_second,
+                    title,
+                    rate_change
+                 FROM contests
+                 ",
+        )
+        .try_map(|row: PgRow| {
+            let id: String = row.try_get("id")?;
+            let start_epoch_second: i64 = row.try_get("start_epoch_second")?;
+            let duration_second: i64 = row.try_get("duration_second")?;
+            let title: String = row.try_get("title")?;
+            let rate_change: String = row.try_get("rate_change")?;
+            Ok(Contest {
+                id,
+                start_epoch_second,
+                duration_second,
+                title,
+                rate_change,
+            })
+        })
+        .fetch_all(self)
+        .await?;
+        Ok(contests)
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_language_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_language_count.rs
@@ -91,4 +91,3 @@ async fn test_language_count() {
         ]
     );
 }
-

--- a/atcoder-problems-backend/sql-client/tests/test_simple_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_simple_client.rs
@@ -1,0 +1,56 @@
+use sql_client::models::{Contest, Problem};
+use sql_client::simple_client::SimpleClient;
+
+mod utils;
+
+#[async_std::test]
+async fn test_insert_contests() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    assert!(pool.load_contests().await.unwrap().is_empty());
+    pool.insert_contests(&vec![Contest {
+        id: "contest1".to_string(),
+        start_epoch_second: 0,
+        duration_second: 0,
+        title: "".to_string(),
+        rate_change: "".to_string(),
+    }])
+    .await
+    .unwrap();
+
+    let contests = pool.load_contests().await.unwrap();
+    assert_eq!(contests[0].id.as_str(), "contest1");
+
+    pool.insert_contests(&vec![Contest {
+        id: "contest1".to_string(),
+        start_epoch_second: 0,
+        duration_second: 0,
+        title: "".to_string(),
+        rate_change: "".to_string(),
+    }])
+    .await
+    .unwrap();
+}
+
+#[async_std::test]
+async fn test_insert_problems() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    assert!(pool.load_problems().await.unwrap().is_empty());
+    pool.insert_problems(&vec![Problem {
+        id: "problem1".to_string(),
+        contest_id: "".to_string(),
+        title: "".to_string(),
+    }])
+    .await
+    .unwrap();
+
+    let problems = pool.load_problems().await.unwrap();
+    assert_eq!(problems[0].id.as_str(), "problem1");
+
+    pool.insert_problems(&vec![Problem {
+        id: "problem1".to_string(),
+        contest_id: "".to_string(),
+        title: "".to_string(),
+    }])
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
Related issue: #701

`SimpleClient` の sqlx 版です。
`ProblemInfoUpdater` を先にやるつもりでしたが、これのテストが `SimpleClient` と `SubmissionClient` に依存していることに気づいたため、これらを先に作成したいです。

#### やったこと

- 非同期対応の `SimpleClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `SimpleClient` のテストを作成（もとのテストを移植）

