### PR TITLE
Regard submission at a contest's last second after contest

### DIFF
--- a/atcoder-problems-frontend/src/utils/TableColor.ts
+++ b/atcoder-problems-frontend/src/utils/TableColor.ts
@@ -97,14 +97,14 @@ export const statusToTableColor = ({
       if (
         status.label === StatusLabel.Success &&
         status.epoch !== void 0 &&
-        status.epoch <= contest.start_epoch_second + contest.duration_second
+        status.epoch < contest.start_epoch_second + contest.duration_second
       ) {
         return status.epoch < contest.start_epoch_second
           ? TableColor.SuccessBeforeContest
           : TableColor.SuccessIntime;
       } else if (
         status.label === StatusLabel.Warning &&
-        status.epoch <= contest.start_epoch_second + contest.duration_second
+        status.epoch < contest.start_epoch_second + contest.duration_second
       ) {
         return TableColor.WarningIntime;
       } else {


### PR DESCRIPTION
resolves #855 
「コンテスト終了時刻ちょうどのACがコンテスト中AC扱いになっている」ことを修正しました。また、ACではない提出に同様の修正を行いました。