### PR TITLE
add hidden_contest.json in static_data

### DIFF
--- a/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
@@ -83,14 +83,14 @@ mod tests {
         assert_eq!(contests.len(), 50);
     }
 
-    #[test]
-    fn test_fetch_hidden_contest() {
-        let client = AtCoderClient::default();
-        let contests =
-            block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Hidden))
-                .unwrap();
-        assert!(contests.len() >= 1);
-    }
+    // #[test]
+    // fn test_fetch_hidden_contest() {
+    //     let client = AtCoderClient::default();
+    //     let contests =
+    //         block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Hidden))
+    //             .unwrap();
+    //     assert!(contests.len() >= 1);
+    // }
 
     #[test]
     fn test_fetch_problem_list() {

--- a/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
@@ -38,8 +38,8 @@ impl AtCoderClient {
     }
 
     async fn fetch_atcoder_hidden_contests(&self) -> Result<Vec<AtCoderContest>> {
-        // FIXME Currently, this function cannot fetch anything. Fix it to fetch the list of hidden contests and parse the result.
-        Ok(Vec::new())
+        let uri = "https://kenkoooo.com/atcoder/static_data/backend/hidden_contests.json";
+        util::get_json(&uri).await
     }
 
     /// Fetch a list of submissions.
@@ -81,6 +81,15 @@ mod tests {
             block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Normal { page: 1 }))
                 .unwrap();
         assert_eq!(contests.len(), 50);
+    }
+
+    #[test]
+    fn test_fetch_hidden_contest() {
+        let client = AtCoderClient::default();
+        let contests =
+            block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Hidden))
+                .unwrap();
+        assert!(contests.len() >= 1);
     }
 
     #[test]

--- a/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/client.rs
@@ -83,14 +83,14 @@ mod tests {
         assert_eq!(contests.len(), 50);
     }
 
-    // #[test]
-    // fn test_fetch_hidden_contest() {
-    //     let client = AtCoderClient::default();
-    //     let contests =
-    //         block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Hidden))
-    //             .unwrap();
-    //     assert!(contests.len() >= 1);
-    // }
+    #[test]
+    fn test_fetch_hidden_contest() {
+        let client = AtCoderClient::default();
+        let contests =
+            block_on(client.fetch_atcoder_contests(ContestTypeSpecifier::Hidden))
+                .unwrap();
+        assert!(contests.len() >= 1);
+    }
 
     #[test]
     fn test_fetch_problem_list() {

--- a/atcoder-problems-backend/atcoder-client/src/util.rs
+++ b/atcoder-problems-backend/atcoder-client/src/util.rs
@@ -10,7 +10,6 @@ pub(crate) async fn get_html(url: &str) -> Result<String> {
         .await?)
 }
 
-#[allow(dead_code)]
 pub(crate) async fn get_json<T: DeserializeOwned>(url: &str) -> Result<T> {
     Ok(surf::get(url)
         .set_header("accept", "application/json")

--- a/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
+++ b/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
@@ -1,0 +1,9 @@
+[
+    { 
+        "id": "monamieHB2021", 
+        "start_epoch_second": 1618920000, 
+        "duration_second": 7200, 
+        "title": "えびまのお誕生日コンテスト 2021 Day 1", 
+        "rate_change": "-"
+    } 
+]

--- a/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
+++ b/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
@@ -1,9 +1,9 @@
 [
-    { 
-        "id": "monamieHB2021", 
-        "start_epoch_second": 1618920000, 
-        "duration_second": 7200, 
-        "title": "えびまのお誕生日コンテスト 2021 Day 1", 
-        "rate_change": "-"
-    } 
+  { 
+    "id": "monamieHB2021", 
+    "start_epoch_second": 1618920000, 
+    "duration_second": 7200, 
+    "title": "えびまのお誕生日コンテスト 2021 Day 1", 
+    "rate_change": "-"
+  } 
 ]


### PR DESCRIPTION
#916
#924
`static_data` 内に隠しコンテストのリストを格納した json ファイルを追加し、バックエンド側ではそのデータにアクセスすることでクローリング対象に追加するようにしています。json を手動で更新することで対象のコンテストを追加できます。