### PR TITLE
recommendationに関するオプションをlocal storageに保存する

### DIFF
--- a/atcoder-problems-frontend/.gitignore
+++ b/atcoder-problems-frontend/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
 
 npm-debug.log*
 yarn-debug.log*

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations/index.tsx
@@ -24,6 +24,7 @@ import {
 import { PROBLEM_ID_SEPARATE_SYMBOL } from "../../../utils/QueryString";
 import { RatingInfo } from "../../../utils/RatingInfo";
 import * as Url from "../../../utils/Url";
+import { useLocalStorage } from "../../../utils/LocalStorage";
 import {
   ExcludeOption,
   RecommendController,
@@ -96,11 +97,17 @@ export const Recommendations: React.FC<Props> = (props) => {
 
   const history = useHistory();
 
-  const [recommendOption, setRecommendOption] = useState<RecommendOption>(
-    "Moderate"
+  const [recommendOption, setRecommendOption] = useLocalStorage<
+    RecommendOption
+  >("recommendOption", "Moderate");
+  const [recommendExperimental, setRecommendExperimental] = useLocalStorage<
+    boolean
+  >("recommendExperimental", true);
+  const [excludeOption, setExcludeOption] = useLocalStorage<ExcludeOption>(
+    "recoomendExcludeOption",
+    "Exclude"
   );
-  const [recommendExperimental, setRecommendExperimental] = useState(true);
-  const [excludeOption, setExcludeOption] = useState<ExcludeOption>("Exclude");
+
   const [recommendNum, setRecommendNum] = useState(10);
   const [selectedProblemIdSet, setSelectedProblemIdSet] = useState<
     Set<ProblemId>

--- a/atcoder-problems-frontend/src/utils/LocalStorage.tsx
+++ b/atcoder-problems-frontend/src/utils/LocalStorage.tsx
@@ -14,6 +14,9 @@ const LocalStorageKeys = [
   "climbingLineChartReverseColorOrder",
   "pinMe",
   "showRating",
+  "recommendOption",
+  "recommendExperimental",
+  "recoomendExcludeOption",
 ] as const;
 type LocalStorageKey = typeof LocalStorageKeys[number];
 


### PR DESCRIPTION
https://github.com/kenkoooo/AtCoderProblems/issues/884 をやりました。

issueで触れていたのはshow experimentalのみでしたが、recommendOption(Moderateとかのやつ)、excludeOptionも保存するようにしています。