### PR TITLE
TopcoderLikeCircle background bug fix

### DIFF
--- a/atcoder-problems-frontend/src/components/TopcoderLikeCircle.tsx
+++ b/atcoder-problems-frontend/src/components/TopcoderLikeCircle.tsx
@@ -32,11 +32,9 @@ const getStyleOptions = (
     const colorCode = getRatingColorCode(color, theme);
     return {
       borderColor: colorCode,
-      background: `linear-gradient(to top, \
-        ${colorCode} 0%, \
+      background: `border-box linear-gradient(to top, \
         ${colorCode} ${fillRatio * 100}%, \
-        rgba(0,0,0,0) ${fillRatio * 100}%, \
-        rgba(0,0,0,0) 100%)`,
+        rgba(0,0,0,0) ${fillRatio * 100}%)`,
     };
   }
 };


### PR DESCRIPTION
resolve #1049 
私の環境でもブラウザの拡大縮小を行うことで一部欠けることを確認しました。
borderとbackgroundが拡大率によって1pxずれてしまうことが原因だと思われたため、backgroundにborder-boxを追記してます。