### PR TITLE
backend: 直近のAC数を扱う sql_client

### DIFF
--- a/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
@@ -1,6 +1,6 @@
 use crate::models::{Submission, UserProblemCount};
 use crate::{PgPool, MAX_INSERT_ROWS};
-use crate::streak::AsJst;
+use crate::utils::AsJst;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
@@ -3,7 +3,6 @@ use crate::{PgPool, MAX_INSERT_ROWS};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use chrono::{TimeZone, Utc};
 use sqlx::postgres::PgRow;
 use sqlx::Row;
 use std::collections::BTreeMap;
@@ -87,7 +86,7 @@ impl IntensiveAcceptedCountClient for PgPool {
             .iter()
             .map(|s| {
                 (
-                    Utc.timestamp(s.epoch_second, 0),
+                    s.epoch_second,
                     s.user_id.as_str(),
                     s.problem_id.as_str(),
                 )

--- a/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
@@ -1,0 +1,122 @@
+use crate::models::{Submission, UserProblemCount};
+use crate::{PgPool, MAX_INSERT_ROWS};
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::postgres::PgRow;
+use sqlx::Row;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Range;
+
+#[async_trait]
+pub trait IntensiveAcceptedCountClient {
+    async fn load_intensive_accepted_count(&self) -> Result<Vec<UserProblemCount>>;
+    async fn load_intensive_accepted_count_in_range(
+        &self,
+        rank_range: Range<usize>,
+    ) -> Result<Vec<UserProblemCount>>;
+    async fn get_users_intensive_accepted_count(&self, user_id: &str) -> Option<i32>;
+    async fn get_intensive_accepted_count_rank(&self, intensive_accepted_count: i32) -> Result<i64>;
+    async fn update_intensive_accepted_count(&self, submissions: &[Submission]) -> Result<()>;
+}
+
+#[async_trait]
+impl IntensiveAcceptedCountClient for PgPool {
+    async fn load_intensive_accepted_count(&self) -> Result<Vec<UserProblemCount>> {
+        let count = sqlx::query(
+            r"
+            SELECT user_id, problem_count FROM intensive_accepted_count
+            ORDER BY problem_count DESC, user_id ASC
+            ",
+        )
+        .try_map(|row: PgRow| {
+            let user_id: String = row.try_get("user_id")?;
+            let problem_count: i32 = row.try_get("problem_count")?;
+            Ok(UserProblemCount {
+                user_id,
+                problem_count,
+            })
+        })
+        .fetch_all(self)
+        .await?;
+
+        Ok(count)
+    }
+
+    async fn load_intensive_accepted_count_in_range(
+        &self,
+        rank_range: Range<usize>,
+    ) -> Result<Vec<UserProblemCount>> {
+        let count = sqlx::query(
+            r"
+            SELECT user_id, problem_count FROM intensive_accepted_count
+            ORDER BY problem_count DESC, user_id ASC
+            OFFSET $1 LIMIT $2;
+            ",
+        )
+        .bind(rank_range.start as i32)
+        .bind(rank_range.len() as i32)
+        .try_map(|row: PgRow| {
+            let user_id: String = row.try_get("user_id")?;
+            let problem_count: i32 = row.try_get("problem_count")?;
+            Ok(UserProblemCount {
+                user_id,
+                problem_count,
+            })
+        })
+        .fetch_all(self)
+        .await?;
+
+        Ok(count)
+    }
+
+    async fn get_users_intensive_accepted_count(&self, user_id: &str) -> Option<i32> {
+        let count = sqlx::query(
+            r"
+            SELECT problem_count FROM intensive_accepted_count
+            WHERE user_id = $1
+            ",
+        )
+        .bind(user_id)
+        .try_map(|row: PgRow| row.try_get::<i32, _>("problem_count"))
+        .fetch_one(self)
+        .await
+        .ok()?;
+
+        Some(count)
+    }
+
+    async fn get_intensive_accepted_count_rank(&self, intensive_accepted_count: i32) -> Result<i64> {
+        let rank = sqlx::query(
+            r"
+            SELECT COUNT(*) AS rank
+            FROM intensive_accepted_count
+            WHERE problem_count > $1
+            ",
+        )
+        .bind(intensive_accepted_count)
+        .try_map(|row: PgRow| row.try_get::<i64, _>("rank"))
+        .fetch_one(self)
+        .await?;
+
+        Ok(rank)
+    }
+
+    async fn update_intensive_accepted_count(&self, submissions: &[Submission]) -> Result<()> {
+        // copy from StreakClient
+        unimplemented!()
+    }
+}
+
+fn get_max_streak<Tz: TimeZone>(mut v: Vec<DateTime<Tz>>) -> i64 {
+    v.sort();
+    let (_, max_streak) = (1..v.len()).fold((1, 1), |(current_streak, max_streak), i| {
+        if v[i - 1].is_same_day_in_jst(&v[i]) {
+            (current_streak, max_streak)
+        } else if (v[i - 1].clone() + Duration::days(1)).is_same_day_in_jst(&v[i]) {
+            (current_streak + 1, cmp::max(max_streak, current_streak + 1))
+        } else {
+            (1, max_streak)
+        }
+    });
+    max_streak
+}

--- a/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/intensive_accepted_count.rs
@@ -14,7 +14,6 @@ const DEFAULT_DURATION: i64 = 7;
 
 #[async_trait]
 pub trait IntensiveAcceptedCountClient {
-    async fn load_intensive_accepted_count(&self) -> Result<Vec<UserProblemCount>>;
     async fn load_intensive_accepted_count_in_range(
         &self,
         rank_range: Range<usize>,
@@ -26,27 +25,6 @@ pub trait IntensiveAcceptedCountClient {
 
 #[async_trait]
 impl IntensiveAcceptedCountClient for PgPool {
-    async fn load_intensive_accepted_count(&self) -> Result<Vec<UserProblemCount>> {
-        let count = sqlx::query(
-            r"
-            SELECT user_id, problem_count FROM intensive_accepted_count
-            ORDER BY problem_count DESC, user_id ASC
-            ",
-        )
-        .try_map(|row: PgRow| {
-            let user_id: String = row.try_get("user_id")?;
-            let problem_count: i32 = row.try_get("problem_count")?;
-            Ok(UserProblemCount {
-                user_id,
-                problem_count,
-            })
-        })
-        .fetch_all(self)
-        .await?;
-
-        Ok(count)
-    }
-
     async fn load_intensive_accepted_count_in_range(
         &self,
         rank_range: Range<usize>,

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 pub mod accepted_count;
 pub mod contest_problem;
+pub mod intensive_accepted_count;
 pub mod internal;
 pub mod language_count;
 pub mod models;

--- a/atcoder-problems-backend/sql-client/src/lib.rs
+++ b/atcoder-problems-backend/sql-client/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rated_point_sum;
 pub mod simple_client;
 pub mod streak;
 pub mod submission_client;
+pub mod utils;
 
 pub use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 pub use sqlx::{query, Row};

--- a/atcoder-problems-backend/sql-client/src/streak.rs
+++ b/atcoder-problems-backend/sql-client/src/streak.rs
@@ -1,5 +1,6 @@
 use crate::models::{Submission, UserStreak};
 use crate::{PgPool, MAX_INSERT_ROWS};
+use crate::utils::AsJst;
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -7,7 +8,7 @@ use sqlx::postgres::PgRow;
 use sqlx::Row;
 
 use chrono::Duration;
-use chrono::{DateTime, Datelike, FixedOffset, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use std::cmp;
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -152,23 +153,6 @@ fn get_max_streak<Tz: TimeZone>(mut v: Vec<DateTime<Tz>>) -> i64 {
     max_streak
 }
 
-pub(crate) trait AsJst {
-    fn as_jst(&self) -> DateTime<FixedOffset>;
-    fn is_same_day_in_jst<T: TimeZone>(&self, rhs: &DateTime<T>) -> bool {
-        let d1 = self.as_jst();
-        let d2 = rhs.as_jst();
-        d1.day() == d2.day() && d1.month() == d2.month() && d1.year() == d2.year()
-    }
-}
-
-impl<Tz> AsJst for DateTime<Tz>
-where
-    Tz: TimeZone,
-{
-    fn as_jst(&self) -> DateTime<FixedOffset> {
-        self.with_timezone(&FixedOffset::east(9 * 3600))
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/atcoder-problems-backend/sql-client/src/streak.rs
+++ b/atcoder-problems-backend/sql-client/src/streak.rs
@@ -152,7 +152,7 @@ fn get_max_streak<Tz: TimeZone>(mut v: Vec<DateTime<Tz>>) -> i64 {
     max_streak
 }
 
-trait AsJst {
+pub(crate) trait AsJst {
     fn as_jst(&self) -> DateTime<FixedOffset>;
     fn is_same_day_in_jst<T: TimeZone>(&self, rhs: &DateTime<T>) -> bool {
         let d1 = self.as_jst();

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -34,6 +34,9 @@ pub enum SubmissionRequest<'a> {
         from_second: i64,
     },
     AllAccepted,
+    AcceptedFrom {
+        from_second: i64,
+    },
     ByIds {
         ids: &'a [i64],
     },
@@ -136,6 +139,15 @@ impl SubmissionClient for PgPool {
                     WHERE result = 'AC'
                     ",
             )
+            .fetch_all(self),
+            SubmissionRequest::AcceptedFrom { from_second } => sqlx::query_as(
+                r"
+                    SELECT * FROM submissions
+                    WHERE result = 'AC'
+                    AND epoch_second >= $1
+                    ",
+            )
+            .bind(from_second)
             .fetch_all(self),
             SubmissionRequest::InvalidResult { from_second } => sqlx::query_as(
                 r"

--- a/atcoder-problems-backend/sql-client/src/utils.rs
+++ b/atcoder-problems-backend/sql-client/src/utils.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Datelike, FixedOffset, TimeZone};
+
+pub(crate) trait AsJst {
+    fn as_jst(&self) -> DateTime<FixedOffset>;
+    fn is_same_day_in_jst<T: TimeZone>(&self, rhs: &DateTime<T>) -> bool {
+        let d1 = self.as_jst();
+        let d2 = rhs.as_jst();
+        d1.day() == d2.day() && d1.month() == d2.month() && d1.year() == d2.year()
+    }
+}
+
+impl<Tz: TimeZone> AsJst for DateTime<Tz> {
+    fn as_jst(&self) -> DateTime<FixedOffset> {
+        self.with_timezone(&FixedOffset::east(9 * 3600))
+    }
+}

--- a/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
@@ -6,7 +6,7 @@ use chrono::{TimeZone, Utc};
 mod utils;
 
 #[async_std::test]
-async fn test_streak_ranking() {
+async fn test_intensive_accepted_count() {
     let pool = utils::initialize_and_connect_to_test_sql().await;
     sqlx::query(
         r"

--- a/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
@@ -1,0 +1,90 @@
+use sql_client::models::UserProblemCount;
+use sql_client::intensive_accepted_count::IntensiveAcceptedCountClient;
+use sql_client::submission_client::{SubmissionClient, SubmissionRequest};
+use chrono::{TimeZone, Utc};
+
+mod utils;
+
+#[async_std::test]
+async fn test_streak_ranking() {
+    let pool = utils::initialize_and_connect_to_test_sql().await;
+    sqlx::query(
+        r"
+        INSERT INTO submissions (id, epoch_second, problem_id, contest_id, user_id, language, point, length, result) VALUES 
+        (1, 1570186800, 'problem_a', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-04T20:00:00+09:00
+        (2, 1570237200, 'problem_b', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-05T10:00:00+09:00
+        (3, 1570532400, 'problem_c', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-08T20:00:00+09:00
+        (4, 1570726800, 'problem_d', '', 'user1', '', 0, 0, 'AC'), -- 2019-10-11T02:00:00+09:00
+        (5, 1570114799, 'problem_a', '', 'user2', '', 0, 0, 'AC'), -- 2019-10-03T23:59:59+09:00
+        (6, 1570496400, 'problem_b', '', 'user2', '', 0, 0, 'AC'), -- 2019-10-08T10:00:00+09:00
+        (7, 1570618800, 'problem_b', '', 'user2', '', 0, 0, 'AC'), -- 2019-10-09T20:00:00+09:00
+        (8, 1568473200, 'problem_a', '', 'user3', '', 0, 0, 'AC'), -- 2019-09-15T00:00:00+09:00
+        (9, 1569423600, 'problem_b', '', 'user3', '', 0, 0, 'AC'), -- 2019-09-26T00:00:00+09:00
+        (10, 1570114800, 'problem_a', '', 'user4', '', 0, 0, 'AC'), -- 2019-10-04T00:00:00+09:00
+        (11, 1570496400, 'problem_a', '', 'user5', '', 0, 0, 'AC'); -- 2019-10-11T10:00:00+09:00
+        ",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // update IAC
+    let submissions = pool
+        .get_submissions(SubmissionRequest::AllAccepted)
+        .await
+        .unwrap();
+    let today = Utc.ymd(2019, 10, 10).and_hms(22, 32, 11); // 2019-10-11T07:32:11+09:00
+    pool.update_intensive_accepted_count(&submissions, today).await.unwrap();
+
+    // get users IAC
+    assert_eq!(
+        pool.get_users_intensive_accepted_count("user1").await.unwrap(),
+        4
+    );
+    assert_eq!(
+        pool.get_users_intensive_accepted_count("user2").await.unwrap(),
+        1
+    );
+    assert_eq!(
+        pool.get_users_intensive_accepted_count("user4").await.unwrap(),
+        1
+    );
+    assert!(
+        pool.get_users_intensive_accepted_count("non_existing_user")
+        .await
+        .is_none()
+    );
+
+    // get streak count rank
+    assert_eq!(pool.get_intensive_accepted_count_rank(4).await.unwrap(), 0);
+    assert_eq!(pool.get_intensive_accepted_count_rank(2).await.unwrap(), 1);
+    assert_eq!(pool.get_intensive_accepted_count_rank(1).await.unwrap(), 2);
+    assert_eq!(pool.get_intensive_accepted_count_rank(0).await.unwrap(), 4);
+
+    // load streak count in range
+    let rank_1st_to_3rd = pool
+    .load_intensive_accepted_count_in_range(0..3).await.unwrap();
+    assert_eq!(rank_1st_to_3rd.len(), 3);
+    assert_eq!(rank_1st_to_3rd[0].user_id, "user1".to_owned());
+    assert_eq!(rank_1st_to_3rd[0].problem_count, 4);
+    assert_eq!(rank_1st_to_3rd[2].user_id, "user4".to_owned());
+    assert_eq!(rank_1st_to_3rd[2].problem_count, 1);
+
+    let rank_3rd_to_8th = pool
+    .load_intensive_accepted_count_in_range(2..8).await.unwrap();
+    assert_eq!(rank_3rd_to_8th[1], UserProblemCount{
+        user_id: "user5".to_owned(),
+        problem_count: 1
+    });
+    assert_eq!(rank_3rd_to_8th.len(), 2);
+
+    let rank_2nd_to_2nd = pool
+    .load_intensive_accepted_count_in_range(1..2).await.unwrap();
+    assert_eq!(rank_2nd_to_2nd.len(), 1);
+    assert_eq!(rank_2nd_to_2nd[0], UserProblemCount{
+        user_id: "user2".to_owned(),
+        problem_count: 2
+    });
+    
+}
+

--- a/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
@@ -21,7 +21,7 @@ async fn test_streak_ranking() {
         (8, 1568473200, 'problem_a', '', 'user3', '', 0, 0, 'AC'), -- 2019-09-15T00:00:00+09:00
         (9, 1569423600, 'problem_b', '', 'user3', '', 0, 0, 'AC'), -- 2019-09-26T00:00:00+09:00
         (10, 1570114800, 'problem_a', '', 'user4', '', 0, 0, 'AC'), -- 2019-10-04T00:00:00+09:00
-        (11, 1570496400, 'problem_a', '', 'user5', '', 0, 0, 'AC'); -- 2019-10-11T10:00:00+09:00
+        (11, 1570719600, 'problem_a', '', 'user5', '', 0, 0, 'AC'); -- 2019-10-11T10:00:00+09:00
         ",
     )
     .execute(&pool)
@@ -33,6 +33,7 @@ async fn test_streak_ranking() {
         .get_submissions(SubmissionRequest::AllAccepted)
         .await
         .unwrap();
+
     let today = Utc.ymd(2019, 10, 10).and_hms(22, 32, 11); // 2019-10-11T07:32:11+09:00
     pool.update_intensive_accepted_count(&submissions, today).await.unwrap();
 
@@ -57,8 +58,7 @@ async fn test_streak_ranking() {
 
     // get streak count rank
     assert_eq!(pool.get_intensive_accepted_count_rank(4).await.unwrap(), 0);
-    assert_eq!(pool.get_intensive_accepted_count_rank(2).await.unwrap(), 1);
-    assert_eq!(pool.get_intensive_accepted_count_rank(1).await.unwrap(), 2);
+    assert_eq!(pool.get_intensive_accepted_count_rank(1).await.unwrap(), 1);
     assert_eq!(pool.get_intensive_accepted_count_rank(0).await.unwrap(), 4);
 
     // load streak count in range
@@ -76,15 +76,14 @@ async fn test_streak_ranking() {
         user_id: "user5".to_owned(),
         problem_count: 1
     });
-    assert_eq!(rank_3rd_to_8th.len(), 2);
+    assert_eq!(rank_3rd_to_8th.len(), 3);
 
     let rank_2nd_to_2nd = pool
     .load_intensive_accepted_count_in_range(1..2).await.unwrap();
     assert_eq!(rank_2nd_to_2nd.len(), 1);
     assert_eq!(rank_2nd_to_2nd[0], UserProblemCount{
         user_id: "user2".to_owned(),
-        problem_count: 2
+        problem_count: 1
     });
-    
 }
 

--- a/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
@@ -34,8 +34,8 @@ async fn test_intensive_accepted_count() {
         .await
         .unwrap();
 
-    let today = Utc.ymd(2019, 10, 10).and_hms(22, 32, 11); // 2019-10-11T07:32:11+09:00
-    pool.update_intensive_accepted_count(&submissions, today).await.unwrap();
+    let threshold = Utc.ymd(2019, 10, 3).and_hms(15, 0, 0).timestamp(); // 2019-10-04T00:00:00+09:00
+    pool.update_intensive_accepted_count(&submissions, threshold).await.unwrap();
 
     // get users IAC
     assert_eq!(

--- a/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_intensive_accepted_count.rs
@@ -29,13 +29,13 @@ async fn test_intensive_accepted_count() {
     .unwrap();
 
     // update IAC
+    let threshold = Utc.ymd(2019, 10, 3).and_hms(15, 0, 0).timestamp(); // 2019-10-04T00:00:00+09:00
     let submissions = pool
-        .get_submissions(SubmissionRequest::AllAccepted)
+        .get_submissions(SubmissionRequest::AcceptedFrom{ from_second: threshold })
         .await
         .unwrap();
 
-    let threshold = Utc.ymd(2019, 10, 3).and_hms(15, 0, 0).timestamp(); // 2019-10-04T00:00:00+09:00
-    pool.update_intensive_accepted_count(&submissions, threshold).await.unwrap();
+    pool.update_intensive_accepted_count(&submissions).await.unwrap();
 
     // get users IAC
     assert_eq!(
@@ -76,7 +76,7 @@ async fn test_intensive_accepted_count() {
         user_id: "user5".to_owned(),
         problem_count: 1
     });
-    assert_eq!(rank_3rd_to_8th.len(), 3);
+    assert_eq!(rank_3rd_to_8th.len(), 2);
 
     let rank_2nd_to_2nd = pool
     .load_intensive_accepted_count_in_range(1..2).await.unwrap();

--- a/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_submission_client.rs
@@ -120,6 +120,13 @@ async fn test_submission_client() {
         .unwrap();
     assert_eq!(submissions.len(), 3);
 
+    let request = SubmissionRequest::AcceptedFrom {
+        from_second: 200,
+    };
+    let submissions = pool.get_submissions(request).await.unwrap();
+    assert_eq!(submissions.len(), 2);
+
+
     assert_eq!(pool.count_stored_submissions(&[1]).await.unwrap(), 1);
     assert_eq!(pool.count_stored_submissions(&[9]).await.unwrap(), 0);
 

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -76,6 +76,13 @@ CREATE TABLE accepted_count (
   PRIMARY KEY (user_id)
 );
 
+DROP TABLE IF EXISTS intensive_accepted_count;
+CREATE TABLE intensive_accepted_count (
+  user_id       VARCHAR(255)  NOT NULL,
+  problem_count INT           NOT NULL,
+  PRIMARY KEY (user_id)
+);
+
 DROP TABLE IF EXISTS points;
 CREATE TABLE points (
   problem_id            VARCHAR(255) NOT NULL,


### PR DESCRIPTION
ref: #849 

過去 7 日間の新規AC数を扱う sql_client を作成しました。名前は Intensive Accepted Count  (集中的AC数) としましたが、もっとわかりやすい名前の案があれば教えてください。

他の client と異なり、update 関数内で現在時刻を扱う必要があるので、この部分の実装に関しては一考の余地があります。
将来的に current streak をバックエンド側に回すことにすることも考えて、統一しやすい方法を取りたいので皆さんの意見を伺いたいです。

現在は sql_client の update() は現在時刻を引数として受け取るようになっています。定時クロールで client を呼び出す側で日時を取得して渡すイメージです。
ただ、これは内部で現在時刻を計算してしまうと test 実行の際に任意の時刻を指定できない、という消極的な理由によるものなので、よりよい方法があれば変更します。

また、「新規AC」を対象としているため、過去にAC済みかどうかを判定するために全Submissionを読んでいます。せっかく期間指定submission取得関数が追加された(#952)ので、何かうまいこと使えないかな……とかなしい気持ちになっています。
「7 日間のみのUnique AC」を計算することも考えましたが、一週おきに自分の全ACを再提出する人が現れた場合どうしようもないので、どうしようかな、という気持ちです。