### PR TITLE
Fix #1027

### DIFF
--- a/atcoder-problems-backend/sql-client/src/accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/src/accepted_count.rs
@@ -73,7 +73,7 @@ impl AcceptedCountClient for PgPool {
         let count = sqlx::query(
             r"
             SELECT problem_count FROM accepted_count
-            WHERE user_id = $1
+            WHERE LOWER(user_id) = LOWER($1)
             ",
         )
         .bind(user_id)

--- a/atcoder-problems-backend/sql-client/tests/test_accepted_count.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_accepted_count.rs
@@ -95,6 +95,8 @@ async fn test_accepted_count() {
 
     assert_eq!(pool.get_users_accepted_count("user1").await.unwrap(), 2);
     assert_eq!(pool.get_users_accepted_count("user2").await.unwrap(), 3);
+    assert_eq!(pool.get_users_accepted_count("USER1").await.unwrap(), 2);
+    assert_eq!(pool.get_users_accepted_count("USER2").await.unwrap(), 3);
     assert_eq!(pool.get_accepted_count_rank(3).await.unwrap(), 0);
     assert_eq!(pool.get_accepted_count_rank(2).await.unwrap(), 1);
 

--- a/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_ac_ranking.rs
@@ -112,6 +112,24 @@ async fn test_ac_ranking() {
         .unwrap();
     assert_eq!(response, json!({"count": 1, "rank": 1}));
 
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=U1", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(response, json!({"count": 1, "rank": 1}));
+
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=U2", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(response, json!({"count": 2, "rank": 0}));
+
+    let response = surf::get(url("/atcoder-api/v3/user/ac_rank?user=U3", port))
+        .recv_json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(response, json!({"count": 1, "rank": 1}));
+
     let response = surf::get(url(
         "/atcoder-api/v3/user/ac_rank?user=does_not_exist",
         port,


### PR DESCRIPTION
Resolves #1027
ユーザーIDに英大文字が含まれていてもAC数ランクが表示されるようになるはずです。