### PR TITLE
ABC の Ex 問題の配置を修正

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -17,7 +17,7 @@ import {
   combineTableColorList,
 } from "../../utils/TableColor";
 import { ProblemLink } from "../../components/ProblemLink";
-import { ContestLink } from "../../components/ContestLink";
+import { ContestLink, getRatedTarget } from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
 import { SubmitTimespan } from "../../components/SubmitTimespan";
 import { RatingInfo } from "../../utils/RatingInfo";
@@ -36,9 +36,11 @@ interface Props {
   userRatingInfo: RatingInfo;
 }
 
-const getProblemHeaderAlphabetFromTitle = (problem: MergedProblem) => {
+const getProblemHeaderAlphabet = (problem: MergedProblem, contest: Contest) => {
   const list = problem.title.split(".");
-  return list.length === 0 ? "" : list[0];
+  if (list.length === 0) return "";
+  if (list[0] === "H" && getRatedTarget(contest) < 2000) return "Ex";
+  return list[0];
 };
 
 const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
@@ -80,7 +82,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
       });
       const problemStatus = new Map(
         problemStatusList.map((status) => {
-          const alphabet = getProblemHeaderAlphabetFromTitle(status.problem);
+          const alphabet = getProblemHeaderAlphabet(status.problem, contest);
           return [alphabet, status];
         })
       );
@@ -107,11 +109,17 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
     );
 
   const headerList = props.contests
-    .flatMap((contest) => props.contestToProblems.get(contest.id) ?? [])
-    .map((problem) => getProblemHeaderAlphabetFromTitle(problem))
+    .flatMap((contest) =>
+      (props.contestToProblems.get(contest.id) ?? []).map((problem) =>
+        getProblemHeaderAlphabet(problem, contest)
+      )
+    )
     .filter((alphabet) => alphabet.length > 0);
 
-  const header = Array.from(new Set(headerList)).sort();
+  let header = Array.from(new Set(headerList));
+  if (header.includes("Ex"))
+    header = header.filter((c) => c != "Ex").concat("Ex");
+
   return (
     <Row className="my-4">
       <h2>{props.title}</h2>


### PR DESCRIPTION
close: #1088 

Issue に取りかかる旨の報告がわからずに勝手に進めてしまったので，問題があれば close します。

## 変更内容
- 問題名からアルファベットを取得するところで，ABC or ABC-like であれば `H` を `Ex` に変換
- A[B/R/G]C(-like) では `Ex` 問題はすべて問題の末尾に配置するように変更

![image](https://user-images.githubusercontent.com/25224540/147389068-0f13104b-7d8b-4845-82c5-3ececcb42fe6.png)
