### PR TITLE
Hide estimated performances before the contest starts

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -113,8 +113,11 @@ const InnerContestTable: React.FC<InnerProps> = (props) => {
     (problemId) => pointOverrideMap.get(problemId)
   );
 
+  const currentSecond = Math.floor(new Date().getTime() / 1000);
   const showEstimatedPerformances =
-    props.enableEstimatedPerformances && modelArray.length === problems.length;
+    props.enableEstimatedPerformances &&
+    modelArray.length === problems.length &&
+    currentSecond >= start;
   const botRunnerIds = new Set<UserId>();
   const ratingMap = new Map<UserId, number>();
   if (showEstimatedPerformances) {


### PR DESCRIPTION
fixed #874 

開始前のバーチャルコンテストでは、Estimated Performanceを非表示にしました。