### PR TITLE
Function of creating virtual-contest from recommendation

### DIFF
--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -30,7 +30,7 @@ import { TrainingPage } from "./pages/TrainingPage";
 import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { caseInsensitiveUserId } from "./utils";
-import { problemIdSeparateSymbol } from "./utils/QueryString";
+import { PROBLEMID_SEPARATE_SYMBOL } from "./utils/QueryString";
 
 const App: React.FC = () => {
   return (
@@ -115,7 +115,7 @@ const App: React.FC = () => {
                   const query = new URLSearchParams(location.search);
                   const items = query
                     .get("problemIds")
-                    ?.split(problemIdSeparateSymbol)
+                    ?.split(PROBLEMID_SEPARATE_SYMBOL)
                     .map((id) => ({
                       id: id,
                       point: null,

--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -30,8 +30,7 @@ import { TrainingPage } from "./pages/TrainingPage";
 import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { caseInsensitiveUserId } from "./utils";
-import { separateSymbol } from "./utils/QueryString";
-import { VirtualContestItem } from "./pages/Internal/types";
+import { problemIdSeparateSymbol } from "./utils/QueryString";
 
 const App: React.FC = () => {
   return (
@@ -116,15 +115,12 @@ const App: React.FC = () => {
                   const query = new URLSearchParams(location.search);
                   const items = query
                     .get("problemIds")
-                    ?.split(separateSymbol)
-                    .map(
-                      (id) =>
-                        ({
-                          id: id,
-                          point: null,
-                          order: null,
-                        } as VirtualContestItem)
-                    );
+                    ?.split(problemIdSeparateSymbol)
+                    .map((id) => ({
+                      id: id,
+                      point: null,
+                      order: null,
+                    }));
                   const itemList = items ? List(items) : undefined;
                   return <ContestCreatePage initialProblems={itemList} />;
                 }}

--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -30,6 +30,8 @@ import { TrainingPage } from "./pages/TrainingPage";
 import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { caseInsensitiveUserId } from "./utils";
+import { separateSymbol } from "./utils/QueryString";
+import { VirtualContestItem } from "./pages/Internal/types";
 
 const App: React.FC = () => {
   return (
@@ -110,7 +112,22 @@ const App: React.FC = () => {
               />
               <Route
                 path="/contest/create"
-                render={() => <ContestCreatePage />}
+                render={({ location }) => {
+                  const query = new URLSearchParams(location.search);
+                  const items = query
+                    .get("problemIds")
+                    ?.split(separateSymbol)
+                    .map(
+                      (id) =>
+                        ({
+                          id: id,
+                          point: null,
+                          order: null,
+                        } as VirtualContestItem)
+                    );
+                  const itemList = items ? List(items) : undefined;
+                  return <ContestCreatePage initialProblems={itemList} />;
+                }}
               />
               <Route
                 path="/contest/update/:contestId([a-zA-Z0-9_-]+)"

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -18,6 +18,7 @@ import { USER_GET } from "../pages/Internal/ApiUrl";
 import { UserResponse } from "../pages/Internal/types";
 import { GITHUB_LOGIN_LINK } from "../utils/Url";
 import { ACCOUNT_INFO } from "../utils/RouterPath";
+import * as UserState from "../utils/UserState";
 import { UserSearchBar } from "./UserSearchBar";
 import { ThemeSelector } from "./ThemeSelector";
 
@@ -26,16 +27,8 @@ interface InnerProps {
 }
 
 const InnerNavigationBar: React.FC<InnerProps> = (props) => {
-  const isLoggedIn =
-    props.loginState.fulfilled &&
-    props.loginState.value &&
-    props.loginState.value.internal_user_id.length > 0;
-  const loggedInUserId =
-    props.loginState.fulfilled &&
-    props.loginState.value &&
-    props.loginState.value.atcoder_user_id
-      ? props.loginState.value.atcoder_user_id
-      : "";
+  const isLoggedIn = UserState.isLoggedIn(props.loginState);
+  const loggedInUserId = UserState.loggedInUserId(props.loginState, "");
 
   const [isOpen, setIsOpen] = React.useState(false);
 

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -28,7 +28,7 @@ interface InnerProps {
 
 const InnerNavigationBar: React.FC<InnerProps> = (props) => {
   const isLoggedIn = UserState.isLoggedIn(props.loginState);
-  const loggedInUserId = UserState.loggedInUserId(props.loginState, "");
+  const loggedInUserId = UserState.loggedInUserId(props.loginState) ?? "";
 
   const [isOpen, setIsOpen] = React.useState(false);
 

--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -15,6 +15,7 @@ import {
 } from "reactstrap";
 import { connect, PromiseState } from "react-refetch";
 import { extractRivalsParam, normalizeUserId } from "../utils";
+import * as UserState from "../utils/UserState";
 import { USER_GET } from "../pages/Internal/ApiUrl";
 import { UserResponse } from "../pages/Internal/types";
 
@@ -69,12 +70,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
   const pathUserId = pathState?.userId;
   const pathRivalIdString = pathState?.rivalIdString;
 
-  const loggedInUserId =
-    props.loginState.fulfilled &&
-    props.loginState.value &&
-    props.loginState.value.atcoder_user_id
-      ? props.loginState.value.atcoder_user_id
-      : "";
+  const loggedInUserId = UserState.loggedInUserId(props.loginState, "");
 
   const [userId, setUserId] = React.useState(pathUserId ?? "");
   const [rivalIdString, setRivalIdString] = React.useState(

--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -70,7 +70,7 @@ const InnerUserSearchBar: React.FC<InnerProps> = (props) => {
   const pathUserId = pathState?.userId;
   const pathRivalIdString = pathState?.rivalIdString;
 
-  const loggedInUserId = UserState.loggedInUserId(props.loginState, "");
+  const loggedInUserId = UserState.loggedInUserId(props.loginState) ?? "";
 
   const [userId, setUserId] = React.useState(pathUserId ?? "");
   const [rivalIdString, setRivalIdString] = React.useState(

--- a/atcoder-problems-frontend/src/pages/Internal/ProblemList/SingleProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/ProblemList/SingleProblemList.tsx
@@ -118,7 +118,10 @@ const InnerSingleProblemList = (props: InnerProps) => {
       </Row>
       <Row className="my-2">
         <Col sm="12">
-          <Button onClick={(): void => setCreatingContest(true)}>
+          <Button
+            color="success"
+            onClick={(): void => setCreatingContest(true)}
+          >
             Create Virtual Contest
           </Button>
         </Col>

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -30,6 +30,7 @@ import { RatingInfo } from "../../utils/RatingInfo";
 import { generatePathWithParams } from "../../utils/QueryString";
 import { fetchUserSubmissions } from "../../utils/Api";
 import { PROGRESS_RESET_LIST, USER_GET } from "../Internal/ApiUrl";
+import { loggedInUserId } from "../../utils/UserState";
 import {
   filterResetProgress,
   ProgressResetList,
@@ -181,12 +182,7 @@ const InnerListPage: React.FC<InnerProps> = (props) => {
     : Map<ProblemId, ProblemModel>();
   const submissions = submissionsFetch.fulfilled ? submissionsFetch.value : [];
 
-  const loginUserId =
-    props.loginState.fulfilled &&
-    props.loginState.value &&
-    props.loginState.value.atcoder_user_id
-      ? props.loginState.value.atcoder_user_id
-      : undefined;
+  const loginUserId = loggedInUserId(props.loginState, undefined);
   const progressReset =
     props.progressResetList.fulfilled && props.progressResetList.value
       ? props.progressResetList.value

--- a/atcoder-problems-frontend/src/pages/ListPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/index.tsx
@@ -182,7 +182,7 @@ const InnerListPage: React.FC<InnerProps> = (props) => {
     : Map<ProblemId, ProblemModel>();
   const submissions = submissionsFetch.fulfilled ? submissionsFetch.value : [];
 
-  const loginUserId = loggedInUserId(props.loginState, undefined);
+  const loginUserId = loggedInUserId(props.loginState);
   const progressReset =
     props.progressResetList.fulfilled && props.progressResetList.value
       ? props.progressResetList.value

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "../Internal/types";
 import { PROGRESS_RESET_LIST, USER_GET } from "../Internal/ApiUrl";
 import { RatingInfo, ratingInfoOf } from "../../utils/RatingInfo";
+import { loggedInUserId } from "../../utils/UserState";
 import { classifyContest, ContestCategory } from "./ContestClassifier";
 import { TableTabButtons } from "./TableTab";
 import { Options } from "./Options";
@@ -99,12 +100,7 @@ const InnerTablePage: React.FC<InnerProps> = (props) => {
     ? props.submissions.value
     : [];
 
-  const loginUserId =
-    props.loginState.fulfilled &&
-    props.loginState.value &&
-    props.loginState.value.atcoder_user_id
-      ? props.loginState.value.atcoder_user_id
-      : undefined;
+  const loginUserId = loggedInUserId(props.loginState, undefined);
   const progressReset =
     props.progressResetList.fulfilled && props.progressResetList.value
       ? props.progressResetList.value

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -100,7 +100,7 @@ const InnerTablePage: React.FC<InnerProps> = (props) => {
     ? props.submissions.value
     : [];
 
-  const loginUserId = loggedInUserId(props.loginState, undefined);
+  const loginUserId = loggedInUserId(props.loginState);
   const progressReset =
     props.progressResetList.fulfilled && props.progressResetList.value
       ? props.progressResetList.value

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations.tsx
@@ -38,7 +38,7 @@ import { ProblemLink } from "../../components/ProblemLink";
 import { ContestLink } from "../../components/ContestLink";
 import { NewTabLink } from "../../components/NewTabLink";
 import { ProblemId } from "../../interfaces/Status";
-import { generateProblemIdsToString } from "../../utils/QueryString";
+import { problemIdSeparateSymbol } from "../../utils/QueryString";
 
 interface Props {
   readonly userSubmissions: Submission[];
@@ -388,7 +388,7 @@ export const Recommendations: React.FC<Props> = (props) => {
           },
         } as SelectRow);
 
-    const problemIdToString = generateProblemIdsToString(selectedProblemIds);
+    const problemIdToString = selectedProblemIds.join(problemIdSeparateSymbol);
     const createContestLocation = {
       pathname: "/contest/create",
       search: !problemIdToString ? "" : "?problemIds=" + problemIdToString,

--- a/atcoder-problems-frontend/src/pages/UserPage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/index.tsx
@@ -22,6 +22,9 @@ import { calcStreak, countUniqueAcByDate } from "../../utils/StreakCounter";
 import { isRatedContest } from "../TablePage/ContestClassifier";
 import { UserNameLabel } from "../../components/UserNameLabel";
 import { calculateTopPlayerEquivalentEffort } from "../../utils/ProblemModelUtil";
+import { UserResponse } from "../Internal/types";
+import { USER_GET } from "../Internal/ApiUrl";
+import { isLoggedIn } from "../../utils/UserState";
 import { PieChartBlock } from "./PieChartBlock";
 import { AchievementBlock } from "./AchievementBlock";
 import { ProgressChartBlock } from "./ProgressChartBlock";
@@ -57,6 +60,7 @@ interface InnerProps extends OuterProps {
   contestsFetch: PromiseState<ImmutableMap<ContestId, Contest>>;
   contestToProblemsFetch: PromiseState<ImmutableMap<ContestId, List<Problem>>>;
   problemModelsFetch: PromiseState<ImmutableMap<ProblemId, ProblemModel>>;
+  loginState: PromiseState<UserResponse | null>;
 }
 
 const InnerUserPage: React.FC<InnerProps> = (props) => {
@@ -257,6 +261,7 @@ const InnerUserPage: React.FC<InnerProps> = (props) => {
             contests={contests}
             problemModels={problemModels}
             userRatingInfo={userRatingInfo}
+            isLoggedIn={isLoggedIn(props.loginState)}
           />
         </>
       )}
@@ -294,4 +299,5 @@ export const UserPage = connect<OuterProps, InnerProps>(({ userId }) => ({
     value: (): Promise<ImmutableMap<string, List<Problem>>> =>
       CachedApiClient.cachedContestToProblemMap(),
   },
+  loginState: USER_GET,
 }))(InnerUserPage);

--- a/atcoder-problems-frontend/src/utils/QueryString.ts
+++ b/atcoder-problems-frontend/src/utils/QueryString.ts
@@ -1,5 +1,4 @@
 import { Location } from "history";
-import { ProblemId } from "../interfaces/Status";
 
 export const generatePathWithParams = (
   location: Location,
@@ -11,14 +10,4 @@ export const generatePathWithParams = (
   return `${location.pathname}?${searchParams.toString()}`;
 };
 
-export const separateSymbol = "~";
-
-export const generateProblemIdsToString = (ids: ProblemId[] | undefined) => {
-  if (!ids) return "";
-  let qs = "";
-  for (const id of ids) {
-    if (qs.length > 0) qs += separateSymbol;
-    qs += id;
-  }
-  return qs;
-};
+export const problemIdSeparateSymbol = "~";

--- a/atcoder-problems-frontend/src/utils/QueryString.ts
+++ b/atcoder-problems-frontend/src/utils/QueryString.ts
@@ -10,4 +10,4 @@ export const generatePathWithParams = (
   return `${location.pathname}?${searchParams.toString()}`;
 };
 
-export const problemIdSeparateSymbol = "~";
+export const PROBLEMID_SEPARATE_SYMBOL = "~";

--- a/atcoder-problems-frontend/src/utils/QueryString.ts
+++ b/atcoder-problems-frontend/src/utils/QueryString.ts
@@ -1,4 +1,5 @@
 import { Location } from "history";
+import { ProblemId } from "../interfaces/Status";
 
 export const generatePathWithParams = (
   location: Location,
@@ -8,4 +9,16 @@ export const generatePathWithParams = (
   Object.keys(params).forEach((key) => searchParams.set(key, params[key]));
 
   return `${location.pathname}?${searchParams.toString()}`;
+};
+
+export const separateSymbol = "~";
+
+export const generateProblemIdsToString = (ids: ProblemId[] | undefined) => {
+  if (!ids) return "";
+  let qs = "";
+  for (const id of ids) {
+    if (qs.length > 0) qs += separateSymbol;
+    qs += id;
+  }
+  return qs;
 };

--- a/atcoder-problems-frontend/src/utils/UserState.ts
+++ b/atcoder-problems-frontend/src/utils/UserState.ts
@@ -1,0 +1,17 @@
+import { PromiseState } from "react-refetch";
+import { UserResponse } from "../pages/Internal/types";
+
+export const isLoggedIn = (loginState: PromiseState<UserResponse | null>) =>
+  loginState.fulfilled &&
+  loginState.value !== null &&
+  loginState.value.internal_user_id.length > 0;
+
+export const loggedInUserId = <V>(
+  loginState: PromiseState<UserResponse | null>,
+  failedVal: V
+): string | V =>
+  loginState.fulfilled &&
+  loginState.value !== null &&
+  loginState.value.atcoder_user_id
+    ? loginState.value.atcoder_user_id
+    : failedVal;

--- a/atcoder-problems-frontend/src/utils/UserState.ts
+++ b/atcoder-problems-frontend/src/utils/UserState.ts
@@ -8,18 +8,9 @@ export const isLoggedIn = (
   loginState.value !== null &&
   loginState.value.internal_user_id.length > 0;
 
-export const loggedInUserId = <V>(
-  loginState: PromiseState<UserResponse | null>,
-  failedVal: V
-): string | V =>
+export const loggedInUserId = (
+  loginState: PromiseState<UserResponse | null>
+): string | undefined =>
   loginState.fulfilled && loginState.value?.atcoder_user_id
     ? loginState.value.atcoder_user_id
-    : failedVal;
-
-export const loggedInInternalUserId = <V>(
-  loginState: PromiseState<UserResponse | null>,
-  failedVal: V
-): string | V =>
-  loginState.fulfilled && loginState.value?.internal_user_id
-    ? loginState.value.internal_user_id
-    : failedVal;
+    : undefined;

--- a/atcoder-problems-frontend/src/utils/UserState.ts
+++ b/atcoder-problems-frontend/src/utils/UserState.ts
@@ -1,7 +1,9 @@
 import { PromiseState } from "react-refetch";
 import { UserResponse } from "../pages/Internal/types";
 
-export const isLoggedIn = (loginState: PromiseState<UserResponse | null>) =>
+export const isLoggedIn = (
+  loginState: PromiseState<UserResponse | null>
+): boolean =>
   loginState.fulfilled &&
   loginState.value !== null &&
   loginState.value.internal_user_id.length > 0;
@@ -10,8 +12,14 @@ export const loggedInUserId = <V>(
   loginState: PromiseState<UserResponse | null>,
   failedVal: V
 ): string | V =>
-  loginState.fulfilled &&
-  loginState.value !== null &&
-  loginState.value.atcoder_user_id
+  loginState.fulfilled && loginState.value?.atcoder_user_id
     ? loginState.value.atcoder_user_id
+    : failedVal;
+
+export const loggedInInternalUserId = <V>(
+  loginState: PromiseState<UserResponse | null>,
+  failedVal: V
+): string | V =>
+  loginState.fulfilled && loginState.value?.internal_user_id
+    ? loginState.value.internal_user_id
     : failedVal;


### PR DESCRIPTION
Task 1, 2 of #865

# Implementation
1. /contest/createのquery string に付加された問題一覧からContestCreatePage.initialProblemsを設定
2. Recommendation
  2.1 Tableにチェックボックスを設けて問題を選択
  2.2 選択した問題を内部で保持しておく機能を実装
  2.3 選択した問題からContestを作成

# Refactor
3. ~~コンポーネントRecommendationの変数依存関係を整理し，hookでメモ化することで描画速度を改善~~
4. ログイン判定処理(isLoggedIn, etc)を共通化