### PR TITLE
Add redirection to the original page after login

### DIFF
--- a/atcoder-problems-backend/README.md
+++ b/atcoder-problems-backend/README.md
@@ -25,13 +25,13 @@ production backend server, you don't need to run the backend applications in mos
 
 Below are the list of files you need to modify:
 
-- `atcoder-problems-backend/src/server/auth.rs`: change `redirect_url` to `http://localhost:3000/atcoder/#/login/user`
+- `atcoder-problems-backend/src/server/auth.rs`: change `REDIRECT_URL` to `http://localhost:3000/atcoder/`
   for your backend to redirect to your frontend web app after logging in.
 - `atcoder-problems-frontend/src/setupProxy.js`: change `target` to `http://localhost:8080`
   **and** remove the `pathRewrite` section for your frontend web app to use your
   backend server.
-- `atcoder-problems-frontend/src/utils/Url.tsx`: change `GITHUB_LOGIN_LINK` to `https://github.com/login/oauth/authorize?client_id=<YOUR_CLIENT_ID>`,
-  where `<YOUR_CLIENT_ID>` is the client ID of your GitHub app.
+- `atcoder-problems-frontend/src/utils/Url.tsx`: change `CLIENT_ID` to the client ID of your GitHub app
+  **and** change `AUTHORIZATION_CALLBACK_URL` to `http://localhost:8080/internal-api/authorize`.
 - (For running backend tests) `atcoder-problems-backend/tests/utils.rs`: change `SQL_URL`
   to the correct connection URL. **Note that** it should be different from the database
   you intend to develop on.

--- a/atcoder-problems-backend/src/server/auth.rs
+++ b/atcoder-problems-backend/src/server/auth.rs
@@ -7,6 +7,8 @@ use tide::http::headers::LOCATION;
 use tide::StatusCode;
 use tide::{Request, Response, Result};
 
