### PR TITLE
Add "AC during/after Contest" filter for ListTable

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -21,15 +21,19 @@ import { ListPaginationPanel } from "../../components/ListPaginationPanel";
 import { RatingInfo } from "../../utils/RatingInfo";
 import { INF_POINT, ProblemRowData } from "./index";
 
+export const statusFilters = [
+  "All",
+  "Only Trying",
+  "Only AC",
+  "AC during Contest",
+  "AC after Contest",
+] as const;
+export type StatusFilter = typeof statusFilters[number];
+
 interface Props {
   fromPoint: number;
   toPoint: number;
-  statusFilterState:
-    | "All"
-    | "Only Trying"
-    | "Only AC"
-    | "AC during Contest"
-    | "AC after Contest";
+  statusFilterState: StatusFilter;
   ratedFilterState:
     | "All"
     | "Only Rated"
@@ -394,28 +398,24 @@ export const ListTable: React.FC<Props> = (props) => {
           (row) => props.fromPoint <= row.point && row.point <= props.toPoint
         ) // eslint-disable-next-line
         .filter((row) => {
+          const { status, contest } = row;
+          const isSuccess = status.label === StatusLabel.Success;
+          const isSubmittedInContest =
+            status.label === StatusLabel.Success &&
+            contest !== undefined &&
+            status.epoch <=
+              contest.start_epoch_second + contest.duration_second;
           switch (props.statusFilterState) {
             case "All":
               return true;
             case "Only AC":
-              return row.status.label === StatusLabel.Success;
+              return isSuccess;
             case "Only Trying":
-              return row.status.label !== StatusLabel.Success;
+              return !isSuccess;
             case "AC during Contest":
-              return (
-                row.status.label === StatusLabel.Success &&
-                row.contest !== undefined &&
-                row.status.epoch <=
-                  row.contest.start_epoch_second + row.contest.duration_second
-              );
+              return isSuccess && isSubmittedInContest;
             case "AC after Contest":
-              return (
-                row.status.label === StatusLabel.Success &&
-                (row.contest === undefined ||
-                  row.status.epoch >
-                    row.contest.start_epoch_second +
-                      row.contest.duration_second)
-              );
+              return isSuccess && !isSubmittedInContest;
           }
         }) // eslint-disable-next-line
         .filter((row) => {

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -24,7 +24,12 @@ import { INF_POINT, ProblemRowData } from "./index";
 interface Props {
   fromPoint: number;
   toPoint: number;
-  statusFilterState: "All" | "Only Trying" | "Only AC";
+  statusFilterState:
+    | "All"
+    | "Only Trying"
+    | "Only AC"
+    | "AC during Contest"
+    | "AC after Contest";
   ratedFilterState:
     | "All"
     | "Only Rated"
@@ -396,6 +401,21 @@ export const ListTable: React.FC<Props> = (props) => {
               return row.status.label === StatusLabel.Success;
             case "Only Trying":
               return row.status.label !== StatusLabel.Success;
+            case "AC during Contest":
+              return (
+                row.status.label === StatusLabel.Success &&
+                row.contest !== undefined &&
+                row.status.epoch <=
+                  row.contest.start_epoch_second + row.contest.duration_second
+              );
+            case "AC after Contest":
+              return (
+                row.status.label === StatusLabel.Success &&
+                (row.contest === undefined ||
+                  row.status.epoch >
+                    row.contest.start_epoch_second +
+                      row.contest.duration_second)
+              );
           }
         }) // eslint-disable-next-line
         .filter((row) => {

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -60,7 +60,13 @@ export interface ProblemRowData {
   readonly status: ProblemStatus;
 }
 
-const statusFilters = ["All", "Only Trying", "Only AC"] as const;
+const statusFilters = [
+  "All",
+  "Only Trying",
+  "Only AC",
+  "AC during Contest",
+  "AC after Contest",
+] as const;
 type StatusFilter = typeof statusFilters[number];
 const convertToValidStatusFilterState = (
   value: string | null

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -35,7 +35,7 @@ import {
   ProgressResetList,
   UserResponse,
 } from "../Internal/types";
-import { ListTable } from "./ListTable";
+import { ListTable, StatusFilter, statusFilters } from "./ListTable";
 import { DifficultyTable } from "./DifficultyTable";
 import { SmallTable } from "./SmallTable";
 
@@ -60,14 +60,6 @@ export interface ProblemRowData {
   readonly status: ProblemStatus;
 }
 
-const statusFilters = [
-  "All",
-  "Only Trying",
-  "Only AC",
-  "AC during Contest",
-  "AC after Contest",
-] as const;
-type StatusFilter = typeof statusFilters[number];
 const convertToValidStatusFilterState = (
   value: string | null
 ): StatusFilter => {


### PR DESCRIPTION
- ListTable において，コンテスト中の AC／コンテスト後のACのみを絞り込めるようにします．
- コンテスト中にACした最高 difficulty 付近の問題を公表するというのが Twitter で若干流行っているので，使途はありそうです．
![image](https://user-images.githubusercontent.com/59337901/91182665-6b67ea80-e725-11ea-8b53-252c84ffa5de.png)
