### PR TITLE
add contest types AHC, Other Marathons

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
@@ -11,8 +11,9 @@ export const ContestCategories = [
   "PAST",
   "JOI",
   "JAG",
-  "Marathon",
   "Other Contests",
+  "AHC",
+  "Other Marathons",
 ] as const;
 export type ContestCategory = typeof ContestCategories[number];
 
@@ -60,6 +61,10 @@ export const classifyContest = (contest: Contest): ContestCategory => {
   if (/^(jag|JAG)/.exec(contest.id)) {
     return "JAG";
   }
+
+  if (/^ahc\d{3}$/.exec(contest.id)) {
+    return "AHC";
+  }
   if (
     /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title
@@ -72,7 +77,7 @@ export const classifyContest = (contest: Contest): ContestCategory => {
       "wn2017_1",
     ].includes(contest.id)
   ) {
-    return "Marathon";
+    return "Other Marathons";
   }
 
   return "Other Contests";

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
@@ -11,9 +11,9 @@ export const ContestCategories = [
   "PAST",
   "JOI",
   "JAG",
-  "Other Contests",
   "AHC",
-  "Other Marathons",
+  "Marathon",
+  "Other Contests",
 ] as const;
 export type ContestCategory = typeof ContestCategories[number];
 
@@ -77,7 +77,7 @@ export const classifyContest = (contest: Contest): ContestCategory => {
       "wn2017_1",
     ].includes(contest.id)
   ) {
-    return "Other Marathons";
+    return "Marathon";
   }
 
   return "Other Contests";


### PR DESCRIPTION
Fix #887

現状の"Marathon"カテゴリーを"AHC", "Other Marathons"に分類しました。
選択タブ上ではこの2つが他のカテゴリーの後に並ぶようになります。アルゴとマラソンでButtonGroupを分けた方がいいかもしれません。