### PR TITLE
提出の一部を取得できる API を作る

### DIFF
--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -19,6 +19,10 @@ pub enum SubmissionRequest<'a> {
         from_second: i64,
         count: i64,
     },
+    FromUserAndTime {
+        user_id: &'a str,
+        from_second: i64,
+    },
     RecentAccepted {
         count: i64,
     },
@@ -79,6 +83,17 @@ impl SubmissionClient for PgPool {
             )
             .bind(from_second)
             .bind(count)
+            .fetch_all(self),
+            SubmissionRequest::FromUserAndTime { user_id, from_second } => sqlx::query_as(
+                r"
+                         SELECT * FROM submissions
+                         WHERE LOWER(user_id) = LOWER($1)
+                         AND epoch_second >= $2
+                         ORDER BY epoch_second ASC
+                         ",
+            )
+            .bind(user_id)
+            .bind(from_second)
             .fetch_all(self),
             SubmissionRequest::RecentAccepted { count } => sqlx::query_as(
                 r"

--- a/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
@@ -72,6 +72,22 @@ async fn test_submission_client() {
     let submissions = pool.get_submissions(request).await.unwrap();
     assert_eq!(submissions.len(), 1);
 
+    let request = SubmissionRequest::FromUserAndTime {
+        user_id: "usEr1",
+        from_second: 300,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 2);
+    assert_eq!(submissions[0].result, "WA".to_owned());
+    assert_eq!(submissions[1].result, "AC".to_owned());
+
+    let request = SubmissionRequest::FromUserAndTime {
+        user_id: "user3",
+        from_second: 300,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 0);
+
     let request = SubmissionRequest::UsersAccepted {
         user_ids: &["user1", "user2"],
     };


### PR DESCRIPTION
とりあえず API の部分は作ったので PR を作りました。

- [x] `(user_id, from_second)` のペアを受け取ったとき、それに合致する提出一覧を返す
  - 質問: 他の API の実装を見るに、最大 fetch 数 `count` というパラメータがある場合がありますが、今回の場合これは必要ですか？
  - 質問: サーバー側から API を呼び出すところも実装するべきですか？
    - #945 を参考にしながら作業したので、一旦は関数を追加したところで PR を出すようにしました。
- [ ] API を叩いた結果を IndexedDB (ローカル環境) に保存、フロントエンド側で結合
  - 質問: issue には「このissueではブラウザ側（フロントエンド）の実装は置いておいて、まずはサーバーサイドの方をやります。」とありますが、これは別の issue/PR で対応すればよいですか？

ref: #948 