### PR TITLE
atcoder-client: add ContestTypeSpecifier

### DIFF
--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "atcoder-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "futures 0.3.5",

--- a/atcoder-problems-backend/atcoder-client/Cargo.toml
+++ b/atcoder-problems-backend/atcoder-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atcoder-client"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["kenkoooo <kenkou.n@gmail.com>"]
 edition = "2018"
 publish = false

--- a/atcoder-problems-backend/atcoder-client/src/atcoder.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder.rs
@@ -5,4 +5,4 @@ mod submission;
 mod types;
 
 pub use client::AtCoderClient;
-pub use types::{AtCoderContest, AtCoderProblem, AtCoderSubmission, AtCoderSubmissionListResponse};
+pub use types::{AtCoderContest, AtCoderProblem, AtCoderSubmission, AtCoderSubmissionListResponse, ContestTypeSpecifier};

--- a/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
@@ -14,10 +14,26 @@ impl Default for AtCoderClient {
 }
 
 impl AtCoderClient {
-    pub async fn fetch_atcoder_contests(&self, page: u32) -> Result<Vec<AtCoderContest>> {
+    pub async fn fetch_atcoder_contests(&self, spf: ContestTypeSpecifier) -> Result<Vec<AtCoderContest>> {
+        match spf {
+            ContestTypeSpecifier::Normal { page } => self.fetch_atcoder_normal_contests(page).await,
+            ContestTypeSpecifier::Permanent => self.fetch_atcoder_permanent_contests().await,
+            ContestTypeSpecifier::Hidden => self.fetch_atcoder_hidden_contests().await,
+        }
+    }
+
+    async fn fetch_atcoder_normal_contests(&self, page: u32) -> Result<Vec<AtCoderContest>> {
         let url = format!("{}/contests/archive?lang=ja&page={}", ATCODER_PREFIX, page);
         let html = util::get_html(&url).await?;
         contest::scrape(&html)
+    }
+
+    async fn fetch_atcoder_permanent_contests(&self) -> Result<Vec<AtCoderContest>> {
+        unimplemented!()
+    }
+
+    async fn fetch_atcoder_hidden_contests(&self) -> Result<Vec<AtCoderContest>> {
+        unimplemented!()
     }
 
     /// Fetch a list of submissions.
@@ -55,7 +71,7 @@ mod tests {
     #[test]
     fn test_fetch_contest_list() {
         let client = AtCoderClient::default();
-        let contests = block_on(client.fetch_atcoder_contests(1)).unwrap();
+        let contests = block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Normal{ page: 1 })).unwrap();
         assert_eq!(contests.len(), 50);
     }
 

--- a/atcoder-problems-backend/atcoder-client/src/atcoder/types.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/types.rs
@@ -1,5 +1,11 @@
 use crate::util::Problem;
 
+pub enum ContestTypeSpecifier {
+    Normal {page: u32},
+    Permanent,
+    Hidden
+}
+
 pub struct AtCoderSubmissionListResponse {
     pub max_page: u32,
     pub submissions: Vec<AtCoderSubmission>,

--- a/atcoder-problems-backend/atcoder-client/src/lib.rs
+++ b/atcoder-problems-backend/atcoder-client/src/lib.rs
@@ -1,6 +1,6 @@
 pub(crate) mod atcoder;
 pub use atcoder::{
-    AtCoderClient, AtCoderContest, AtCoderProblem, AtCoderSubmission, AtCoderSubmissionListResponse,
+    AtCoderClient, AtCoderContest, AtCoderProblem, AtCoderSubmission, AtCoderSubmissionListResponse, ContestTypeSpecifier
 };
 
 pub(crate) mod util;

--- a/atcoder-problems-backend/src/crawler/problem_crawler.rs
+++ b/atcoder-problems-backend/src/crawler/problem_crawler.rs
@@ -1,5 +1,6 @@
 use crate::crawler::AtCoderFetcher;
 use anyhow::Result;
+use atcoder_client::ContestTypeSpecifier;
 use sql_client::contest_problem::ContestProblemClient;
 use sql_client::models::{Contest, ContestProblem, Problem};
 use sql_client::simple_client::SimpleClient;
@@ -23,7 +24,7 @@ where
         log::info!("Starting...");
         let mut contests = Vec::new();
         for page in 1.. {
-            match self.fetcher.fetch_contests(page).await {
+            match self.fetcher.fetch_contests(ContestTypeSpecifier::Normal{ page }).await {
                 Ok(c) => {
                     if c.is_empty() {
                         break;

--- a/atcoder-problems-backend/src/crawler/utils.rs
+++ b/atcoder-problems-backend/src/crawler/utils.rs
@@ -1,6 +1,7 @@
 use crate::crawler::AtCoderFetcher;
 use anyhow::Result;
 use async_trait::async_trait;
+use atcoder_client::ContestTypeSpecifier;
 use sql_client::models::{Contest, ContestProblem, Problem, Submission};
 
 pub(crate) struct MockFetcher<F: Fn(&str, u32) -> Vec<Submission>>(pub(crate) F);
@@ -14,7 +15,7 @@ where
         (self.0)(contest_id, page)
     }
 
-    async fn fetch_contests(&self, _: u32) -> Result<Vec<Contest>> {
+    async fn fetch_contests(&self, _: ContestTypeSpecifier) -> Result<Vec<Contest>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
#916 
これを実現する準備として、アーカイブからコンテストの一覧を fetch してくる関数（`AtCoderFetcher::fetch_contest`）に page 番号ではなく列挙子を渡すようにしました。今まで `page` を渡していた部分は `Normal{page}` を渡すようになり、そのほかに

- 常設コンテストを fetch する指定子 `Permanent`
- 隠しコンテストを fetch する指定子 `Hidden`

を受け取れるようになっています。
本 commit では `page` を `Normal{page}` に書き換えただけですが、今後上記二つの指定子に対して、 `Permanent` は（アーカイブではない）コンテスト一覧ページをスクレイピングしてくる関数、 `Hidden` は手動で定義した json などを読み込む関数をそれぞれ定義することでクローリングが可能になります。