### PR TITLE
Fix login check on virtual contest page

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -67,7 +67,7 @@ export const ShowContest = (props: Props) => {
   const internalUserId = loginState?.data?.internal_user_id;
 
   const atCoderUserId = rawAtCoderUserId ? rawAtCoderUserId : "";
-  const isLoggedIn = internalUserId !== null;
+  const isLoggedIn = internalUserId !== undefined;
   const userIdIsSet = atCoderUserId !== "";
 
   const start = contestInfo.start_epoch_second;


### PR DESCRIPTION
Resolves #906.

「ログインしているかどうか」の判定に失敗しているようです。

https://github.com/kenkoooo/AtCoderProblems/blob/8a817f7070a68272d57f61c42a06ff101c17c78c/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx#L66-L71

ここの `internalUserId` は実際には `string | undefined` なので `!== undefined` に変えるとログインしていない人が正常に判定され、ログインページへの誘導になります。

他所のログイン判定では src/utils/Url.tsx の `UserState.isLoggedIn` という関数が使われているところもあるようですが、変更の差分を小さくするという判断を取りました。