### PR TITLE
feat: add "Add to Google Calendar" for virtual contests

### DIFF
--- a/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
+++ b/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Button } from "reactstrap";
+
+interface Props {
+  id: string;
+  title: string;
+  color: string;
+  startEpochSecond: number;
+  endEpochSecond: number;
+  children: React.ReactNode;
+}
+
+/**
+ * Google Calendar accepts a subset of ISO 8601 combined date and time.
+ * Ref. https://stackoverflow.com/a/41733538
+ * @param epochSeconds Date to format in epoch seconds.
+ * @return Date formatted to generate Google Calendar URL.
+ */
+const formatDateForGoogleCalendar = (epochSeconds: number): string =>
+  new Date(epochSeconds * 1000).toISOString().replace(/[^0-9TZ]/g, "");
+
+export const GoogleCalendarButton: React.FC<Props> = (props) => {
+  const internalUrl = `https://kenkoooo.com/atcoder/#/contest/show/${props.id}`;
+  const startDate = formatDateForGoogleCalendar(props.startEpochSecond);
+  const endDate = formatDateForGoogleCalendar(props.endEpochSecond);
+  const shareUrl = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+    props.title
+  )}&dates=${startDate}/${endDate}&location=${encodeURIComponent(internalUrl)}`;
+  return (
+    <Button
+      href={shareUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+      color={props.color}
+    >
+      {props.children}
+    </Button>
+  );
+};

--- a/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
+++ b/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
@@ -2,12 +2,10 @@ import React from "react";
 import { Button } from "reactstrap";
 
 interface Props {
-  id: string;
+  contestId: string;
   title: string;
-  color: string;
   startEpochSecond: number;
   endEpochSecond: number;
-  children: React.ReactNode;
 }
 
 /**
@@ -20,7 +18,7 @@ const formatDateForGoogleCalendar = (epochSeconds: number): string =>
   new Date(epochSeconds * 1000).toISOString().replace(/[^0-9TZ]/g, "");
 
 export const GoogleCalendarButton: React.FC<Props> = (props) => {
-  const internalUrl = `https://kenkoooo.com/atcoder/#/contest/show/${props.id}`;
+  const internalUrl = `https://kenkoooo.com/atcoder/#/contest/show/${props.contestId}`;
   const startDate = formatDateForGoogleCalendar(props.startEpochSecond);
   const endDate = formatDateForGoogleCalendar(props.endEpochSecond);
   const shareUrl = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
@@ -31,9 +29,9 @@ export const GoogleCalendarButton: React.FC<Props> = (props) => {
       href={shareUrl}
       rel="noopener noreferrer"
       target="_blank"
-      color={props.color}
+      color="primary"
     >
-      {props.children}
+      Add to Google Calendar
     </Button>
   );
 };

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -33,6 +33,7 @@ import { ACCOUNT_INFO } from "../../../../utils/RouterPath";
 import { useLocalStorage } from "../../../../utils/LocalStorage";
 import { ProblemLink } from "../../../../components/ProblemLink";
 import { joinContest, leaveContest } from "../ApiClient";
+import { GoogleCalendarButton } from "../../../../components/GoogleCalendarButton";
 import { ContestTable } from "./ContestTable";
 import { LockoutContestTable } from "./LockoutContestTable";
 import { TrainingContestTable } from "./TrainingContestTable";
@@ -219,6 +220,17 @@ export const ShowContest = (props: Props) => {
             >
               Tweet
             </TweetButton>
+            {now < end ? (
+              <GoogleCalendarButton
+                id={contestInfo.id}
+                title={contestInfo.title}
+                startEpochSecond={start}
+                endEpochSecond={end}
+                color="primary"
+              >
+                Add to Google Calendar
+              </GoogleCalendarButton>
+            ) : null}
           </ButtonGroup>
         </Col>
       </Row>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -182,7 +182,7 @@ export const ShowContest = (props: Props) => {
             </Alert>
           ) : null}
           <ButtonGroup>
-            {canJoin ? (
+            {canJoin && (
               <Button
                 onClick={async () => {
                   await joinContest(props.contestId);
@@ -191,8 +191,8 @@ export const ShowContest = (props: Props) => {
               >
                 Join
               </Button>
-            ) : null}
-            {canLeave ? (
+            )}
+            {canLeave && (
               <Button
                 onClick={async () => {
                   await leaveContest(props.contestId);
@@ -201,8 +201,8 @@ export const ShowContest = (props: Props) => {
               >
                 Leave
               </Button>
-            ) : null}
-            {isOwner ? (
+            )}
+            {isOwner && (
               <Button
                 onClick={(): void =>
                   history.push({
@@ -212,7 +212,7 @@ export const ShowContest = (props: Props) => {
               >
                 Edit
               </Button>
-            ) : null}
+            )}
             <TweetButton
               id={contestInfo.id}
               text={contestInfo.title}
@@ -220,14 +220,14 @@ export const ShowContest = (props: Props) => {
             >
               Tweet
             </TweetButton>
-            {now < end ? (
+            {now < end && (
               <GoogleCalendarButton
                 contestId={contestInfo.id}
                 title={contestInfo.title}
                 startEpochSecond={start}
                 endEpochSecond={end}
               />
-            ) : null}
+            )}
           </ButtonGroup>
         </Col>
       </Row>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -222,14 +222,11 @@ export const ShowContest = (props: Props) => {
             </TweetButton>
             {now < end ? (
               <GoogleCalendarButton
-                id={contestInfo.id}
+                contestId={contestInfo.id}
                 title={contestInfo.title}
                 startEpochSecond={start}
                 endEpochSecond={end}
-                color="primary"
-              >
-                Add to Google Calendar
-              </GoogleCalendarButton>
+              />
             ) : null}
           </ButtonGroup>
         </Col>


### PR DESCRIPTION
Resolves #1055.

## やったこと

バーチャルコンテストのページで、コンテストが終わってないなら「Add to Google Calendar」のボタンを追加しました。

## スクリーンショット

![Screenshot of virtual contest detail page](https://user-images.githubusercontent.com/6523469/132119343-dce93919-7279-4d62-9a62-80d76ea3f0f3.png)
![Screenshot of event creation page in Google Calendar](https://user-images.githubusercontent.com/6523469/132119321-6e400fab-75ba-4ee6-bd00-bc4e0371cbfa.png)
