### PR TITLE
ユーザー検索画面を固定できるように

### DIFF
--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -31,26 +31,13 @@ import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { caseInsensitiveUserId } from "./utils";
 import { PROBLEM_ID_SEPARATE_SYMBOL } from "./utils/QueryString";
-import { UserSearchBar } from "./components/UserSearchBar";
 
 const App: React.FC = () => {
   return (
     <ThemeProvider>
       <Router>
         <div>
-          <div className="sticky-top">
-            <NavigationBar />
-          </div>
-
-          <Route
-            path={[
-              "/user/:userIds([a-zA-Z0-9_]+)+",
-              "/table/:userIds([a-zA-Z0-9_]*)*",
-              "/list/:userIds([a-zA-Z0-9_]*)*",
-            ]}
-          >
-            <UserSearchBar />
-          </Route>
+          <NavigationBar />
 
           <Container
             className="my-5"

--- a/atcoder-problems-frontend/src/App.tsx
+++ b/atcoder-problems-frontend/src/App.tsx
@@ -31,6 +31,7 @@ import { ACCOUNT_INFO } from "./utils/RouterPath";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { caseInsensitiveUserId } from "./utils";
 import { PROBLEM_ID_SEPARATE_SYMBOL } from "./utils/QueryString";
+import { UserSearchBar } from "./components/UserSearchBar";
 
 const App: React.FC = () => {
   return (
@@ -40,6 +41,16 @@ const App: React.FC = () => {
           <div className="sticky-top">
             <NavigationBar />
           </div>
+
+          <Route
+            path={[
+              "/user/:userIds([a-zA-Z0-9_]+)+",
+              "/table/:userIds([a-zA-Z0-9_]*)*",
+              "/list/:userIds([a-zA-Z0-9_]*)*",
+            ]}
+          >
+            <UserSearchBar />
+          </Route>
 
           <Container
             className="my-5"

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { NavLink as RouterLink } from "react-router-dom";
+import React, { useState } from "react";
+import { NavLink as RouterLink, Route } from "react-router-dom";
 import {
   Collapse,
   DropdownItem,
@@ -18,6 +18,7 @@ import { useLoginLink } from "../utils/Url";
 import { ACCOUNT_INFO } from "../utils/RouterPath";
 import * as UserState from "../utils/UserState";
 import { ThemeSelector } from "./ThemeSelector";
+import { UserSearchBar } from "./UserSearchBar";
 
 export const NavigationBar = () => {
   const loginState = useLoginState().data;
@@ -27,8 +28,10 @@ export const NavigationBar = () => {
 
   const [isOpen, setIsOpen] = React.useState(false);
 
+  const [isNavigationFixed, setIsNavigationFixed] = useState(true);
+
   return (
-    <>
+    <div className={isNavigationFixed ? "sticky-top" : ""}>
       <Navbar color="dark" dark expand="lg">
         <NavbarBrand tag={RouterLink} to="/" className="mb-0 h1">
           AtCoder Problems
@@ -167,6 +170,19 @@ export const NavigationBar = () => {
           </Nav>
         </Collapse>
       </Navbar>
-    </>
+
+      <Route
+        path={[
+          "/user/:userIds([a-zA-Z0-9_]+)+",
+          "/table/:userIds([a-zA-Z0-9_]*)*",
+          "/list/:userIds([a-zA-Z0-9_]*)*",
+        ]}
+      >
+        <UserSearchBar
+          isNavigationFixed={isNavigationFixed}
+          setIsNavigationFixed={() => setIsNavigationFixed((e) => !e)}
+        />
+      </Route>
+    </div>
   );
 };

--- a/atcoder-problems-frontend/src/components/NavigationBar.tsx
+++ b/atcoder-problems-frontend/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { NavLink as RouterLink, Route } from "react-router-dom";
+import { NavLink as RouterLink } from "react-router-dom";
 import {
   Collapse,
   DropdownItem,
@@ -17,7 +17,6 @@ import { useLoginState } from "../api/InternalAPIClient";
 import { useLoginLink } from "../utils/Url";
 import { ACCOUNT_INFO } from "../utils/RouterPath";
 import * as UserState from "../utils/UserState";
-import { UserSearchBar } from "./UserSearchBar";
 import { ThemeSelector } from "./ThemeSelector";
 
 export const NavigationBar = () => {
@@ -168,16 +167,6 @@ export const NavigationBar = () => {
           </Nav>
         </Collapse>
       </Navbar>
-
-      <Route
-        path={[
-          "/user/:userIds([a-zA-Z0-9_]+)+",
-          "/table/:userIds([a-zA-Z0-9_]*)*",
-          "/list/:userIds([a-zA-Z0-9_]*)*",
-        ]}
-      >
-        <UserSearchBar isOpen={isOpen} />
-      </Route>
     </>
   );
 };

--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { GoPin } from "react-icons/go";
 import {
   NavLink as RouterLink,
@@ -46,6 +46,11 @@ const extractUserIds = (
   return { userId, rivalIdString };
 };
 
+type Props = {
+  isNavigationFixed: boolean;
+  setIsNavigationFixed: () => void;
+};
+
 const generatePath = (
   kind: PageKind,
   userId: string,
@@ -55,7 +60,7 @@ const generatePath = (
   return "/" + kind + "/" + users.join("/");
 };
 
-export const UserSearchBar = () => {
+export const UserSearchBar = (props: Props) => {
   const { pathname } = useLocation();
   const loginState = useLoginState().data;
   const pageKind = extractPageKind(pathname);
@@ -65,8 +70,6 @@ export const UserSearchBar = () => {
   const pathRivalIdString = pathState?.rivalIdString;
 
   const loggedInUserId = UserState.loggedInUserId(loginState) ?? "";
-
-  const [userSearchBarIsFixed, setUserSearchBarIsFixed] = useState(false);
 
   const [userId, setUserId] = React.useState(pathUserId ?? "");
   const [rivalIdString, setRivalIdString] = React.useState(
@@ -106,7 +109,7 @@ export const UserSearchBar = () => {
       color="light"
       light
       expand="md"
-      className={`${userSearchBarIsFixed ? "sticky-top" : ""} border-bottom`}
+      className="border-bottom"
       style={{ padding: 0 }}
     >
       <Nav navbar style={{ padding: "0.5rem 1rem", width: "100%" }}>
@@ -169,8 +172,8 @@ export const UserSearchBar = () => {
             <Col className="col-auto">
               <Button
                 color="light"
-                active={userSearchBarIsFixed}
-                onClick={() => setUserSearchBarIsFixed((e) => !e)}
+                active={props.isNavigationFixed}
+                onClick={props.setIsNavigationFixed}
               >
                 <GoPin />
               </Button>

--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -46,10 +46,10 @@ const extractUserIds = (
   return { userId, rivalIdString };
 };
 
-type Props = {
+interface Props {
   isNavigationFixed: boolean;
   setIsNavigationFixed: () => void;
-};
+}
 
 const generatePath = (
   kind: PageKind,

--- a/atcoder-problems-frontend/src/components/UserSearchBar.tsx
+++ b/atcoder-problems-frontend/src/components/UserSearchBar.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { GoPin } from "react-icons/go";
 import {
   NavLink as RouterLink,
   useLocation,
@@ -7,11 +8,13 @@ import {
 import {
   Button,
   ButtonGroup,
+  Col,
   Form,
   Input,
   Nav,
   Navbar,
-  Collapse,
+  NavItem,
+  Row,
 } from "reactstrap";
 import { useLoginState } from "../api/InternalAPIClient";
 import { extractRivalsParam, normalizeUserId } from "../utils";
@@ -43,10 +46,6 @@ const extractUserIds = (
   return { userId, rivalIdString };
 };
 
-interface Props {
-  isOpen: boolean;
-}
-
 const generatePath = (
   kind: PageKind,
   userId: string,
@@ -56,7 +55,7 @@ const generatePath = (
   return "/" + kind + "/" + users.join("/");
 };
 
-export const UserSearchBar = (props: Props) => {
+export const UserSearchBar = () => {
   const { pathname } = useLocation();
   const loginState = useLoginState().data;
   const pageKind = extractPageKind(pathname);
@@ -66,6 +65,8 @@ export const UserSearchBar = (props: Props) => {
   const pathRivalIdString = pathState?.rivalIdString;
 
   const loggedInUserId = UserState.loggedInUserId(loginState) ?? "";
+
+  const [userSearchBarIsFixed, setUserSearchBarIsFixed] = useState(false);
 
   const [userId, setUserId] = React.useState(pathUserId ?? "");
   const [rivalIdString, setRivalIdString] = React.useState(
@@ -105,11 +106,11 @@ export const UserSearchBar = (props: Props) => {
       color="light"
       light
       expand="md"
-      className="border-bottom"
+      className={`${userSearchBarIsFixed ? "sticky-top" : ""} border-bottom`}
       style={{ padding: 0 }}
     >
-      <Collapse isOpen={props.isOpen} navbar>
-        <Nav navbar style={{ padding: "0.5rem 1rem" }}>
+      <Nav navbar style={{ padding: "0.5rem 1rem", width: "100%" }}>
+        <NavItem>
           <Form inline>
             <Input
               className="mt-2 mr-2 mt-lg-0 mt-md-0"
@@ -126,7 +127,6 @@ export const UserSearchBar = (props: Props) => {
               placeholder={loggedInUserId ? loggedInUserId : "User ID"}
               onChange={(e): void => setUserId(e.target.value)}
             />
-
             <Input
               className="mt-2 mr-2 mt-lg-0 mt-md-0"
               style={{ width: 160 }}
@@ -142,28 +142,42 @@ export const UserSearchBar = (props: Props) => {
               placeholder="Rival ID, ..."
               onChange={(e): void => setRivalIdString(e.target.value)}
             />
-
-            <ButtonGroup className="mt-2 mb-0 mt-lg-0 mt-md-0">
-              <Button tag={RouterLink} to={tablePath} color="light">
-                Table
-              </Button>
-
-              <Button tag={RouterLink} to={listPath} color="light">
-                List
-              </Button>
-
-              <Button
-                disabled={userId.length === 0 && loggedInUserId.length === 0}
-                tag={RouterLink}
-                to={userPath}
-                color="light"
-              >
-                User
-              </Button>
-            </ButtonGroup>
           </Form>
-        </Nav>
-      </Collapse>
+        </NavItem>
+        <NavItem style={{ flexGrow: 1 }}>
+          <Row className="justify-content-between align-items-center">
+            <Col className="col-auto">
+              <ButtonGroup className="mt-2 mb-0 mt-lg-0 mt-md-0">
+                <Button tag={RouterLink} to={tablePath} color="light">
+                  Table
+                </Button>
+
+                <Button tag={RouterLink} to={listPath} color="light">
+                  List
+                </Button>
+
+                <Button
+                  disabled={userId.length === 0 && loggedInUserId.length === 0}
+                  tag={RouterLink}
+                  to={userPath}
+                  color="light"
+                >
+                  User
+                </Button>
+              </ButtonGroup>
+            </Col>
+            <Col className="col-auto">
+              <Button
+                color="light"
+                active={userSearchBarIsFixed}
+                onClick={() => setUserSearchBarIsFixed((e) => !e)}
+              >
+                <GoPin />
+              </Button>
+            </Col>
+          </Row>
+        </NavItem>
+      </Nav>
     </Navbar>
   );
 };


### PR DESCRIPTION
Fix: #1054 
- ユーザー検索をナビゲーションから外し、モバイル表示で常に表示されるよう変更しました
- 上部ナビゲーションの固定・固定解除が行えるようにしました

https://user-images.githubusercontent.com/64473501/141733717-be1ff5e3-061e-4e6b-befe-bf645c1e5544.mov


https://user-images.githubusercontent.com/64473501/141733727-de05c30d-c333-48c5-8a28-ba0e8b89c89d.mov



