### PR TITLE
Userid case insensitive

### DIFF
--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -180,7 +180,7 @@ impl SubmissionClient for PgPool {
         let count = sqlx::query(
             r"
             SELECT count FROM submission_count
-            WHERE LOWER(user_id) = LOWER($1)
+            WHERE user_id = $1
             ",
         )
         .bind(user_id)

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -159,7 +159,7 @@ impl SubmissionClient for PgPool {
                 sqlx::query_as(
                     r"
                     SELECT * FROM submissions
-                    WHERE LOWER(user_id) = ANY($1)
+                    WHERE user_id = ANY($1)
                     AND problem_id = ANY($2)
                     AND epoch_second >= $3
                     AND epoch_second <= $4

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -64,7 +64,7 @@ impl SubmissionClient for PgPool {
                 sqlx::query_as(
                     r"
                     SELECT * FROM submissions
-                    WHERE user_id = $1
+                    WHERE LOWER(user_id) = LOWER($1)
                     ",
                 )
                 .bind(user_id)
@@ -180,7 +180,7 @@ impl SubmissionClient for PgPool {
         let count = sqlx::query(
             r"
             SELECT count FROM submission_count
-            WHERE user_id = $1
+            WHERE LOWER(user_id) = LOWER($1)
             ",
         )
         .bind(user_id)

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -159,7 +159,7 @@ impl SubmissionClient for PgPool {
                 sqlx::query_as(
                     r"
                     SELECT * FROM submissions
-                    WHERE user_id = ANY($1)
+                    WHERE LOWER(user_id) = ANY($1)
                     AND problem_id = ANY($2)
                     AND epoch_second >= $3
                     AND epoch_second <= $4

--- a/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
@@ -23,7 +23,7 @@ async fn test_submission_client() {
     .await
     .unwrap();
 
-    let request = SubmissionRequest::UserAll { user_id: "user1" };
+    let request = SubmissionRequest::UserAll { user_id: "usEr1" };
     let submissions = pool.get_submissions(request).await.unwrap();
     assert_eq!(submissions.len(), 3);
 

--- a/atcoder-problems-backend/src/server/user_submissions.rs
+++ b/atcoder-problems-backend/src/server/user_submissions.rs
@@ -44,7 +44,7 @@ pub(crate) async fn get_users_time_submissions<A>(
 
     let conn = request.state().pg_pool.clone();
     let query = request.query::<Query>().map_anyhow()?;
-    let user_ids = query.users.split(',').map(|s| s.trim().to_lowercase()).collect::<Vec<_>>();
+    let user_ids = query.users.split(',').map(|s| s.trim()).collect::<Vec<_>>();
     let problem_ids = query
         .problems
         .split(',')

--- a/atcoder-problems-backend/src/server/user_submissions.rs
+++ b/atcoder-problems-backend/src/server/user_submissions.rs
@@ -44,7 +44,7 @@ pub(crate) async fn get_users_time_submissions<A>(
 
     let conn = request.state().pg_pool.clone();
     let query = request.query::<Query>().map_anyhow()?;
-    let user_ids = query.users.split(',').map(|s| s.trim()).collect::<Vec<_>>();
+    let user_ids = query.users.split(',').map(|s| s.trim().to_lowercase()).collect::<Vec<_>>();
     let problem_ids = query
         .problems
         .split(',')

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -17,6 +17,7 @@ CREATE TABLE submissions (
   PRIMARY KEY (id)
 );
 CREATE INDEX ON submissions (user_id);
+CREATE INDEX ON submissions (LOWER(user_id));
 CREATE INDEX ON submissions (epoch_second);
 
 DROP TABLE IF EXISTS problems;


### PR DESCRIPTION
issuesの[User IDs should be case-insensitive](https://github.com/kenkoooo/AtCoderProblems/issues/113)に対応しました。

- データを再クロールしなくても良いようにget時のSQLマッチング部分を変更しています。

Closes #113 