### PR TITLE
Fix README

### DIFF
--- a/atcoder-problems-backend/README.md
+++ b/atcoder-problems-backend/README.md
@@ -32,9 +32,6 @@ Below are the list of files you need to modify:
   backend server.
 - `atcoder-problems-frontend/src/utils/Url.tsx`: change `CLIENT_ID` to the client ID of your GitHub app
   **and** change `AUTHORIZATION_CALLBACK_URL` to `http://localhost:8080/internal-api/authorize`.
-- (For running backend tests) `atcoder-problems-backend/tests/utils.rs`: change `SQL_URL`
-  to the correct connection URL. **Note that** it should be different from the database
-  you intend to develop on.
 
 **Be careful** not to commit these files to the Git repository.
 


### PR DESCRIPTION
https://github.com/kenkoooo/AtCoderProblems/commit/da09dfb88822281c17367a2418586fdf51d4a9f7#diff-d5419e5f338bb11d774f03f5651a34a5e76a12b30124a09b77054be8dfb8f200

この差分以降、ローカル変数`SQL_URL`ではなく環境変数を使うようになったのと、このREADME.mdの一番下にテスト用の環境変数`SQL_URL`の設定方法が記述されているので、この一文は不要になったように見えます。