### PR TITLE
Add formatted TEE

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/AchievementBlock/index.tsx
@@ -32,6 +32,17 @@ const findFromRanking = (
   }
 };
 
+const formatTEE = (topPlayerEquivalentEffort: number): string => {
+  const days = Math.floor(topPlayerEquivalentEffort / (3600 * 24));
+  const hours = Math.floor((topPlayerEquivalentEffort / 3600) % 24);
+  const minutes = Math.floor((topPlayerEquivalentEffort / 60) % 60);
+  const seconds = Math.floor(topPlayerEquivalentEffort % 60);
+  const pad = (num: number): string => `0${num}`.slice(-2);
+  return `${days > 0 ? `${days}d ` : ""}${hours}:${pad(minutes)}:${pad(
+    seconds
+  )}`;
+};
+
 interface OuterProps {
   userId: string;
   solvedCount: number;
@@ -179,6 +190,7 @@ const InnerAchievementBlock: React.FC<InnerProps> = (props) => {
             </UncontrolledTooltip>
           </h6>
           <h3>{Math.round(topPlayerEquivalentEffort)}</h3>
+          <h6 className="text-muted">{formatTEE(topPlayerEquivalentEffort)}</h6>
         </Col>
         <Col />
       </Row>


### PR DESCRIPTION
TEE の表示に，日・時・分・秒でフォーマットしたバージョンを併記します．

TEE は時間の次元を持つ量ですが，秒数基準のみでは分かりづらく，多くの利用者が各々で TEE/3600 や TEE/3600/24 を計算しているのを観測しています．したがって，初めから分かりやすい形式で表示することには需要があると考えられます．

また，このような表示を行うことで，N 時間，あるいは N 日といったマイルストーンを設定しやすくなるとも思います．

![image](https://user-images.githubusercontent.com/59337901/104912241-5e4ae100-59cf-11eb-99ce-571264c7a66d.png)
![image](https://user-images.githubusercontent.com/59337901/104912276-67d44900-59cf-11eb-9924-7aa3d687ca14.png)