+const REDIRECT_URL: &str = "https://kenkoooo.com/atcoder/";
+
 #[async_trait]
 pub trait Authentication {
     async fn get_token(&self, code: &str) -> Result<String>;
@@ -74,6 +76,7 @@ impl GitHubAuthentication {
 #[derive(Deserialize)]
 struct Query {
     code: String,
+    redirect_to: Option<String>,
 }
 
 pub(crate) async fn get_token<A: Authentication + Clone>(
@@ -89,7 +92,10 @@ pub(crate) async fn get_token<A: Authentication + Clone>(
     conn.register_user(&internal_user_id).await?;
 
     let cookie = Cookie::build("token", token).path("/").finish();
-    let redirect_url = "https://kenkoooo.com/atcoder/#/login/user";
+    let redirect_fragment = query
+        .redirect_to
+        .unwrap_or_else(|| "/login/user".to_string());
+    let redirect_url = format!("{}#{}", REDIRECT_URL, redirect_fragment);
     let mut response = Response::builder(StatusCode::Found)
         .header(LOCATION, redirect_url)
         .build();

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -14,7 +14,7 @@ import {
   UncontrolledDropdown,
 } from "reactstrap";
 import { useLoginState } from "../api/InternalAPIClient";
-import { GITHUB_LOGIN_LINK } from "../utils/Url";
+import { useLoginLink } from "../utils/Url";
 import { ACCOUNT_INFO } from "../utils/RouterPath";
 import * as UserState from "../utils/UserState";
 import { UserSearchBar } from "./UserSearchBar";
@@ -24,6 +24,7 @@ export const NavigationBar = () => {
   const loginState = useLoginState().data;
   const isLoggedIn = UserState.isLoggedIn(loginState);
   const loggedInUserId = UserState.loggedInUserId(loginState) ?? "";
+  const loginLink = useLoginLink();
 
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -161,7 +162,7 @@ export const NavigationBar = () => {
                   Account ({loggedInUserId})
                 </NavLink>
               ) : (
-                <NavLink href={GITHUB_LOGIN_LINK}>Login</NavLink>
+                <NavLink href={loginLink}>Login</NavLink>
               )}
             </NavItem>
           </Nav>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -27,7 +27,7 @@ import {
 } from "../../../../utils/DateUtil";
 import { formatMode, formatPublicState, VirtualContestItem } from "../../types";
 import { TweetButton } from "../../../../components/TweetButton";
-import { GITHUB_LOGIN_LINK } from "../../../../utils/Url";
+import { useLoginLink } from "../../../../utils/Url";
 import { Timer } from "../../../../components/Timer";
 import { ACCOUNT_INFO } from "../../../../utils/RouterPath";
 import { useLocalStorage } from "../../../../utils/LocalStorage";
@@ -51,6 +51,7 @@ export const ShowContest = (props: Props) => {
   const history = useHistory();
   const virtualContestResponse = useVirtualContest(props.contestId);
   const { data: problemMap } = useMergedProblemMap();
+  const loginLink = useLoginLink();
 
   if (!virtualContestResponse.data && !virtualContestResponse.error) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
@@ -170,8 +171,7 @@ export const ShowContest = (props: Props) => {
         <Col sm="12">
           {!isLoggedIn ? (
             <Alert color="warning">
-              Please <a href={GITHUB_LOGIN_LINK}>Login</a> before you join the
-              contest.
+              Please <a href={loginLink}>Login</a> before you join the contest.
             </Alert>
           ) : !userIdIsSet ? (
             <Alert color="warning">

--- a/atcoder-problems-frontend/src/pages/TrainingPage/LoginAdvice.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/LoginAdvice.tsx
@@ -3,20 +3,22 @@ import { Alert } from "reactstrap";
 import { Link } from "react-router-dom";
 import { UserResponse } from "../Internal/types";
 import { ACCOUNT_INFO } from "../../utils/RouterPath";
-import { GITHUB_LOGIN_LINK } from "../../utils/Url";
+import { useLoginLink } from "../../utils/Url";
 
 interface Props {
   user: UserResponse | undefined;
   loading: boolean;
 }
 export const LoginAdvice: React.FC<Props> = (props) => {
+  const loginLink = useLoginLink();
+
   if (props.loading) {
     return <Alert color="primary">Loading user info...</Alert>;
   }
   if (!props.user) {
     return (
       <Alert color="danger">
-        <a href={GITHUB_LOGIN_LINK}>Login</a> to record your progress.
+        <a href={loginLink}>Login</a> to record your progress.
       </Alert>
     );
   }

--- a/atcoder-problems-frontend/src/utils/Url.tsx
+++ b/atcoder-problems-frontend/src/utils/Url.tsx
@@ -1,5 +1,9 @@
 const BASE_URL = "https://atcoder.jp";
 
+const CLIENT_ID = "162a5276634fc8b970f7";
+const AUTHORIZATION_CALLBACK_URL =
+  "https://kenkoooo.com/atcoder/internal-api/authorize";
+
 export const formatContestUrl = (contest: string): string =>
   `${BASE_URL}/contests/${contest}`;
 
@@ -15,5 +19,13 @@ export const formatSolversUrl = (contest: string, problem: string): string =>
 export const formatUserUrl = (userId: string): string =>
   `https://atcoder.jp/users/${userId}`;
 
-export const GITHUB_LOGIN_LINK =
-  "https://github.com/login/oauth/authorize?client_id=162a5276634fc8b970f7";
+export function useLoginLink(): string {
+  const currentPath = location.hash.slice(1);
+  const redirectUri = `${AUTHORIZATION_CALLBACK_URL}?redirect_to=${encodeURIComponent(
+    currentPath
+  )}`;
+  const loginLink = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(
+    redirectUri
+  )}`;
+  return loginLink;
+}

--- a/atcoder-problems-frontend/src/utils/Url.tsx
+++ b/atcoder-problems-frontend/src/utils/Url.tsx
@@ -19,7 +19,7 @@ export const formatSolversUrl = (contest: string, problem: string): string =>
 export const formatUserUrl = (userId: string): string =>
   `https://atcoder.jp/users/${userId}`;
 
-export function useLoginLink(): string {
+export const useLoginLink = (): string => {
   const currentPath = location.hash.slice(1);
   const redirectUri = `${AUTHORIZATION_CALLBACK_URL}?redirect_to=${encodeURIComponent(
     currentPath
@@ -28,4 +28,4 @@ export function useLoginLink(): string {
     redirectUri
   )}`;
   return loginLink;
-}
+};


### PR DESCRIPTION
Resolves #912.

ログイン後、もといたページにリダイレクトするようにします。

念のためオープンリダイレクト悪用の可能性について
- GitHub → コールバック URL:
  - GitHub OAuth Apps によってある程度検証されるので大丈夫かと思います。
  - https://docs.github.com/ja/developers/apps/authorizing-oauth-apps#redirect-urls
- コールバック URL → リダイレクト先
  - 自サイトの `#` 以下のみを指定するようにしています。`#` 以下に急に飛ばされて困るページは無いかと思います。