### PR TITLE
ユーザーIDに英大文字が含まれるときにRPSランクが表示されないバグを修正

### DIFF
--- a/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
@@ -104,12 +104,17 @@ impl RatedPointSumClient for PgPool {
     }
 
     async fn get_users_rated_point_sum(&self, user_id: &str) -> Option<i64> {
-        let sum = sqlx::query("SELECT point_sum FROM rated_point_sum WHERE user_id = $1")
-            .bind(user_id)
-            .try_map(|row: PgRow| row.try_get::<i64, _>("point_sum"))
-            .fetch_one(self)
-            .await
-            .ok()?;
+        let sum = sqlx::query(
+            r"
+            SELECT point_sum FROM rated_point_sum
+            WHERE LOWER(user_id) = LOWER($1)
+            ",
+        )
+        .bind(user_id)
+        .try_map(|row: PgRow| row.try_get::<i64, _>("point_sum"))
+        .fetch_one(self)
+        .await
+        .ok()?;
         Some(sum)
     }
 

--- a/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
@@ -191,6 +191,12 @@ async fn test_update_rated_point_sum() {
     assert_eq!(sums[0].user_id, USER_ID.to_string());
     assert_eq!(sums[0].point_sum, 300);
     assert_eq!(pool.get_users_rated_point_sum(USER_ID).await.unwrap(), 300);
+    assert_eq!(
+        pool.get_users_rated_point_sum(&USER_ID.to_ascii_uppercase())
+            .await
+            .unwrap(),
+        300
+    );
     assert_eq!(pool.get_rated_point_sum_rank(300).await.unwrap(), 0);
 
     assert!(pool

--- a/atcoder-problems-backend/tests/test_server_e2e_rated_point_sum_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_rated_point_sum_ranking.rs
@@ -191,6 +191,54 @@ async fn test_users_rated_point_sum_ranking() {
     );
 
     let response = surf::get(url(
+        "/atcoder-api/v3/user/rated_point_sum_rank?user=U2",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+
+    assert_eq!(
+        response,
+        json!({
+            "count":2,
+            "rank":0
+        })
+    );
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/user/rated_point_sum_rank?user=U1",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+
+    assert_eq!(
+        response,
+        json!({
+            "count":1,
+            "rank":1
+        })
+    );
+
+    let response = surf::get(url(
+        "/atcoder-api/v3/user/rated_point_sum_rank?user=U3",
+        port,
+    ))
+    .recv_json::<Value>()
+    .await
+    .unwrap();
+
+    assert_eq!(
+        response,
+        json!({
+            "count":1,
+            "rank":1
+        })
+    );
+
+    let response = surf::get(url(
         "/atcoder-api/v3/user/rated_point_sum_rank?user=not_exist",
         port,
     ))
@@ -199,4 +247,6 @@ async fn test_users_rated_point_sum_ranking() {
     .unwrap();
 
     assert_eq!(response.status(), 404);
+
+    server.race(ready(())).await;
 }


### PR DESCRIPTION
ユーザーIDに英大文字が含まれるときにユーザーページの Rated Point Sum ランクが表示されていなかったため、#1028 と同様にユーザーIDの検索を case-insensitive に行うようにし、テストを追加しました。