### PR TITLE
Language Ranking用APIエンドポイント追加

### DIFF
--- a/atcoder-problems-backend/sql-client/tests/test_language_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_language_count.rs
@@ -1,5 +1,5 @@
 use sql_client::language_count::LanguageCountClient;
-use sql_client::models::{Submission, UserLanguageCount, UserLanguageCountRank};
+use sql_client::models::{Submission, UserLanguageCount, UserLanguageCountRank, UserProblemCount};
 
 mod utils;
 
@@ -130,6 +130,44 @@ async fn test_language_count() {
                 problem_count: 2
             }
         ]
+    );
+
+    let language_count_1st_to_2nd = pool
+        .load_language_count_in_range(&"language1", 0..2)
+        .await
+        .unwrap();
+    assert_eq!(
+        language_count_1st_to_2nd,
+        vec![
+            UserProblemCount {
+                user_id: "user1".to_owned(),
+                problem_count: 2
+            },
+            UserProblemCount {
+                user_id: "user2".to_owned(),
+                problem_count: 1
+            }
+        ]
+    );
+
+    let language_count_2nd_to_2nd = pool
+        .load_language_count_in_range(&"language1", 1..2)
+        .await
+        .unwrap();
+    assert_eq!(
+        language_count_2nd_to_2nd,
+        vec![UserProblemCount {
+            user_id: "user2".to_owned(),
+            problem_count: 1
+        }]
+    );
+
+    assert_eq!(
+        pool.load_language_count_in_range(&"language1", 0..10)
+            .await
+            .unwrap()
+            .len(),
+        2
     );
 
     let language_count = pool.load_users_language_count(&"user1").await.unwrap();

--- a/atcoder-problems-backend/src/server/mod.rs
+++ b/atcoder-problems-backend/src/server/mod.rs
@@ -15,8 +15,8 @@ pub(crate) mod virtual_contest;
 pub use auth::{Authentication, GitHubAuthentication, GitHubUserResponse};
 
 use crate::server::ranking::{
-    get_ac_ranking, get_streak_ranking, get_users_ac_rank, get_users_language_rank,
-    get_users_streak_rank,
+    get_ac_ranking, get_language_ranking, get_streak_ranking, get_users_ac_rank,
+    get_users_language_rank, get_users_streak_rank,
 };
 use auth::get_token;
 use language_count::get_language_list;
@@ -111,6 +111,7 @@ where
             api.at("/ac_ranking").get(ranking::ranking(get_ac_ranking));
             api.at("/streak_ranking")
                 .get(ranking::ranking(get_streak_ranking));
+            api.at("/language_ranking").get(get_language_ranking);
             api.at("/from/:from").get(get_time_submissions);
             api.at("/recent").get(get_recent_submissions);
             api.at("/users_and_time").get(get_users_time_submissions);

--- a/atcoder-problems-backend/tests/test_server_e2e_language_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_language_ranking.rs
@@ -61,6 +61,78 @@ async fn test_language_ranking() {
     });
     task::sleep(std::time::Duration::from_millis(1000)).await;
 
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=1&to=3&language=lang2",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+    assert_eq!(
+        response,
+        json!([
+            {"user_id": "user3", "problem_count": 2},
+            {"user_id": "user1", "problem_count": 1},
+        ])
+    );
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=0&to=1&language=lang2",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+    assert_eq!(
+        response,
+        json!([
+            {"user_id": "user2", "problem_count": 2}
+        ])
+    );
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=10&to=20&language=lang2",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+    assert!(response.as_array().unwrap().is_empty());
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=0&to=1&language=does_not_exist",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+    assert!(response.as_array().unwrap().is_empty());
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=0&to=2000&language=lang2",
+        port,
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 400);
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=1&to=0&language=lang2",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+    assert!(response.as_array().unwrap().is_empty());
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/language_ranking?from=-1&to=0&language=lang2",
+        port,
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 400);
+
     let response = surf::get(url("/atcoder-api/v3/user/language_rank?user=user1", port))
         .recv_json::<Value>()
         .await


### PR DESCRIPTION
#945の言語別AC数ランキングを得るためのsql_clientとAPIエンドポイントです。

~~language_ownerを表示するためのクエリだと思うので、このように言語ごとの上位x位からy位まで出力しちゃう形でどうでしょう？
よさそうであれば、テスト書きます。~~
言語名とレンジをクエリとして受け取る必要があります。