### PR TITLE
[replacement with sqlx] ProblemInfoUpdater

### DIFF
--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod contest_problem;
 pub mod internal;
 pub mod language_count;
 pub mod models;
+pub mod problem_info;
 
 pub type PgPool = sqlx::postgres::PgPool;
 

--- a/atcoder-problems-backend/sql-client/src/problem_info.rs
+++ b/atcoder-problems-backend/sql-client/src/problem_info.rs
@@ -1,0 +1,48 @@
+use crate::PgPool;
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait ProblemInfoUpdater {
+    async fn update_solver_count(&self) -> Result<()>;
+    async fn update_problem_points(&self) -> Result<()>;
+}
+
+#[async_trait]
+impl ProblemInfoUpdater for PgPool {
+    async fn update_solver_count(&self) -> Result<()> {
+        sqlx::query(
+            r"
+                INSERT INTO solver (user_count, problem_id)
+                    SELECT COUNT(DISTINCT(user_id)), problem_id
+                    FROM submissions
+                    WHERE result = 'AC'
+                    GROUP BY problem_id
+                ON CONFLICT (problem_id) DO UPDATE
+                SET user_count = EXCLUDED.user_count;
+            ",
+        )
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_problem_points(&self) -> Result<()> {
+        sqlx::query(
+            r"
+                INSERT INTO points (problem_id, point)
+                    SELECT submissions.problem_id, MAX(submissions.point)
+                    FROM submissions
+                    INNER JOIN contests ON contests.id = submissions.contest_id
+                    WHERE contests.start_epoch_second >= 1468670400
+                    AND contests.rate_change != '-'
+                    GROUP BY submissions.problem_id
+                ON CONFLICT (problem_id) DO UPDATE
+                SET point = EXCLUDED.point;
+            ",
+        )
+        .execute(self)
+        .await?;
+        Ok(())
+    }
+}

--- a/atcoder-problems-backend/sql-client/src/problem_info.rs
+++ b/atcoder-problems-backend/sql-client/src/problem_info.rs
@@ -1,4 +1,4 @@
-use crate::PgPool;
+use crate::{PgPool, FIRST_AGC_EPOCH_SECOND};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -34,13 +34,14 @@ impl ProblemInfoUpdater for PgPool {
                     SELECT submissions.problem_id, MAX(submissions.point)
                     FROM submissions
                     INNER JOIN contests ON contests.id = submissions.contest_id
-                    WHERE contests.start_epoch_second >= 1468670400
+                    WHERE contests.start_epoch_second >= $1
                     AND contests.rate_change != '-'
                     GROUP BY submissions.problem_id
                 ON CONFLICT (problem_id) DO UPDATE
                 SET point = EXCLUDED.point;
             ",
         )
+        .bind(FIRST_AGC_EPOCH_SECOND)
         .execute(self)
         .await?;
         Ok(())

--- a/atcoder-problems-backend/sql-client/tests/test_problem_info.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_problem_info.rs
@@ -1,0 +1,129 @@
+use sql_client::models::{Contest, Submission};
+use sql_client::problem_info::ProblemInfoUpdater;
+use sql_client::simple_client::SimpleClient;
+use sql_client::PgPool;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+mod utils;
+
+async fn get_solver(pool: &PgPool) -> Vec<(String, i32)> {
+    sqlx::query("SELECT problem_id, user_count FROM solver")
+        .map(|row: PgRow| {
+            let problem_id: String = row.get("problem_id");
+            let user_count: i32 = row.get("user_count");
+            (problem_id, user_count)
+        })
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+async fn get_points(pool: &PgPool) -> Vec<(String, Option<f64>)> {
+    sqlx::query("SELECT problem_id, point FROM points")
+        .map(|row: PgRow| {
+            let problem_id: String = row.get("problem_id");
+            let point: Option<f64> = row.get("point");
+            (problem_id, point)
+        })
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+#[async_std::test]
+async fn test_update_problem_solver_count() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+
+    assert!(get_solver(&pool).await.is_empty());
+
+    pool.update_submissions(&[
+        Submission {
+            id: 0,
+            user_id: "user1".to_string(),
+            result: "AC".to_string(),
+            problem_id: "problem".to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 1,
+            user_id: "user2".to_string(),
+            result: "AC".to_string(),
+            problem_id: "problem".to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 2,
+            user_id: "user3".to_string(),
+            result: "WA".to_string(),
+            problem_id: "problem".to_string(),
+            ..Default::default()
+        },
+    ])
+    .await
+    .unwrap();
+    pool.update_solver_count().await.unwrap();
+    assert_eq!(get_solver(&pool).await, vec![("problem".to_string(), 2)]);
+
+    pool.update_submissions(&[Submission {
+        id: 3,
+        user_id: "user3".to_string(),
+        result: "AC".to_string(),
+        problem_id: "problem".to_string(),
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+    pool.update_solver_count().await.unwrap();
+    assert_eq!(get_solver(&pool).await, vec![("problem".to_string(), 3)]);
+}
+
+#[async_std::test]
+async fn test_update_problem_points() {
+    let contest_id = "contest";
+    let problem_id = "problem";
+
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    pool.insert_contests(&[Contest {
+        id: contest_id.to_string(),
+        start_epoch_second: 1468670400,
+        rate_change: "All".to_string(),
+
+        duration_second: 0,
+        title: "".to_string(),
+    }])
+    .await
+    .unwrap();
+
+    assert!(get_points(&pool).await.is_empty());
+
+    pool.update_submissions(&[Submission {
+        id: 0,
+        point: 0.0,
+        problem_id: problem_id.to_string(),
+        contest_id: contest_id.to_string(),
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+    pool.update_problem_points().await.unwrap();
+    assert_eq!(
+        get_points(&pool).await,
+        vec![("problem".to_string(), Some(0.0))]
+    );
+
+    pool.update_submissions(&[Submission {
+        id: 1,
+        point: 100.0,
+        problem_id: problem_id.to_string(),
+        contest_id: contest_id.to_string(),
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+    pool.update_problem_points().await.unwrap();
+    assert_eq!(
+        get_points(&pool).await,
+        vec![("problem".to_string(), Some(100.0))]
+    );
+}

--- a/atcoder-problems-backend/sql-client/tests/test_problem_info.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_problem_info.rs
@@ -1,6 +1,7 @@
 use sql_client::models::{Contest, Submission};
 use sql_client::problem_info::ProblemInfoUpdater;
 use sql_client::simple_client::SimpleClient;
+use sql_client::submission_client::SubmissionClient;
 use sql_client::PgPool;
 use sqlx::postgres::PgRow;
 use sqlx::Row;


### PR DESCRIPTION
Related issue: #701

`ProblemInfoUpdater` の sqlx 版です。

#### やったこと

- 非同期対応の `ProblemInfoUpdater` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `ProblemInfoUpdater` のテストを作成（もとのテストを踏襲）
