### PR TITLE
fronted: Adjust AtcoderRegularTable cells position to its alphabet

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -75,7 +75,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
       const problemStatus = new Map(
         problemStatusList.map((status) => {
           const list = status.problem.title.split(".");
-          const alphabet = list.length == 0 ? "" : list[0];
+          const alphabet = list.length === 0 ? "" : list[0];
           return [alphabet, status];
         })
       );


### PR DESCRIPTION
Resolve #805 
Related #803

`AtcoderRegularTable`の問題のカラムを、問題のアルファベットに合わせる仕様に変更しました。

具体的には、コンテストごとの問題ステータスをアルファベット{A..F}の連想配列で管理するようになりました。