### PR TITLE
TableのContest Result表示のペナルティからCEを除外

### DIFF
--- a/atcoder-problems-frontend/src/interfaces/Status.ts
+++ b/atcoder-problems-frontend/src/interfaces/Status.ts
@@ -95,7 +95,7 @@ export const constructStatusLabelMap = (
       .filter((s) => isAccepted(s.result));
 
     const rejectedEpochSeconds = userRejected
-      .filter((submission) => submission.result != "CE")
+      .filter((submission) => submission.result !== "CE")
       .map((submission) => submission.epoch_second);
 
     if (userAccepted.length > 0) {

--- a/atcoder-problems-frontend/src/interfaces/Status.ts
+++ b/atcoder-problems-frontend/src/interfaces/Status.ts
@@ -94,9 +94,9 @@ export const constructStatusLabelMap = (
       .filter((s) => caseInsensitiveUserId(s.user_id) !== userId)
       .filter((s) => isAccepted(s.result));
 
-    const rejectedEpochSeconds = userRejected.map(
-      (submission) => submission.epoch_second
-    );
+    const rejectedEpochSeconds = userRejected
+      .filter((submission) => submission.result != "CE")
+      .map((submission) => submission.epoch_second);
 
     if (userAccepted.length > 0) {
       const languageSet = new Set(userAccepted.map((s) => s.language));


### PR DESCRIPTION
This PR will close #1046 
## やったこと
TableのContest Result表示でのペナルティのカウントからCEが取り除かれるようにしました
## 詳細
rejectedEpochSecondsの長さを数えていたので、そこからCEを取り除きました

今回変更を加えたrejectedEpochSecondsはテーブルページ(AtCoderRegularTableとContestTableのSubmitTimeSpan内)でしか用いられていないようなので、この変更はTableのContest Result表示のみへの影響にとどまるかと思います