### PR TITLE
Sort APG4b correctly

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.test.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.test.tsx
@@ -1,0 +1,21 @@
+import { convertProblemTitleForSorting } from "./ContestTable";
+
+describe("Convert a problem title", () => {
+  it("No number", () => {
+    const title = "J. Kuru Kuru Kururin";
+    expect(convertProblemTitleForSorting(title)).toMatchObject(["J", NaN]);
+  });
+
+  it("No string", () => {
+    const title = "1000000007. The Most Famous Prime Number";
+    expect(convertProblemTitleForSorting(title)).toMatchObject([
+      "",
+      1000000007,
+    ]);
+  });
+
+  it("Both exists", () => {
+    const title = "EX1. 1.01";
+    expect(convertProblemTitleForSorting(title)).toMatchObject(["EX", 1]);
+  });
+});

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -25,6 +25,13 @@ interface Props {
   userRatingInfo: RatingInfo;
 }
 
+export function convertProblemTitleForSorting(title: string): [string, number] {
+  const idx = title.split(".")[0];
+  const str = idx.replace(/[0-9]/g, "");
+  const num = parseInt(idx.replace(/[^0-9]/g, ""), 10);
+  return [str, num];
+}
+
 export const ContestTable: React.FC<Props> = (props) => {
   const {
     contests,
@@ -42,12 +49,8 @@ export const ContestTable: React.FC<Props> = (props) => {
     .map((contest) => ({
       contest,
       problems: (contestToProblems.get(contest.id) ?? []).sort((a, b) => {
-        const idx_a = a.title.split(".")[0];
-        const str_a = idx_a.replace(/[0-9]/g, "");
-        const num_a = parseInt(idx_a.replace(/[^0-9]/g, ""), 10);
-        const idx_b = b.title.split(".")[0];
-        const str_b = idx_b.replace(/[0-9]/g, "");
-        const num_b = parseInt(idx_b.replace(/[^0-9]/g, ""), 10);
+        const [str_a, num_a] = convertProblemTitleForSorting(a.title);
+        const [str_b, num_b] = convertProblemTitleForSorting(b.title);
         const cmp = str_a.localeCompare(str_b);
         return cmp === 0 ? num_a - num_b : cmp;
       }),

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -25,12 +25,14 @@ interface Props {
   userRatingInfo: RatingInfo;
 }
 
-export function convertProblemTitleForSorting(title: string): [string, number] {
+export const convertProblemTitleForSorting = (
+  title: string
+): [string, number] => {
   const idx = title.split(".")[0];
   const str = idx.replace(/[0-9]/g, "");
   const num = parseInt(idx.replace(/[^0-9]/g, ""), 10);
   return [str, num];
-}
+};
 
 export const ContestTable: React.FC<Props> = (props) => {
   const {

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -41,9 +41,15 @@ export const ContestTable: React.FC<Props> = (props) => {
     .sort((a, b) => b.start_epoch_second - a.start_epoch_second)
     .map((contest) => ({
       contest,
-      problems: (contestToProblems.get(contest.id) ?? []).sort((a, b) =>
-        a.title.localeCompare(b.title)
-      ),
+      problems: (contestToProblems.get(contest.id) ?? []).sort((a, b) => {
+        if (contest.id === "APG4b") {
+          const str_a = a.title.slice(0, 1) + a.title.slice(-4);
+          const str_b = b.title.slice(0, 1) + b.title.slice(-4);
+          return str_a.localeCompare(str_b);
+        } else {
+          return a.title.localeCompare(b.title);
+        }
+      }),
     }))
     .map(({ contest, problems }) => {
       const problemStatus = problems.map((p) => ({

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -42,13 +42,14 @@ export const ContestTable: React.FC<Props> = (props) => {
     .map((contest) => ({
       contest,
       problems: (contestToProblems.get(contest.id) ?? []).sort((a, b) => {
-        if (contest.id === "APG4b") {
-          const str_a = a.title.slice(0, 1) + a.title.slice(-4);
-          const str_b = b.title.slice(0, 1) + b.title.slice(-4);
-          return str_a.localeCompare(str_b);
-        } else {
-          return a.title.localeCompare(b.title);
-        }
+        const idx_a = a.title.split(".")[0];
+        const str_a = idx_a.replace(/[0-9]/g, "");
+        const num_a = parseInt(idx_a.replace(/[^0-9]/g, ""), 10);
+        const idx_b = b.title.split(".")[0];
+        const str_b = idx_b.replace(/[0-9]/g, "");
+        const num_b = parseInt(idx_b.replace(/[^0-9]/g, ""), 10);
+        const cmp = str_a.localeCompare(str_b);
+        return cmp === 0 ? num_a - num_b : cmp;
       }),
     }))
     .map(({ contest, problems }) => {


### PR DESCRIPTION
#937 
APG4bの問題は文字列として辞書順ソートすると順番が崩れるため、「A. 1.00.はじめに」が最初に来て、他はEXの後に続く数字の順番に並ぶように修正しました。
![image](https://user-images.githubusercontent.com/27503986/117128325-3ba2d380-add8-11eb-9d01-f5961675a148.png)
