### PR TITLE
RecentSubmissions の react-refetch を swr で置き換える

### DIFF
--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -287,3 +287,8 @@ export const useVirtualContestSubmissions = (
     }
   ).data;
 };
+
+export const useRecentSubmissions = () => {
+  const url = `${ATCODER_API_URL}/v3/recent`;
+  return useSWRData(url, (url) => fetchTypedArray(url, isSubmission));
+};

--- a/atcoder-problems-frontend/src/pages/RecentSubmissions.tsx
+++ b/atcoder-problems-frontend/src/pages/RecentSubmissions.tsx
@@ -1,23 +1,19 @@
 import React from "react";
 import { Alert, Row, Spinner } from "reactstrap";
-import { connect, PromiseState } from "react-refetch";
-import Submission from "../interfaces/Submission";
-import { fetchRecentSubmissions } from "../utils/Api";
+import { useRecentSubmissions } from "../api/APIClient";
 import { SubmissionListTable } from "../components/SubmissionListTable";
 
-interface Props {
-  submissions: PromiseState<Submission[]>;
-}
+export const RecentSubmissions = () => {
+  const submissionsResponse = useRecentSubmissions();
 
-const InnerRecentSubmissions: React.FC<Props> = (props) => {
-  if (props.submissions.pending) {
+  if (!submissionsResponse.data && !submissionsResponse.error) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
-  }
-  if (props.submissions.rejected) {
-    return <Alert color="danger">Failed to fetch contest info.</Alert>;
+  } else if (!submissionsResponse.data) {
+    return <Alert color="danger">Failed to fetch submission info.</Alert>;
   }
 
-  const submissions = props.submissions.value.sort((a, b) => b.id - a.id);
+  const submissions = submissionsResponse.data.sort((a, b) => b.id - a.id);
+
   return (
     <Row>
       <h1>Recent Submissions</h1>
@@ -25,10 +21,3 @@ const InnerRecentSubmissions: React.FC<Props> = (props) => {
     </Row>
   );
 };
-
-export const RecentSubmissions = connect<unknown, Props>(() => ({
-  submissions: {
-    comparison: null,
-    value: fetchRecentSubmissions,
-  },
-}))(InnerRecentSubmissions);

--- a/atcoder-problems-frontend/src/utils/Api.tsx
+++ b/atcoder-problems-frontend/src/utils/Api.tsx
@@ -4,12 +4,6 @@ import { hasPropertyAsType, isNumber } from "./TypeUtils";
 
 const ATCODER_API_URL = process.env.REACT_APP_ATCODER_API_URL;
 
-export const fetchRecentSubmissions = (): Promise<Submission[]> => {
-  return fetch(`${ATCODER_API_URL}/v3/recent`)
-    .then((r) => r.json())
-    .then((r: unknown[]) => r.filter(isSubmission));
-};
-
 export const fetchPartialUserSubmissions = async (
   userId: UserId,
   fromSecond: number


### PR DESCRIPTION
関連するissue: #905

RecentSubmissions の react-refetch を swr で置き換えました。


### ロード成功時の画面
<img width="1426" alt="スクリーンショット 2021-09-23 12 45 51" src="https://user-images.githubusercontent.com/56855963/134452433-d088f2fa-cf2d-485d-9580-f2e3526d39ee.png">

### ロード失敗時の画面
意図的に fetcher の URL を誤ったものにした場合。
<img width="1425" alt="スクリーンショット 2021-09-23 12 45 10" src="https://user-images.githubusercontent.com/56855963/134452505-d8c61975-95a1-4fe8-bc0a-09f85ca0b453.png">

