### PR TITLE
ContestUpdatePageのreact-refetch を置き換える

### DIFF
--- a/atcoder-problems-frontend/src/api/InternalAPIClient.ts
+++ b/atcoder-problems-frontend/src/api/InternalAPIClient.ts
@@ -4,6 +4,7 @@ import {
   UserResponse,
   VirtualContestDetails,
   VirtualContestInfo,
+  VirtualContestItem,
 } from "../pages/Internal/types";
 import { useSWRData } from "./index";
 
@@ -50,5 +51,11 @@ export const useProgressResetList = () => {
 export const useRecentContests = () => {
   return useSWRData(`${BASE_URL}/contest/recent`, (url) =>
     typeCastFetcher<VirtualContestInfo[]>(url)
+  );
+};
+
+export const useContestUpdate = () => {
+  return useSWRData(`${BASE_URL}/contest/update/`, (url) =>
+    typeCastFetcher<VirtualContestItem[]>(url)
   );
 };

--- a/atcoder-problems-frontend/src/api/InternalAPIClient.ts
+++ b/atcoder-problems-frontend/src/api/InternalAPIClient.ts
@@ -4,7 +4,6 @@ import {
   UserResponse,
   VirtualContestDetails,
   VirtualContestInfo,
-  VirtualContestItem,
 } from "../pages/Internal/types";
 import { useSWRData } from "./index";
 
@@ -51,11 +50,5 @@ export const useProgressResetList = () => {
 export const useRecentContests = () => {
   return useSWRData(`${BASE_URL}/contest/recent`, (url) =>
     typeCastFetcher<VirtualContestInfo[]>(url)
-  );
-};
-
-export const useContestUpdate = () => {
-  return useSWRData(`${BASE_URL}/contest/update/`, (url) =>
-    typeCastFetcher<VirtualContestItem[]>(url)
   );
 };

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ApiClient.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ApiClient.ts
@@ -66,7 +66,7 @@ export const updateVirtualContestItems = (
         order: i,
       })),
     }),
-  }).then(() => ({}));
+  }).then((response) => response);
 
 export const joinContest = (contestId: string) =>
   fetch(CONTEST_JOIN, {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
@@ -39,7 +39,7 @@ const createAndUpdateContest = async (
 export const ContestUpdatePage = (props: Props) => {
   const { contestId } = props;
   const contestResponse = useVirtualContest(contestId);
-  const [updateResponse, setUpdateResponse] = React.useState<boolean>();
+  const [updateResponse, setUpdateResponse] = React.useState<boolean>(false);
   if (!contestResponse.data && !contestResponse.error) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
   } else if (contestResponse.error || !contestResponse.data) {

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ContestUpdatePage.tsx
@@ -22,7 +22,7 @@ interface Request {
   penalty_second: number;
 }
 
-interface OuterProps {
+interface Props {
   contestId: string;
 }
 
@@ -33,13 +33,13 @@ const createAndUpdateContest = async (
   const response = await updateVirtualContestInfo(request).then(() =>
     updateVirtualContestItems(request.id, problems)
   );
-  return response.status;
+  return response.status === 200;
 };
 
-export const ContestUpdatePage = (props: OuterProps) => {
+export const ContestUpdatePage = (props: Props) => {
   const { contestId } = props;
   const contestResponse = useVirtualContest(contestId);
-  const [updateResponse, setUpdateResponse] = React.useState<number>();
+  const [updateResponse, setUpdateResponse] = React.useState<boolean>();
   if (!contestResponse.data && !contestResponse.error) {
     return <Spinner style={{ width: "3rem", height: "3rem" }} />;
   } else if (contestResponse.error || !contestResponse.data) {
@@ -49,7 +49,7 @@ export const ContestUpdatePage = (props: OuterProps) => {
   const contestInfo = contestResponse.data.info;
   const contestProblems = contestResponse.data.problems;
 
-  if (updateResponse === 200) {
+  if (updateResponse) {
     return <Redirect to={`/contest/show/${contestId}`} />;
   }
 


### PR DESCRIPTION
関連するissue: #905

- 実装内容
  - `connect`, `PromiseState`を削除
  - 不要になったコードを削除

- 機能
  - `updateVirtualContestItems`の返り値のステータスコードが200である時に更新が成功したとし、コンテスト詳細ページにリダイレクト