### PR TITLE
fix: google calendar template issue

### DIFF
--- a/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
+++ b/atcoder-problems-frontend/src/components/GoogleCalendarButton.tsx
@@ -11,11 +11,15 @@ interface Props {
 /**
  * Google Calendar accepts a subset of ISO 8601 combined date and time.
  * Ref. https://stackoverflow.com/a/41733538
+ * Ref. (archived document) https://web.archive.org/web/20120313011336/http://www.google.com/googlecalendar/event_publisher_guide.html
  * @param epochSeconds Date to format in epoch seconds.
  * @return Date formatted to generate Google Calendar URL.
  */
-const formatDateForGoogleCalendar = (epochSeconds: number): string =>
-  new Date(epochSeconds * 1000).toISOString().replace(/[^0-9TZ]/g, "");
+const formatDateForGoogleCalendar = (epochSeconds: number): string => {
+  const isoStringWithoutMillisecond =
+    new Date(epochSeconds * 1000).toISOString().split(".")[0] + "Z";
+  return isoStringWithoutMillisecond.replace(/[^0-9TZ]/g, "");
+};
 
 export const GoogleCalendarButton: React.FC<Props> = (props) => {
   const internalUrl = `https://kenkoooo.com/atcoder/#/contest/show/${props.contestId}`;


### PR DESCRIPTION
バチャの日程をGoogleカレンダーに追加するボタンに設定されているURLのフォーマットが間違っていたので修正しました。([Reference](https://web.archive.org/web/20120313011336/http://www.google.com/googlecalendar/event_publisher_guide.html))
具体的にはミリ秒のところを削っています。

元のフォーマットでもブラウザで開くと問題ないっぽいのですが、スマホアプリ（iOSのGoogleカレンダーアプリ。バージョン略）で開くと間違った時間になります。

変更前の表示例：[このコンテスト](https://kenkoooo.com/atcoder/#/contest/show/4cd84705-f3b6-49da-8dc0-0d2fb67c699a)から Add to Google Calendar ボタンを押すと以下のようになります。
![screenshot](https://user-images.githubusercontent.com/25834248/132627118-7f07455f-6065-4b01-8d38-4689c3fa4f98.jpeg)
