### PR TITLE
progressResetListをswrで書き換える

### DIFF
--- a/atcoder-problems-frontend/src/api/InternalAPIClient.ts
+++ b/atcoder-problems-frontend/src/api/InternalAPIClient.ts
@@ -1,5 +1,6 @@
 import {
   ProblemList,
+  ProgressResetList,
   UserResponse,
   VirtualContestDetails,
   VirtualContestInfo,
@@ -37,5 +38,11 @@ export const useJoinedContests = () => {
 export const useProblemList = (listId: string) => {
   return useSWRData(`${BASE_URL}/list/get/${listId}`, (url) =>
     typeCastFetcher<ProblemList>(url)
+  );
+};
+
+export const useProgressResetList = () => {
+  return useSWRData(`${BASE_URL}/progress_reset/list`, (url) =>
+    typeCastFetcher<ProgressResetList>(url)
   );
 };

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { connect, PromiseState } from "react-refetch";
 import { List, Set as ImmutableSet } from "immutable";
 import {
   useContests,
@@ -8,13 +7,15 @@ import {
   useUserSubmission,
   useMultipleUserSubmissions,
 } from "../../api/APIClient";
-import { useLoginState } from "../../api/InternalAPIClient";
+import {
+  useLoginState,
+  useProgressResetList,
+} from "../../api/InternalAPIClient";
 import Problem from "../../interfaces/Problem";
 import { constructStatusLabelMap, ContestId } from "../../interfaces/Status";
 import { useLocalStorage } from "../../utils/LocalStorage";
 import { ColorMode } from "../../utils/TableColor";
-import { filterResetProgress, ProgressResetList } from "../Internal/types";
-import { PROGRESS_RESET_LIST } from "../Internal/ApiUrl";
+import { filterResetProgress } from "../Internal/types";
 import { loggedInUserId } from "../../utils/UserState";
 import { classifyContest, ContestCategory } from "./ContestClassifier";
 import { TableTabButtons } from "./TableTab";
@@ -27,11 +28,7 @@ interface OuterProps {
   rivals: List<string>;
 }
 
-interface InnerProps extends OuterProps {
-  readonly progressResetList: PromiseState<ProgressResetList | null>;
-}
-
-const InnerTablePage: React.FC<InnerProps> = (props) => {
+export const TablePage: React.FC<OuterProps> = (props) => {
   const [activeTab, setActiveTab] = useLocalStorage<ContestCategory>(
     "contestTableTab",
     "ABC"
@@ -67,10 +64,7 @@ const InnerTablePage: React.FC<InnerProps> = (props) => {
       .data ?? [];
   const loginState = useLoginState().data;
   const loginUserId = loggedInUserId(loginState);
-  const progressReset =
-    props.progressResetList.fulfilled && props.progressResetList.value
-      ? props.progressResetList.value
-      : undefined;
+  const progressReset = useProgressResetList().data;
 
   const filteredSubmissions =
     loginUserId && progressReset
@@ -148,7 +142,3 @@ const InnerTablePage: React.FC<InnerProps> = (props) => {
     </div>
   );
 };
-
-export const TablePage = connect<OuterProps, InnerProps>(() => ({
-  progressResetList: PROGRESS_RESET_LIST,
-}))(InnerTablePage);


### PR DESCRIPTION
[#905 react-refetch を置き換える](https://github.com/kenkoooo/AtCoderProblems/issues/905) の続きです。

- InternalApiClientに `useProgressResetList` を定義し、swr経由でfetchし、Tableページでdataを取得するように書き換えました。
- 不要になったPropsやconnectは削除しました。

どのような操作をすれば動作が確認できるのかわからなかったので教えていただきたいです。