### PR TITLE
ResetProgressのreact-refetch を置き換える

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/ApiClient.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/ApiClient.ts
@@ -1,0 +1,25 @@
+import { PROGRESS_RESET_ADD, PROGRESS_RESET_DELETE } from "../ApiUrl";
+import { getCurrentUnixtimeInSecond } from "../../../utils/DateUtil";
+
+export const addResetProgress = (problemId: string) =>
+  fetch(PROGRESS_RESET_ADD, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      problem_id: problemId,
+      reset_epoch_second: getCurrentUnixtimeInSecond(),
+    }),
+  });
+
+export const deleteResetProgress = (problemId: string) =>
+  fetch(PROGRESS_RESET_DELETE, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      problem_id: problemId,
+    }),
+  });


### PR DESCRIPTION
関連するissue: #905

- やったこと
  - `react-refetch`を`swr`, `fetch`に置き換えた
  - それに伴い不要になったコードを削除

- addResetProgress

https://user-images.githubusercontent.com/73219274/142984520-5e66e7cb-06e9-4633-ad44-5b9156ad9ced.mov

- deleteResetProgress

https://user-images.githubusercontent.com/73219274/142984551-2dc3ce02-55a5-4cdc-83a6-8913f73afa21.mov