### PR TITLE
ユーザーのAC数の情報を返すAPIエンドポイントを追加

### DIFF
--- a/atcoder-problems-backend/src/server/accepted_count_ranking.rs
+++ b/atcoder-problems-backend/src/server/accepted_count_ranking.rs
@@ -1,5 +1,5 @@
 use crate::server::{AppData, CommonResponse};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sql_client::accepted_count::AcceptedCountClient;
 use tide::{Request, Response, Result};
 
@@ -19,5 +19,31 @@ pub(crate) async fn get_ac_ranking<A>(request: Request<AppData<A>>) -> Result<Re
     }
     let ranking = conn.load_accepted_count_in_range(query).await?;
     let response = Response::json(&ranking)?;
+    Ok(response)
+}
+
+pub(crate) async fn get_users_ac_info<A>(request: Request<AppData<A>>) -> Result<Response> {
+    #[derive(Debug, Deserialize)]
+    struct Query {
+        user: String,
+    }
+    #[derive(Debug, Serialize)]
+    struct UsersACInfo {
+        accepted_count: i32,
+        accepted_count_rank: i64,
+    }
+    let conn = request.state().pg_pool.clone();
+    let query = request.query::<Query>()?;
+    let user_id = &query.user;
+    let accepted_count = match conn.get_users_accepted_count(user_id).await {
+        Some(number) => number,
+        None => return Ok(Response::new(404)),
+    };
+    let accepted_count_rank = conn.get_accepted_count_rank(accepted_count).await?;
+    let users_ac_info = UsersACInfo {
+        accepted_count,
+        accepted_count_rank,
+    };
+    let response = Response::json(&users_ac_info)?;
     Ok(response)
 }

--- a/atcoder-problems-backend/src/server/accepted_count_ranking.rs
+++ b/atcoder-problems-backend/src/server/accepted_count_ranking.rs
@@ -22,28 +22,24 @@ pub(crate) async fn get_ac_ranking<A>(request: Request<AppData<A>>) -> Result<Re
     Ok(response)
 }
 
-pub(crate) async fn get_users_ac_info<A>(request: Request<AppData<A>>) -> Result<Response> {
+pub(crate) async fn get_users_ac_rank<A>(request: Request<AppData<A>>) -> Result<Response> {
     #[derive(Debug, Deserialize)]
     struct Query {
         user: String,
     }
     #[derive(Debug, Serialize)]
     struct UsersACInfo {
-        accepted_count: i32,
-        accepted_count_rank: i64,
+        count: i32,
+        rank: i64,
     }
     let conn = request.state().pg_pool.clone();
     let query = request.query::<Query>()?;
-    let user_id = &query.user;
-    let accepted_count = match conn.get_users_accepted_count(user_id).await {
+    let count = match conn.get_users_accepted_count(&query.user).await {
         Some(number) => number,
         None => return Ok(Response::new(404)),
     };
-    let accepted_count_rank = conn.get_accepted_count_rank(accepted_count).await?;
-    let users_ac_info = UsersACInfo {
-        accepted_count,
-        accepted_count_rank,
-    };
+    let rank = conn.get_accepted_count_rank(count).await?;
+    let users_ac_info = UsersACInfo { count, rank };
     let response = Response::json(&users_ac_info)?;
     Ok(response)
 }

--- a/atcoder-problems-backend/src/server/mod.rs
+++ b/atcoder-problems-backend/src/server/mod.rs
@@ -1,4 +1,4 @@
-use crate::server::accepted_count_ranking::get_ac_ranking;
+use crate::server::accepted_count_ranking::{get_ac_ranking,get_users_ac_info};
 use crate::server::rated_point_sum_ranking::get_rated_point_sum_ranking;
 use crate::server::streak_ranking::{get_streak_ranking, get_users_streak_rank};
 use crate::server::time_submissions::get_time_submissions;
@@ -111,6 +111,7 @@ where
             api.at("/recent").get_ah(get_recent_submissions);
             api.at("/streak_ranking").get_ah(get_streak_ranking);
             api.at("/users_and_time").get_ah(get_users_time_submissions);
+            api.at("/user/ac_info").get_ah(get_users_ac_info);
             api.at("/user/submissions")
                 .get_ah(get_user_submissions_from_time);
             api.at("/user/streak_rank").get_ah(get_users_streak_rank);

--- a/atcoder-problems-backend/src/server/mod.rs
+++ b/atcoder-problems-backend/src/server/mod.rs
@@ -1,4 +1,4 @@
-use crate::server::accepted_count_ranking::{get_ac_ranking,get_users_ac_info};
+use crate::server::accepted_count_ranking::{get_ac_ranking, get_users_ac_rank};
 use crate::server::rated_point_sum_ranking::get_rated_point_sum_ranking;
 use crate::server::streak_ranking::{get_streak_ranking, get_users_streak_rank};
 use crate::server::time_submissions::get_time_submissions;
@@ -111,7 +111,7 @@ where
             api.at("/recent").get_ah(get_recent_submissions);
             api.at("/streak_ranking").get_ah(get_streak_ranking);
             api.at("/users_and_time").get_ah(get_users_time_submissions);
-            api.at("/user/ac_info").get_ah(get_users_ac_info);
+            api.at("/user/ac_rank").get_ah(get_users_ac_rank);
             api.at("/user/submissions")
                 .get_ah(get_user_submissions_from_time);
             api.at("/user/streak_rank").get_ah(get_users_streak_rank);

--- a/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
@@ -94,5 +94,37 @@ async fn test_ac_ranking() {
         .unwrap();
     assert_eq!(response.status(), 400);
 
+    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u1", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        response,
+        json!({"accepted_count": 1, "accepted_count_rank": 1})
+    );
+
+    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u2", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        response,
+        json!({"accepted_count": 2, "accepted_count_rank": 0})
+    );
+
+    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u3", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        response,
+        json!({"accepted_count": 1, "accepted_count_rank": 1})
+    );
+
+    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=do_not_exist", port))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 404);
+
     server.race(ready(())).await;
 }

--- a/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
@@ -94,34 +94,25 @@ async fn test_ac_ranking() {
         .unwrap();
     assert_eq!(response.status(), 400);
 
-    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u1", port))
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=u1", port))
         .recv_json::<Value>()
         .await
         .unwrap();
-    assert_eq!(
-        response,
-        json!({"accepted_count": 1, "accepted_count_rank": 1})
-    );
+    assert_eq!(response, json!({"count": 1, "rank": 1}));
 
-    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u2", port))
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=u2", port))
         .recv_json::<Value>()
         .await
         .unwrap();
-    assert_eq!(
-        response,
-        json!({"accepted_count": 2, "accepted_count_rank": 0})
-    );
+    assert_eq!(response, json!({"count": 2, "rank": 0}));
 
-    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=u3", port))
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=u3", port))
         .recv_json::<Value>()
         .await
         .unwrap();
-    assert_eq!(
-        response,
-        json!({"accepted_count": 1, "accepted_count_rank": 1})
-    );
+    assert_eq!(response, json!({"count": 1, "rank": 1}));
 
-    let response = surf::get(url("/atcoder-api/v3/user/ac_info?user=do_not_exist", port))
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=do_not_exist", port))
         .await
         .unwrap();
     assert_eq!(response.status(), 404);


### PR DESCRIPTION
ref: #945
ユーザー名を渡したらAC数とランクを返してくれるAPIのエンドポイントと、そのテストを追加しました。
