### PR TITLE
[replacement with sqlx] RatedPointSumClient

### DIFF
--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -8,6 +8,7 @@ pub mod language_count;
 pub mod models;
 pub mod problem_info;
 pub mod problems_submissions;
+pub mod rated_point_sum;
 pub mod simple_client;
 pub mod submission_client;
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -84,6 +84,12 @@ pub struct UserProblemCount {
     pub problem_count: i32,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UserSum {
+    pub user_id: String,
+    pub point_sum: f64,
+}
+
 #[derive(PartialEq, Debug, Serialize)]
 pub struct ContestProblem {
     pub contest_id: String,

--- a/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
@@ -1,0 +1,109 @@
+use crate::models::{ContestProblem, Submission};
+use crate::{PgPool, FIRST_AGC_EPOCH_SECOND, MAX_INSERT_ROWS, UNRATED_STATE};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::try_join;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[async_trait]
+pub trait RatedPointSumClient {
+    async fn update_rated_point_sum(&self, ac_submissions: &[Submission]) -> Result<()>;
+    async fn get_users_rated_point_sum(&self, user_id: &str) -> Option<f64>;
+    async fn get_rated_point_sum_rank(&self, point: f64) -> Result<i64>;
+}
+
+#[async_trait]
+impl RatedPointSumClient for PgPool {
+    async fn update_rated_point_sum(&self, ac_submissions: &[Submission]) -> Result<()> {
+        let rated_contest_ids_fut = sqlx::query(
+            r"
+            SELECT id FROM contests
+            WHERE start_epoch_second >= $1
+            AND rate_change != $2
+            ",
+        )
+        .bind(FIRST_AGC_EPOCH_SECOND)
+        .bind(UNRATED_STATE)
+        .try_map(|row: PgRow| row.try_get::<String, _>("id"))
+        .fetch_all(self);
+
+        let rated_problem_ids_fut =
+            sqlx::query("SELECT contest_id, problem_id FROM contest_problem")
+                .try_map(|row: PgRow| {
+                    let contest_id: String = row.try_get("contest_id")?;
+                    let problem_id: String = row.try_get("problem_id")?;
+                    Ok(ContestProblem {
+                        contest_id,
+                        problem_id,
+                    })
+                })
+                .fetch_all(self);
+
+        let (rated_contest_ids, rated_problem_ids) =
+            try_join!(rated_contest_ids_fut, rated_problem_ids_fut)?;
+
+        let rated_contest_ids = rated_contest_ids.into_iter().collect::<BTreeSet<_>>();
+        let rated_problem_ids = rated_problem_ids
+            .into_iter()
+            .filter(|p| rated_contest_ids.contains(&p.contest_id))
+            .map(|p| p.problem_id)
+            .collect::<BTreeSet<_>>();
+        let rated_point_sum = ac_submissions
+            .iter()
+            .filter(|s| rated_problem_ids.contains(&s.problem_id))
+            .map(|s| (s.user_id.as_str(), s.problem_id.as_str(), s.point))
+            .fold(BTreeMap::new(), |mut map, (user_id, problem_id, point)| {
+                map.entry(user_id)
+                    .or_insert_with(BTreeMap::new)
+                    .insert(problem_id, point as u32);
+                map
+            })
+            .into_iter()
+            .map(|(user_id, set)| {
+                let sum = set.into_iter().map(|(_, point)| point).sum::<u32>();
+                (user_id, sum)
+            })
+            .collect::<Vec<_>>();
+
+        for chunk in rated_point_sum.chunks(MAX_INSERT_ROWS) {
+            let (user_ids, point_sums): (Vec<&str>, Vec<u32>) = chunk.iter().copied().unzip();
+            sqlx::query(
+                r"
+                INSERT INTO rated_point_sum (user_id, point_sum)
+                VALUE (
+                    UNNEST($1::VARCHAR(255)[]),
+                    UNNEST($2::FLOAT8[]))
+                )
+                ON CONFLICT (user_id)
+                DO UPDATE SET point_sum = EXCLUDED.point_sum
+                ",
+            )
+            .bind(user_ids)
+            .bind(point_sums)
+            .execute(self)
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn get_users_rated_point_sum(&self, user_id: &str) -> Option<f64> {
+        let sum = sqlx::query("SELECT point_sum FROM rated_point_sum WHERE user_id = $1")
+            .bind(user_id)
+            .try_map(|row: PgRow| row.try_get::<f64, _>("point_sum"))
+            .fetch_one(self)
+            .await
+            .ok()?;
+        Some(sum)
+    }
+
+    async fn get_rated_point_sum_rank(&self, rated_point_sum: f64) -> Result<i64> {
+        let rank = sqlx::query("SELECT COUNT(*) AS rank FROM rated_point_sum WHERE point_sum > $1")
+            .bind(rated_point_sum)
+            .try_map(|row: PgRow| row.try_get::<i64, _>("rank"))
+            .fetch_one(self)
+            .await?;
+        Ok(rank)
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
@@ -1,0 +1,201 @@
+use sql_client::models::{Contest, ContestProblem, Submission, UserSum};
+use sql_client::rated_point_sum::RatedPointSumClient;
+use sql_client::PgPool;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+mod utils;
+
+const FIRST_AGC_EPOCH_SECOND: i64 = 1_468_670_400;
+const UNRATED_STATE: &str = "-";
+const USER_ID: &str = "user";
+const RATED_CONTEST: &str = "rated_contest";
+const UNRATED_CONTEST1: &str = "unrated_contest1";
+const UNRATED_CONTEST2: &str = "unrated_contest2";
+
+const SAME_CONTEST_UNRATED: &str = "same_contest_unrated";
+const SAME_CONTEST_RATED: &str = "same_contest_rated";
+
+async fn setup_contests(pool: &PgPool) {
+    let contests = vec![
+        Contest {
+            id: RATED_CONTEST.to_string(),
+            start_epoch_second: FIRST_AGC_EPOCH_SECOND,
+            duration_second: 1000,
+            title: "Rated Contest".to_string(),
+            rate_change: "All".to_string(),
+        },
+        Contest {
+            id: UNRATED_CONTEST1.to_string(),
+            start_epoch_second: 0,
+            duration_second: 1000,
+            title: "Unrated Old Contest".to_string(),
+            rate_change: "All".to_string(),
+        },
+        Contest {
+            id: UNRATED_CONTEST2.to_string(),
+            start_epoch_second: FIRST_AGC_EPOCH_SECOND,
+            duration_second: 1000,
+            title: "Unrated New Contest".to_string(),
+            rate_change: UNRATED_STATE.to_string(),
+        },
+        Contest {
+            id: SAME_CONTEST_RATED.to_string(),
+            start_epoch_second: FIRST_AGC_EPOCH_SECOND,
+            duration_second: 1000,
+            title: "Unrated New Contest".to_string(),
+            rate_change: "All".to_string(),
+        },
+        Contest {
+            id: SAME_CONTEST_UNRATED.to_string(),
+            start_epoch_second: FIRST_AGC_EPOCH_SECOND,
+            duration_second: 1000,
+            title: "Unrated New Contest".to_string(),
+            rate_change: UNRATED_STATE.to_string(),
+        },
+    ];
+    for contest in contests {
+        sqlx::query(
+            r"
+            INSERT INTO contests
+            (id, start_epoch_second, duration_second, title, rate_change)
+            VALUES ($1, $2, $3, $4, $5)
+            ",
+        )
+        .bind(contest.id)
+        .bind(contest.start_epoch_second)
+        .bind(contest.duration_second)
+        .bind(contest.title)
+        .bind(contest.rate_change)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+async fn setup_contest_problems(pool: &PgPool) {
+    let problems = vec![
+        ContestProblem {
+            problem_id: "problem1".to_string(),
+            contest_id: RATED_CONTEST.to_string(),
+        },
+        ContestProblem {
+            problem_id: "problem2".to_string(),
+            contest_id: UNRATED_CONTEST1.to_string(),
+        },
+        ContestProblem {
+            problem_id: "problem3".to_string(),
+            contest_id: UNRATED_CONTEST1.to_string(),
+        },
+        ContestProblem {
+            problem_id: "problem4".to_string(),
+            contest_id: RATED_CONTEST.to_string(),
+        },
+        ContestProblem {
+            problem_id: "problem5".to_string(),
+            contest_id: SAME_CONTEST_RATED.to_string(),
+        },
+        ContestProblem {
+            problem_id: "problem5".to_string(),
+            contest_id: SAME_CONTEST_UNRATED.to_string(),
+        },
+    ];
+
+    for problem in problems {
+        sqlx::query(
+            r"
+            INSERT INTO contest_problem (problem_id, contest_id)
+            VALUES ($1, $2)
+            ",
+        )
+        .bind(problem.problem_id)
+        .bind(problem.contest_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[async_std::test]
+async fn test_update_rated_point_sum() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+
+    setup_contests(&pool).await;
+    setup_contest_problems(&pool).await;
+
+    let submissions = vec![
+        Submission {
+            id: 0,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem1".to_string(),
+            contest_id: RATED_CONTEST.to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 1,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem1".to_string(),
+            contest_id: RATED_CONTEST.to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 2,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem2".to_string(),
+            contest_id: UNRATED_CONTEST1.to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 3,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem3".to_string(),
+            contest_id: UNRATED_CONTEST2.to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 4,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem4".to_string(),
+            contest_id: RATED_CONTEST.to_string(),
+            ..Default::default()
+        },
+        Submission {
+            id: 5,
+            user_id: USER_ID.to_string(),
+            point: 100.0,
+            problem_id: "problem5".to_string(),
+            contest_id: SAME_CONTEST_UNRATED.to_string(),
+            ..Default::default()
+        },
+    ];
+
+    pool.update_rated_point_sum(&submissions).await.unwrap();
+    let sums = sqlx::query("SELECT user_id, point_sum FROM rated_point_sum")
+        .map(|row: PgRow| {
+            let user_id: String = row.get("user_id");
+            let point_sum: f64 = row.get("point_sum");
+            UserSum { user_id, point_sum }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(sums.len(), 1);
+    assert_eq!(sums[0].user_id, USER_ID.to_string());
+    assert_eq!(sums[0].point_sum, 300.0);
+    assert_eq!(
+        pool.get_users_rated_point_sum(USER_ID).await.unwrap(),
+        300.0
+    );
+    assert_eq!(pool.get_rated_point_sum_rank(300.0).await.unwrap(), 0);
+
+    assert!(pool
+        .get_users_rated_point_sum("non_existing_user")
+        .await
+        .is_none());
+}
+


### PR DESCRIPTION
Related issue: #701

`RatedPointSumClient` の sqlx 版です。

#### やったこと

- 非同期対応の `RatedPointSumClient` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `RatedPointSumClient` のテストを作成（もとのテストを踏襲）