### PR TITLE
[replacement with sqlx] StreakUpdater

### DIFF
--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
+ "chrono",
  "futures 0.3.5",
  "regex",
  "serde",

--- a/atcoder-problems-backend/sql-client/Cargo.toml
+++ b/atcoder-problems-backend/sql-client/Cargo.toml
@@ -16,3 +16,4 @@ anyhow = "1.0.32"
 async-std = { version = "1.6", features = ["attributes"] }
 regex = "1"
 futures = "0.3.5"
+chrono = "0.4"

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -11,6 +11,7 @@ pub mod problems_submissions;
 pub mod rated_point_sum;
 pub mod simple_client;
 pub mod submission_client;
+pub mod streak;
 
 pub type PgPool = sqlx::postgres::PgPool;
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -95,3 +95,9 @@ pub struct ContestProblem {
     pub contest_id: String,
     pub problem_id: String,
 }
+
+#[derive(PartialEq, Debug, Serialize)]
+pub struct UserStreak {
+    pub user_id: String,
+    pub streak: i64,
+}

--- a/atcoder-problems-backend/sql-client/src/streak.rs
+++ b/atcoder-problems-backend/sql-client/src/streak.rs
@@ -1,0 +1,143 @@
+use crate::models::Submission;
+use crate::{PgPool, MAX_INSERT_ROWS};
+use anyhow::Result;
+use async_trait::async_trait;
+
+use chrono::Duration;
+use chrono::{DateTime, Datelike, FixedOffset, TimeZone, Utc};
+use std::cmp;
+use std::collections::BTreeMap;
+
+#[async_trait]
+pub trait StreakUpdater {
+    async fn update_streak_count(&self, submissions: &[Submission]) -> Result<()>;
+}
+
+#[async_trait]
+impl StreakUpdater for PgPool {
+    async fn update_streak_count(&self, ac_submissions: &[Submission]) -> Result<()> {
+        let mut submissions = ac_submissions
+            .iter()
+            .map(|s| {
+                (
+                    Utc.timestamp(s.epoch_second, 0),
+                    s.user_id.as_str(),
+                    s.problem_id.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        submissions.sort_by_key(|&(timestamp, _, _)| timestamp);
+        let first_ac_map = submissions.into_iter().fold(
+            BTreeMap::new(),
+            |mut map, (epoch_second, user_id, problem_id)| {
+                map.entry(user_id)
+                    .or_insert_with(BTreeMap::new)
+                    .entry(problem_id)
+                    .or_insert(epoch_second);
+                map
+            },
+        );
+
+        let user_max_streak = first_ac_map
+            .into_iter()
+            .map(|(user_id, m)| {
+                let max_streak = get_max_streak(m.into_iter().map(|(_, utc)| utc).collect());
+                (user_id, max_streak)
+            })
+            .collect::<Vec<_>>();
+
+        for chunk in user_max_streak.chunks(MAX_INSERT_ROWS) {
+            let (user_ids, max_streaks): (Vec<&str>, Vec<i64>) = chunk.iter().copied().unzip();
+            sqlx::query(
+                r"
+                INSERT INTO max_streaks (user_id, streak)
+                VALUES (
+                    UNNEST($1::VARCHAR(255)[]),
+                    UNNEST($2::BIGINT[])
+                )
+                ON CONFLICT (user_id)
+                DO UPDATE SET streak = EXCLUDED.streak
+                ",
+            )
+            .bind(user_ids)
+            .bind(max_streaks)
+            .execute(self)
+            .await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn get_max_streak<Tz: TimeZone>(mut v: Vec<DateTime<Tz>>) -> i64 {
+    v.sort();
+    let (_, max_streak) = (1..v.len()).fold((1, 1), |(current_streak, max_streak), i| {
+        if v[i - 1].is_same_day_in_jst(&v[i]) {
+            (current_streak, max_streak)
+        } else if (v[i - 1].clone() + Duration::days(1)).is_same_day_in_jst(&v[i]) {
+            (current_streak + 1, cmp::max(max_streak, current_streak + 1))
+        } else {
+            (1, max_streak)
+        }
+    });
+    max_streak
+}
+
+trait AsJst {
+    fn as_jst(&self) -> DateTime<FixedOffset>;
+    fn is_same_day_in_jst<T: TimeZone>(&self, rhs: &DateTime<T>) -> bool {
+        let d1 = self.as_jst();
+        let d2 = rhs.as_jst();
+        d1.day() == d2.day() && d1.month() == d2.month() && d1.year() == d2.year()
+    }
+}
+
+impl<Tz> AsJst for DateTime<Tz>
+where
+    Tz: TimeZone,
+{
+    fn as_jst(&self) -> DateTime<FixedOffset> {
+        self.with_timezone(&FixedOffset::east(9 * 3600))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Datelike;
+
+    #[test]
+    fn test_to_jst() {
+        let dt_10_04 = Utc.timestamp(1570114800, 0); //2019-10-04T00:00:00+09:00
+        assert_eq!(dt_10_04.as_jst().day(), 04);
+
+        let dt_10_03 = Utc.timestamp(1570114799, 0); //2019-10-03T23:59:59+09:00
+        assert_eq!(dt_10_03.as_jst().day(), 03);
+
+        let tomorrow = dt_10_03 + Duration::days(1);
+        assert!((tomorrow).is_same_day_in_jst(&dt_10_04));
+    }
+
+    #[test]
+    fn test_get_max_streak() {
+        let v = vec![
+            "2014-11-28T17:00:09+09:00",
+            "2014-11-28T18:00:09+09:00",
+            "2014-11-28T19:00:09+09:00",
+            "2014-11-28T20:00:09+09:00",
+            "2014-11-28T21:00:09+09:00",
+            "2014-11-28T22:00:09+09:00",
+            "2014-11-28T23:00:09+09:00",
+            "2014-11-28T23:59:59+09:00",
+            "2014-12-04T23:59:59+09:00",
+            "2014-12-02T23:59:59+09:00",
+            "2014-12-03T23:59:59+09:00",
+            "2014-12-01T23:59:59+09:00",
+        ]
+        .into_iter()
+        .map(|s| s.parse::<DateTime<Utc>>().unwrap())
+        .collect::<Vec<_>>();
+        let streak = get_max_streak(v);
+        assert_eq!(streak, 4);
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_streak.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_streak.rs
@@ -1,0 +1,44 @@
+use sql_client::models::UserStreak;
+use sql_client::streak::StreakUpdater;
+use sql_client::submission_client::{SubmissionClient, SubmissionRequest};
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+
+mod utils;
+
+#[async_std::test]
+async fn test_update_streak_ranking() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    sqlx::query(
+        r"
+    INSERT INTO submissions (id, epoch_second, problem_id, contest_id, user_id, language, point, length, result) VALUES 
+    (1, 1570114800, 'problem_a', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-04T00:00:00+09:00
+    (2, 1570150800, 'problem_b', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-04T10:00:00+09:00
+    (3, 1570186800, 'problem_c', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-04T20:00:00+09:00
+    (4, 1570201200, 'problem_d', '', 'user1', '', 0, 0, 'AC'); -- 2019-10-05T00:00:00+09:00
+    ",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let submissions = pool
+        .get_submissions(SubmissionRequest::AllAccepted)
+        .await
+        .unwrap();
+    pool.update_streak_count(&submissions).await.unwrap();
+
+    let v = sqlx::query("SELECT user_id, streak FROM max_streaks")
+        .map(|row: PgRow| {
+            let user_id: String = row.get("user_id");
+            let streak: i64 = row.get("streak");
+            UserStreak { user_id, streak }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].streak, 2);
+}
+


### PR DESCRIPTION
Related issue: #701

`StreakUpdater` の sqlx 版です。

#### やったこと

- 非同期対応の `StreakUpdater` を作って、それを `sqlx::postgres::PgPool` に対して実装
- `StreakUpdater` のテストを作成（もとのテストを踏襲）