### PR TITLE
サーバーのログ出力形式をJSONにする

### DIFF
--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "atcoder-client",
  "chrono",
  "cookie",
+ "fern",
  "futures",
  "log",
  "rand 0.7.3",
@@ -358,7 +359,6 @@ dependencies = [
  "rust-s3",
  "serde",
  "serde_json",
- "simple_logger",
  "sql-client",
  "surf",
  "tide",
@@ -394,17 +394,6 @@ dependencies = [
  "serde_json",
  "url",
  "wildmatch",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1005,6 +994,15 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "fern"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2646,17 +2644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "simple_logger"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
-dependencies = [
- "atty",
- "log",
- "winapi",
 ]
 
 [[package]]

--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -626,17 +626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,8 +2655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
 dependencies = [
  "atty",
- "chrono",
- "colored",
  "log",
  "winapi",
 ]

--- a/atcoder-problems-backend/Cargo.toml
+++ b/atcoder-problems-backend/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 # Logging
 log = "0.4"
-simple_logger = {version = "1.11", default-features=false}
+fern = "0.6.0"
 
 rand = "0.7.3"
 chrono = "0.4"

--- a/atcoder-problems-backend/Cargo.toml
+++ b/atcoder-problems-backend/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 # Logging
 log = "0.4"
-simple_logger = "1.11"
+simple_logger = {version = "1.11", default-features=false}
 
 rand = "0.7.3"
 chrono = "0.4"

--- a/atcoder-problems-backend/src/utils.rs
+++ b/atcoder-problems-backend/src/utils.rs
@@ -1,5 +1,5 @@
+use fern;
 use log::LevelFilter;
-use simple_logger::SimpleLogger;
 
 use anyhow::Result;
 
@@ -24,11 +24,13 @@ pub const EXCLUDED_USERS: [&str; 17] = [
 ];
 
 pub fn init_log_config() -> Result<()> {
-    SimpleLogger::new()
-        .with_level(LevelFilter::Info)
-        .with_module_level("sqlx", LevelFilter::Warn)
-        .with_module_level("tide", LevelFilter::Warn)
-        .with_module_level("surf", LevelFilter::Warn)
-        .init()?;
+    fern::Dispatch::new()
+        .format(|out, message, _record| out.finish(format_args!("{}", message)))
+        .level(LevelFilter::Info)
+        .level_for("sqlx", LevelFilter::Warn)
+        .level_for("tide", LevelFilter::Warn)
+        .level_for("surf", LevelFilter::Warn)
+        .chain(std::io::stdout())
+        .apply()?;
     Ok(())
 }


### PR DESCRIPTION
#1006 
サーバのログをJSONのみにするために、`simple_logger` →`fern` crateに変更しました。