### PR TITLE
[replacement with sqlx] SubmissionClient

### DIFF
--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -7,6 +7,7 @@ pub mod internal;
 pub mod language_count;
 pub mod models;
 pub mod simple_client;
+pub mod submission_client;
 
 pub type PgPool = sqlx::postgres::PgPool;
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -1,5 +1,8 @@
 use crate::{FIRST_AGC_EPOCH_SECOND, UNRATED_STATE};
 use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgRow;
+use sqlx::FromRow;
+use sqlx::Row;
 
 #[derive(Default, Debug, Eq, PartialEq, Serialize)]
 pub struct Contest {
@@ -35,6 +38,33 @@ pub struct Submission {
     pub length: i32,
     pub result: String,
     pub execution_time: Option<i32>,
+}
+
+impl<'c> FromRow<'c, PgRow<'c>> for Submission {
+    fn from_row(row: &PgRow<'c>) -> sqlx::Result<Self> {
+        let id: i64 = row.try_get("id")?;
+        let epoch_second: i64 = row.try_get("epoch_second")?;
+        let problem_id: String = row.try_get("problem_id")?;
+        let contest_id: String = row.try_get("contest_id")?;
+        let user_id: String = row.try_get("user_id")?;
+        let language: String = row.try_get("language")?;
+        let point: f64 = row.try_get("point")?;
+        let length: i32 = row.try_get("length")?;
+        let result: String = row.try_get("result")?;
+        let execution_time: Option<i32> = row.try_get("execution_time")?;
+        Ok(Submission {
+            id,
+            epoch_second,
+            problem_id,
+            contest_id,
+            user_id,
+            language,
+            point,
+            length,
+            result,
+            execution_time,
+        })
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -69,7 +69,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(user_id)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::FromTime { from_second, count } => {
                 sqlx::query_as(
@@ -83,7 +82,6 @@ impl SubmissionClient for PgPool {
                 .bind(from_second)
                 .bind(count)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::RecentAccepted { count } => {
                 sqlx::query_as(
@@ -96,7 +94,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(count)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::RecentAll { count } => {
                 sqlx::query_as(
@@ -108,7 +105,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(count)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::UsersAccepted { user_ids } => {
                 sqlx::query_as(
@@ -120,7 +116,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(user_ids)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::AllAccepted => {
                 sqlx::query_as(
@@ -130,7 +125,6 @@ impl SubmissionClient for PgPool {
                     ",
                 )
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::InvalidResult { from_second } => {
                 sqlx::query_as(
@@ -145,7 +139,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(from_second)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::ByIds { ids } => {
                 sqlx::query_as(
@@ -156,7 +149,6 @@ impl SubmissionClient for PgPool {
                 )
                 .bind(ids)
                 .fetch_all(self)
-                .await
             }
             SubmissionRequest::UsersProblemsTime {
                 user_ids,
@@ -179,9 +171,8 @@ impl SubmissionClient for PgPool {
                 .bind(from_second)
                 .bind(to_second)
                 .fetch_all(self)
-                .await
             }
-        }?;
+        }.await?;
         Ok(submissions)
     }
 

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -137,7 +137,7 @@ impl SubmissionClient for PgPool {
                     r"
                     SELECT * FROM submissions
                     WHERE 
-                        result != ALL(('AC', 'WA', 'TLE', 'CE', 'RE', 'MLE', 'OLE', 'QLE', 'IE', 'NG'))
+                        result != ALL(ARRAY['AC', 'WA', 'TLE', 'CE', 'RE', 'MLE', 'OLE', 'QLE', 'IE', 'NG'])
                     AND 
                         epoch_second >= $1
                     ORDER BY id DESC
@@ -284,7 +284,7 @@ impl SubmissionClient for PgPool {
                 UNNEST($4::VARCHAR(255)[]),
                 UNNEST($5::VARCHAR(255)[]),
                 UNNEST($6::VARCHAR(255)[]),
-                UNNEST($7::DOUBLE[]),
+                UNNEST($7::FLOAT8[]),
                 UNNEST($8::INTEGER[]),
                 UNNEST($9::VARCHAR(255)[]),
                 UNNEST($10::INTEGER[])

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -1,0 +1,365 @@
+use crate::models::Submission;
+use crate::PgPool;
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::postgres::PgQueryAs;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+pub enum SubmissionRequest<'a> {
+    UserAll {
+        user_id: &'a str,
+    },
+    UsersAccepted {
+        user_ids: &'a [&'a str],
+    },
+    FromTime {
+        from_second: i64,
+        count: i64,
+    },
+    RecentAccepted {
+        count: i64,
+    },
+    RecentAll {
+        count: i64,
+    },
+    InvalidResult {
+        from_second: i64,
+    },
+    AllAccepted,
+    ByIds {
+        ids: &'a [i64],
+    },
+    UsersProblemsTime {
+        user_ids: &'a [&'a str],
+        problem_ids: &'a [&'a str],
+        from_second: i64,
+        to_second: i64,
+    },
+}
+
+#[async_trait]
+pub trait SubmissionClient {
+    async fn get_submissions<'a>(&self, request: SubmissionRequest<'a>) -> Result<Vec<Submission>>;
+    async fn get_user_submission_count(&self, user_id: &str) -> Result<i64>;
+    async fn update_submissions(&self, values: &[Submission]) -> Result<usize>;
+    async fn update_submission_count(&self) -> Result<()>;
+    async fn update_user_submission_count(&self, user_id: &str) -> Result<()>;
+    async fn update_delta_submission_count(&self, values: &[Submission]) -> Result<()>;
+
+    async fn count_stored_submissions(&self, ids: &[i64]) -> Result<usize> {
+        let submissions = self
+            .get_submissions(SubmissionRequest::ByIds { ids })
+            .await?;
+        Ok(submissions.len())
+    }
+}
+
+#[async_trait]
+impl SubmissionClient for PgPool {
+    async fn get_submissions<'a>(&self, request: SubmissionRequest<'a>) -> Result<Vec<Submission>> {
+        let submissions = match request {
+            SubmissionRequest::UserAll { user_id } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE user_id = $1
+                    ",
+                )
+                .bind(user_id)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::FromTime { from_second, count } => {
+                sqlx::query_as(
+                    r"
+                         SELECT * FROM submissions
+                         WHERE epoch_second >= $1
+                         ORDER BY epoch_second ASC
+                         LIMIT $2
+                         ",
+                )
+                .bind(from_second)
+                .bind(count)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::RecentAccepted { count } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE result = 'AC'
+                    ORDER BY id DESC
+                    LIMIT $1
+                    ",
+                )
+                .bind(count)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::RecentAll { count } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    ORDER BY id DESC
+                    LIMIT $1
+                    ",
+                )
+                .bind(count)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::UsersAccepted { user_ids } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE result = 'AC'
+                    AND user_id = ANY($1)
+                    ",
+                )
+                .bind(user_ids)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::AllAccepted => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE result = 'AC'
+                    ",
+                )
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::InvalidResult { from_second } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE 
+                        result != ALL(('AC', 'WA', 'TLE', 'CE', 'RE', 'MLE', 'OLE', 'QLE', 'IE', 'NG'))
+                    AND 
+                        epoch_second >= $1
+                    ORDER BY id DESC
+                    "
+                )
+                .bind(from_second)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::ByIds { ids } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE id = ANY($1)
+                    ",
+                )
+                .bind(ids)
+                .fetch_all(self)
+                .await
+            }
+            SubmissionRequest::UsersProblemsTime {
+                user_ids,
+                problem_ids,
+                from_second,
+                to_second,
+            } => {
+                sqlx::query_as(
+                    r"
+                    SELECT * FROM submissions
+                    WHERE user_id = ANY($1)
+                    AND problem_id = ANY($2)
+                    AND epoch_second >= $3
+                    AND epoch_second <= $4
+                    LIMIT 2000
+                    "
+                )
+                .bind(user_ids)
+                .bind(problem_ids)
+                .bind(from_second)
+                .bind(to_second)
+                .fetch_all(self)
+                .await
+            }
+        }?;
+        Ok(submissions)
+    }
+
+    async fn get_user_submission_count(&self, user_id: &str) -> Result<i64> {
+        let count = sqlx::query(
+            r"
+            SELECT count FROM submission_count
+            WHERE user_id = $1
+            ",
+        )
+        .bind(user_id)
+        .try_map(|row: PgRow| row.try_get::<i64, _>("count"))
+        .fetch_one(self)
+        .await?;
+        Ok(count)
+    }
+
+    async fn update_submissions(&self, values: &[Submission]) -> Result<usize> {
+        let (
+            ids,
+            epoch_seconds,
+            problem_ids,
+            contest_ids,
+            user_ids,
+            languages,
+            points,
+            lengths,
+            results,
+            execution_times,
+        ) = values.iter().fold(
+            (
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+            ),
+            |(
+                mut ids,
+                mut epoch_seconds,
+                mut problem_ids,
+                mut contest_ids,
+                mut user_ids,
+                mut languages,
+                mut points,
+                mut lengths,
+                mut results,
+                mut execution_times,
+            ),
+             cur| {
+                ids.push(cur.id);
+                epoch_seconds.push(cur.epoch_second);
+                problem_ids.push(cur.problem_id.clone());
+                contest_ids.push(cur.contest_id.clone());
+                user_ids.push(cur.user_id.clone());
+                languages.push(cur.language.clone());
+                points.push(cur.point);
+                lengths.push(cur.length);
+                results.push(cur.result.clone());
+                execution_times.push(cur.execution_time);
+
+                (
+                    ids,
+                    epoch_seconds,
+                    problem_ids,
+                    contest_ids,
+                    user_ids,
+                    languages,
+                    points,
+                    lengths,
+                    results,
+                    execution_times,
+                )
+            },
+        );
+        let count = sqlx::query(
+            r"
+            INSERT INTO submissions
+            (
+                id,
+                epoch_second,
+                problem_id,
+                contest_id,
+                user_id,
+                language,
+                point,
+                length,
+                result,
+                execution_time
+            )
+            VALUES (
+                UNNEST($1::BIGINT[]),
+                UNNEST($2::BIGINT[]),
+                UNNEST($3::VARCHAR(255)[]),
+                UNNEST($4::VARCHAR(255)[]),
+                UNNEST($5::VARCHAR(255)[]),
+                UNNEST($6::VARCHAR(255)[]),
+                UNNEST($7::DOUBLE[]),
+                UNNEST($8::INTEGER[]),
+                UNNEST($9::VARCHAR(255)[]),
+                UNNEST($10::INTEGER[])
+            )
+            ON CONFLICT (id)
+            DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                result = EXCLUDED.result,
+                point = EXCLUDED.point,
+                execution_time = EXCLUDED.execution_time
+            ",
+        )
+        .bind(ids)
+        .bind(epoch_seconds)
+        .bind(problem_ids)
+        .bind(contest_ids)
+        .bind(user_ids)
+        .bind(languages)
+        .bind(points)
+        .bind(lengths)
+        .bind(results)
+        .bind(execution_times)
+        .execute(self)
+        .await?;
+        Ok(count as usize)
+    }
+
+    async fn update_submission_count(&self) -> Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO submission_count (user_id, count)
+            SELECT user_id, count(*) FROM submissions GROUP BY user_id
+            ON CONFLICT (user_id) DO UPDATE SET count=EXCLUDED.count",
+        )
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_user_submission_count(&self, user_id: &str) -> Result<()> {
+        sqlx::query(
+            r"
+                INSERT INTO submission_count (user_id, count)
+                SELECT user_id, count(*) FROM submissions WHERE user_id = $1 GROUP BY user_id
+                ON CONFLICT (user_id) DO UPDATE SET count=EXCLUDED.count",
+        )
+        .bind(user_id)
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_delta_submission_count(&self, values: &[Submission]) -> Result<()> {
+        let count_map = values.iter().fold(BTreeMap::new(), |mut map, submission| {
+            *map.entry(submission.user_id.as_str()).or_insert(0) += 1;
+            map
+        });
+        let (user_ids, counts): (Vec<&str>, Vec<i32>) = count_map.into_iter().unzip();
+
+        sqlx::query(
+            r"
+            INSERT INTO submission_count (user_id, count)
+            VALUE (
+                UNNEST($1::VARCHAR(255)[]),
+                UNNEST($2::BIGINT[])
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET count = EXCLUDED.count
+            ",
+        )
+        .bind(user_ids)
+        .bind(counts)
+        .execute(self)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
@@ -1,0 +1,193 @@
+use sql_client::models::Submission;
+use sql_client::submission_client::{SubmissionClient, SubmissionRequest};
+
+mod utils;
+
+#[async_std::test]
+async fn test_submission_client() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    sqlx::query(
+        r"
+        INSERT INTO submissions
+            (id, epoch_second, problem_id, contest_id, user_id, language, point, length, result)
+        VALUES
+            (1, 100, 'problem1', 'contest1', 'user1', 'language1', 1.0, 1, 'AC'),
+            (2, 200, 'problem1', 'contest1', 'user2', 'language1', 1.0, 1, 'AC'),
+            (3, 300, 'problem1', 'contest1', 'user1', 'language1', 1.0, 1, 'WA'),
+            (4, 400, 'problem1', 'contest1', 'user1', 'language1', 1.0, 1, 'AC'),
+            (5, 1, 'problem2', 'contest1', 'userx', 'language1', 1.0, 1, '23/42 TLE'),
+            (6, 2, 'problem2', 'contest1', 'userx', 'language1', 1.0, 1, '23/42 TLE');
+    ",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let request = SubmissionRequest::UserAll { user_id: "user1" };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 3);
+
+    let request = SubmissionRequest::UserAll { user_id: "user2" };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 1);
+
+    let request = SubmissionRequest::UserAll { user_id: "user3" };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 0);
+
+    let request = SubmissionRequest::RecentAccepted { count: 0 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 0);
+
+    let request = SubmissionRequest::RecentAccepted { count: 1 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 1);
+
+    let request = SubmissionRequest::RecentAccepted { count: 2 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 2);
+
+    let request = SubmissionRequest::RecentAccepted { count: 100 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 3);
+
+    let request = SubmissionRequest::FromTime {
+        from_second: 100,
+        count: 10,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 4);
+
+    let request = SubmissionRequest::FromTime {
+        from_second: 200,
+        count: 10,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 3);
+
+    let request = SubmissionRequest::FromTime {
+        from_second: 100,
+        count: 1,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 1);
+
+    let request = SubmissionRequest::UsersAccepted {
+        user_ids: &["user1", "user2"],
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 3);
+
+    let request = SubmissionRequest::UsersAccepted {
+        user_ids: &["user1"],
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 2);
+
+    pool.update_submission_count().await.unwrap();
+    assert_eq!(pool.get_user_submission_count("user1").await.unwrap(), 3);
+    assert_eq!(pool.get_user_submission_count("user2").await.unwrap(), 1);
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::AllAccepted)
+        .await
+        .unwrap();
+    assert_eq!(submissions.len(), 3);
+
+    assert_eq!(pool.count_stored_submissions(&[1]).await.unwrap(), 1);
+    assert_eq!(pool.count_stored_submissions(&[9]).await.unwrap(), 0);
+
+    let request = SubmissionRequest::InvalidResult { from_second: 1 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 2);
+
+    let request = SubmissionRequest::InvalidResult { from_second: 2 };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 1);
+}
+
+#[async_std::test]
+async fn test_update_submission_count() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    sqlx::query(
+        r"
+        INSERT INTO submissions
+            (id, epoch_second, problem_id, contest_id, user_id, language, point, length, result)
+        VALUES
+            (1, 100, 'problem1', 'contest1', 'user1', 'language1', 1.0, 1, 'AC');
+    ",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    assert!(pool.get_user_submission_count("user1").await.is_err());
+    pool.update_user_submission_count("user1").await.unwrap();
+    assert_eq!(pool.get_user_submission_count("user1").await.unwrap(), 1);
+}
+
+#[async_std::test]
+async fn test_update_submissions() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    pool.update_submissions(&[Submission {
+        id: 0,
+        user_id: "old_user_name".to_owned(),
+        result: "WJ".to_owned(),
+        point: 0.0,
+        execution_time: None,
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::UserAll {
+            user_id: "old_user_name",
+        })
+        .await
+        .unwrap();
+    assert_eq!(submissions.len(), 1);
+    assert_eq!(submissions[0].user_id, "old_user_name".to_owned());
+    assert_eq!(submissions[0].result, "WJ".to_owned());
+    assert_eq!(submissions[0].point, 0.0);
+    assert_eq!(submissions[0].execution_time, None);
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::UserAll {
+            user_id: "new_user_name",
+        })
+        .await
+        .unwrap();
+    assert_eq!(submissions.len(), 0);
+
+    pool.update_submissions(&[Submission {
+        id: 0,
+        user_id: "new_user_name".to_owned(),
+        result: "AC".to_owned(),
+        point: 100.0,
+        execution_time: Some(1),
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::UserAll {
+            user_id: "old_user_name",
+        })
+        .await
+        .unwrap();
+    assert_eq!(submissions.len(), 0);
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::UserAll {
+            user_id: "new_user_name",
+        })
+        .await
+        .unwrap();
+    assert_eq!(submissions.len(), 1);
+    assert_eq!(submissions[0].user_id, "new_user_name".to_owned());
+    assert_eq!(submissions[0].result, "AC".to_owned());
+    assert_eq!(submissions[0].point, 100.0);
+    assert_eq!(submissions[0].execution_time, Some(1));
+}


### PR DESCRIPTION
Related issue: #701

`SubmissionClient` の sqlx 版です。

#### やったこと

- 非同期対応の `SubmissionClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `SubmissionClient` のテストを作成（もとのテストを踏襲）

今までは `sqlx::query(..).try_map()` と書いていましたが、今回はmap先の構造体に `FromRow` トレイトを実装して `sqlx::query_as` を使うというやり方でやってみました。（こうしないと `get_submissions` が地獄になりそうだったため）