### PR TITLE
frontend: Classify other sponsored contest.

### DIFF
--- a/atcoder-problems-frontend/cypress/integration/table.spec.ts
+++ b/atcoder-problems-frontend/cypress/integration/table.spec.ts
@@ -44,6 +44,7 @@ describe("Table page", () => {
         "PAST",
         "JOI",
         "Marathon",
+        "Other Sponsored",
         "Other Contests",
       ].map((contestType) => cy.contains(contestType))
     );

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestClassifier.ts
@@ -13,6 +13,7 @@ export const ContestCategories = [
   "JAG",
   "AHC",
   "Marathon",
+  "Other Sponsored",
   "Other Contests",
 ] as const;
 export type ContestCategory = typeof ContestCategories[number];
@@ -78,6 +79,19 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     ].includes(contest.id)
   ) {
     return "Marathon";
+  }
+  if (
+    /(ドワンゴ|^Mujin|SoundHound|^codeFlyer|^COLOCON|みんなのプロコン|CODE THANKS FESTIVAL)/.exec(
+      contest.title
+    ) ||
+    /(CODE FESTIVAL|^DISCO|日本最強プログラマー学生選手権|全国統一プログラミング王|Indeed)/.exec(
+      contest.title
+    ) ||
+    /(^Donuts|^dwango|^DigitalArts|^Code Formula|天下一プログラマーコンテスト)/.exec(
+      contest.title
+    )
+  ) {
+    return "Other Sponsored";
   }
 
   return "Other Contests";


### PR DESCRIPTION
#910 
です。TypeScriptはじめてのPRなので粗相があるかもしれません。
見ていただきたいです。

あと本当は`cypress/integration/table.spec.ts`
ものテストの
```
    Promise.all(
      [
        "ABC",
        "ARC",
        "AGC",
        "ABC-Like",
        "ARC-Like",
        "AGC-Like",
        "PAST",
        "JOI",
        "Marathon",
        "Other Contests",
      ].map((contestType) => cy.contains(contestType))
    );
```
この部分にもカテゴリを追加する必要があると思っているのですが、lintエラーがでてコミットできません。

```
✖ eslint --fix --max-warnings=0:

/home/ryo/work/github/AtCoderProblems/atcoder-problems-frontend/cypress/integration/table.spec.ts
  10:7  error  Unsafe assignment of an any value                                                                @typescript-eslint/no-unsafe-assignment
  18:9  error  Unsafe call of an any typed value                                                                @typescript-eslint/no-unsafe-call
  19:9  error  Unsafe assignment of an any value                                                                @typescript-eslint/no-unsafe-assignment
  36:5  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

✖ 4 problems (4 errors, 0 warnings)
```

素人質問ですいませんが、対処方法を教えて欲しいです。