### PR TITLE
fronted: Make user-id comparison case insensitive.

### DIFF
--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { RecentSubmissions } from "./pages/RecentSubmissions";
 import { TrainingPage } from "./pages/TrainingPage";
 import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
+import { caseInsensitiveUserId } from "./utils";
 
 const App: React.FC = () => {
   return (
@@ -57,7 +58,9 @@ const App: React.FC = () => {
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                   const params: { userIds: string } = match.params;
                   const userIds: string = params.userIds;
-                  const userId: string = userIds.split("/")[0];
+                  const userId: string = caseInsensitiveUserId(
+                    userIds.split("/")[0]
+                  );
                   return <UserPage userId={userId} />;
                 }}
               />
@@ -67,11 +70,14 @@ const App: React.FC = () => {
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                   const params: { userIds?: string } = match.params;
                   const userIds = params.userIds;
-                  const userId = (userIds ?? "").split("/")[0];
+                  const userId = caseInsensitiveUserId(
+                    (userIds ?? "").split("/")[0]
+                  );
                   const rivals = (userIds ?? "/").split("/");
                   const rivalList = List(rivals)
                     .skip(1)
-                    .filter((x) => x.length > 0);
+                    .filter((x) => x.length > 0)
+                    .map((x) => caseInsensitiveUserId(x));
                   return <TablePage userId={userId} rivals={rivalList} />;
                 }}
               />
@@ -81,11 +87,14 @@ const App: React.FC = () => {
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                   const params: { userIds?: string } = match.params;
                   const userIds: string | undefined = params.userIds;
-                  const userId = (userIds ?? "").split("/")[0];
+                  const userId = caseInsensitiveUserId(
+                    (userIds ?? "").split("/")[0]
+                  );
                   const rivals = (userIds ?? "/").split("/");
                   const rivalList = List(rivals)
                     .skip(1)
-                    .filter((x) => x.length > 0);
+                    .filter((x) => x.length > 0)
+                    .map((x) => caseInsensitiveUserId(x));
                   return <ListPage userId={userId} rivals={rivalList} />;
                 }}
               />

--- a/atcoder-problems-frontend/src/interfaces/Status.ts
+++ b/atcoder-problems-frontend/src/interfaces/Status.ts
@@ -1,4 +1,4 @@
-import { isAccepted } from "../utils";
+import { caseInsensitiveUserId, isAccepted } from "../utils";
 import Submission from "./Submission";
 export type ContestId = string;
 export type ProblemId = string;
