### PR TITLE
frontend: Add link to participant's user page in virtual contest page

### DIFF
--- a/atcoder-problems-frontend/src/components/UserNameLabel.tsx
+++ b/atcoder-problems-frontend/src/components/UserNameLabel.tsx
@@ -6,6 +6,7 @@ import { RatingInfo } from "../utils/RatingInfo";
 import * as CachedApiClient from "../utils/CachedApiClient";
 import { TopcoderLikeCircle } from "./TopcoderLikeCircle";
 import * as Url from "../utils/Url";
+import { NewTabLink } from "./NewTabLink";
 
 interface OuterProps {
   userId: string;
@@ -49,14 +50,12 @@ const InnerColoredUserNameLabel: React.FC<InnerProps> = (props) => {
         {`Rating: ${userRating}`}
       </Tooltip>
       &nbsp;
-      <a
+      <NewTabLink
         href={Url.formatUserUrl(userId)}
-        target="_blank"
-        rel="noopener noreferrer"
         className={getRatingColorClass(userRating)}
       >
         {userId}
-      </a>
+      </NewTabLink>
     </span>
   );
 };
@@ -72,13 +71,11 @@ export const UserNameLabel: React.FC<OuterProps> = (props) => {
   const label = props.showRating ? (
     <ColoredUserNameLabel {...props} />
   ) : (
-    <a
+    <NewTabLink
       href={Url.formatUserUrl(props.userId)}
-      target="_blank"
-      rel="noopener noreferrer"
     >
       {props.userId}
-    </a>
+    </NewTabLink>
   );
   return props.big ? <h1>{label}</h1> : label;
 };

--- a/atcoder-problems-frontend/src/components/UserNameLabel.tsx
+++ b/atcoder-problems-frontend/src/components/UserNameLabel.tsx
@@ -5,6 +5,7 @@ import { getRatingColor, getRatingColorClass } from "../utils";
 import { RatingInfo } from "../utils/RatingInfo";
 import * as CachedApiClient from "../utils/CachedApiClient";
 import { TopcoderLikeCircle } from "./TopcoderLikeCircle";
+import * as Url from "../utils/Url";
 
 interface OuterProps {
   userId: string;
@@ -48,7 +49,14 @@ const InnerColoredUserNameLabel: React.FC<InnerProps> = (props) => {
         {`Rating: ${userRating}`}
       </Tooltip>
       &nbsp;
-      {userId}
+      <a
+        href={Url.formatUserUrl(userId)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={getRatingColorClass(userRating)}
+      >
+        {userId}
+      </a>
     </span>
   );
 };
@@ -64,7 +72,13 @@ export const UserNameLabel: React.FC<OuterProps> = (props) => {
   const label = props.showRating ? (
     <ColoredUserNameLabel {...props} />
   ) : (
-    <>{props.userId}</>
+    <a
+      href={Url.formatUserUrl(props.userId)}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {props.userId}
+    </a>
   );
   return props.big ? <h1>{label}</h1> : label;
 };

--- a/atcoder-problems-frontend/src/components/UserNameLabel.tsx
+++ b/atcoder-problems-frontend/src/components/UserNameLabel.tsx
@@ -4,8 +4,8 @@ import { connect, PromiseState } from "react-refetch";
 import { getRatingColor, getRatingColorClass } from "../utils";
 import { RatingInfo } from "../utils/RatingInfo";
 import * as CachedApiClient from "../utils/CachedApiClient";
-import { TopcoderLikeCircle } from "./TopcoderLikeCircle";
 import * as Url from "../utils/Url";
+import { TopcoderLikeCircle } from "./TopcoderLikeCircle";
 import { NewTabLink } from "./NewTabLink";
 
 interface OuterProps {
@@ -71,9 +71,7 @@ export const UserNameLabel: React.FC<OuterProps> = (props) => {
   const label = props.showRating ? (
     <ColoredUserNameLabel {...props} />
   ) : (
-    <NewTabLink
-      href={Url.formatUserUrl(props.userId)}
-    >
+    <NewTabLink href={Url.formatUserUrl(props.userId)}>
       {props.userId}
     </NewTabLink>
   );


### PR DESCRIPTION
Resolves #778

# 概要
Virtual Contestページで，
各参加者のユーザページに飛べるリンクを追加しました．

# プレビュー
|「Show Rating」Off時|「Show Rating」On時|
|---|---|
|![Screenshot 2020-08-24 08:34:42](https://user-images.githubusercontent.com/22876812/90991625-99461580-e5e5-11ea-8b61-2818e30da20d.png)|![Screenshot 2020-08-24 08:34:55](https://user-images.githubusercontent.com/22876812/90991626-9cd99c80-e5e5-11ea-9f63-30b7d9996dae.png)|

# 留意点
「Show Rating」On時は，リンクの色がレーティングの色になるように調整しましたが，
「Show Rating」Off時は，特に制御していないためデフォルトのリンクの色(青)になっています．
もともとは黒色なので，そこはビジュアルの変更点になります．
もともとの黒色がよろしければ，制御することで対応可能です．
- 「Show Rating」Off時 Before
![Screenshot 2020-08-24 09:02:19](https://user-images.githubusercontent.com/22876812/90992115-900a7800-e5e8-11ea-8495-bece8d88e59e.png)