@@ -82,13 +82,13 @@ export const constructStatusLabelMap = (
   Array.from(submissionMap.keys()).forEach((problemId) => {
     const list = submissionMap.get(problemId) ?? [];
     const userAccepted = list
-      .filter((s) => s.user_id === userId)
+      .filter((s) => caseInsensitiveUserId(s.user_id) === userId)
       .filter((s) => isAccepted(s.result));
     const userRejected = list
-      .filter((s) => s.user_id === userId)
+      .filter((s) => caseInsensitiveUserId(s.user_id) === userId)
       .filter((s) => !isAccepted(s.result));
     const rivalAccepted = list
-      .filter((s) => s.user_id !== userId)
+      .filter((s) => caseInsensitiveUserId(s.user_id) !== userId)
       .filter((s) => isAccepted(s.result));
 
     const rejectedEpochSeconds = userRejected.map(

--- a/atcoder-problems-frontend/src/pages/Internal/types.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/types.ts
@@ -1,4 +1,5 @@
 import Submission from "../../interfaces/Submission";
+import { caseInsensitiveUserId } from "../../utils";
 
 export interface UserResponse {
   readonly internal_user_id: string;
@@ -81,7 +82,10 @@ export const filterResetProgress = (
   userId: string
 ): Submission[] =>
   submissions.filter((submission) => {
-    if (submission.user_id !== userId) {
+    if (
+      caseInsensitiveUserId(submission.user_id) !==
+      caseInsensitiveUserId(userId)
+    ) {
       return true;
     }
     const resetEpochSecond =

--- a/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Badge, Col, Row, UncontrolledTooltip } from "reactstrap";
 import { connect, PromiseState } from "react-refetch";
-import { ordinalSuffixOf } from "../../../utils";
+import { caseInsensitiveUserId, ordinalSuffixOf } from "../../../utils";
 import { formatMomentDate, getToday } from "../../../utils/DateUtil";
 import { RankingEntry } from "../../../interfaces/RankingEntry";
 import {
@@ -22,7 +22,7 @@ const findFromRanking = (
 } => {
   const entry = ranking
     .sort((a, b) => b.problem_count - a.problem_count)
-    .find((r) => r.user_id === userId);
+    .find((r) => caseInsensitiveUserId(r.user_id) === userId);
   if (entry) {
     const count = entry.problem_count;
     const rank = ranking.filter((e) => e.problem_count > count).length;

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -2,7 +2,11 @@ import { Col, Row } from "reactstrap";
 import React from "react";
 import Problem from "../../../interfaces/Problem";
 import Submission from "../../../interfaces/Submission";
-import { isAccepted, isValidResult } from "../../../utils";
+import {
+  caseInsensitiveUserId,
+  isAccepted,
+  isValidResult,
+} from "../../../utils";
 import { ContestId, ProblemId } from "../../../interfaces/Status";
 import { SmallPieChart } from "./SmallPieChart";
 
@@ -55,7 +59,11 @@ const solvedCountForPieChart = (
       const titleStatus = problems.map((problem) => {
         const validSubmissions = submissions
           .get(problem.id)
-          ?.filter((s) => s.user_id === userId && isValidResult(s.result));
+          ?.filter(
+            (s) =>
+              caseInsensitiveUserId(s.user_id) === userId &&
+              isValidResult(s.result)
+          );
         const status = !validSubmissions
           ? SubmissionStatus.TRYING
           : validSubmissions?.find((s) => isAccepted(s.result))

--- a/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
@@ -16,6 +16,7 @@ import {
   RatingColor,
   RatingColors,
   isAccepted,
+  caseInsensitiveUserId,
 } from "../../../utils";
 import {
   formatMomentDate,
@@ -132,7 +133,10 @@ export const ProgressChartBlock: React.FC<Props> = (props) => {
   const dateColorCountMap = Array.from(submissions.values())
     .map((submissionList) =>
       submissionList
-        .filter((s) => s.user_id === userId && isAccepted(s.result))
+        .filter(
+          (s) =>
+            caseInsensitiveUserId(s.user_id) === userId && isAccepted(s.result)
+        )
         .sort((a, b) => a.epoch_second - b.epoch_second)
         .find(() => true)
     )

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -7,7 +7,7 @@ import { connect, PromiseState } from "react-refetch";
 import Submission from "../../interfaces/Submission";
 import MergedProblem from "../../interfaces/MergedProblem";
 import Contest from "../../interfaces/Contest";
-import { isAccepted } from "../../utils";
+import { caseInsensitiveUserId, isAccepted } from "../../utils";
 import { ContestId, ProblemId } from "../../interfaces/Status";
 import * as CachedApiClient from "../../utils/CachedApiClient";
 import ProblemModel from "../../interfaces/ProblemModel";
@@ -113,8 +113,10 @@ const InnerUserPage: React.FC<InnerProps> = (props) => {
   const userSubmissions = submissions
     .valueSeq()
     .flatMap((list) => list)
-    .filter((s) => s.user_id === userId)
+    .filter((s) => caseInsensitiveUserId(s.user_id) === userId)
     .toArray();
+  const actualUserId =
+    userSubmissions.length > 0 ? userSubmissions[0].user_id : userId;
   const dailyCount = countUniqueAcByDate(userSubmissions);
   const { longestStreak, currentStreak, prevDateLabel } = calcStreak(
     dailyCount
@@ -145,7 +147,7 @@ const InnerUserPage: React.FC<InnerProps> = (props) => {
   return (
     <div>
       <Row className="my-2 border-bottom">
-        <UserNameLabel userId={userId} big showRating />
+        <UserNameLabel userId={actualUserId} big showRating />
       </Row>
       <Nav tabs>
         {userPageTabs.map((tab) => (

--- a/atcoder-problems-frontend/src/utils/index.ts
+++ b/atcoder-problems-frontend/src/utils/index.ts
@@ -22,6 +22,9 @@ export const normalizeUserId = (userId: string): string => {
   const trimmedUserId = userId.trim();
   return ATCODER_USER_REGEXP.exec(trimmedUserId) ? trimmedUserId : "";
 };
+export const caseInsensitiveUserId = (userId: string): string => {
+  return userId.toLowerCase();
+};
 
 export const isAccepted = (result: string): boolean => result === "AC";
 export const isValidResult = (result: string): boolean =>


### PR DESCRIPTION
Fix #838
Related #113

フロントエンド側で，ユーザ名の比較をCase-Insensitiveにしました．

## 更新内容
- App以下のページでは，トップバーに入力されたid(`props.userId`)はlower caseが保証されるようにした
- `Submission.user_id`は実際のユーザIDの表記になっているので，比較箇所でlower caseに直して比較するようにした
   (これはあらゆる箇所で忘れがちな処理になるので，ユーザIDの比較専用の関数を作って明示的にしてもよいかもしれない)
- userページで，ユーザ名がユーザ入力の表記そのままになっていたので，正しい表記を取得して表示するようにした
    - 実装は懐疑的で，現在はユーザのsubmissionsの中のSubmission.user_idを使うようにしている