### PR TITLE
UserPageのPieChartsでABC-Exのバグを修正

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -186,8 +186,9 @@ const PieCharts: React.FC<PieChartsProps> = ({ problems, title }) => (
     </Row>
     <Row className="my-3">
       {problems.map(({ solved, rejected, total }, i) => {
-        const key = "ABCDEFGH".charAt(i);
-        if(i==7)key="Ex";
+        const key;
+        if(i<=6)key = "ABCDEFG".charAt(i);
+        if(i==7)key = "H/Ex";
         return (
           <Col
             key={key}

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -53,7 +53,7 @@ const solvedCountForPieChart = (
       case "G": {
         return 6;
       }
-      case "H": 
+      case "H":
       case "Ex": {
         return 7;
       }

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -187,6 +187,7 @@ const PieCharts: React.FC<PieChartsProps> = ({ problems, title }) => (
     <Row className="my-3">
       {problems.map(({ solved, rejected, total }, i) => {
         const key = "ABCDEFGH".charAt(i);
+        if(i==7)key="Ex";
         return (
           <Col
             key={key}

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -186,7 +186,7 @@ const PieCharts: React.FC<PieChartsProps> = ({ problems, title }) => (
     </Row>
     <Row className="my-3">
       {problems.map(({ solved, rejected, total }, i) => {
-        const key = (i<=6? "ABCDEFG".charAt(i):"H/Ex");
+        const key = i <= 6 ? "ABCDEFG".charAt(i) : "H/Ex";
         return (
           <Col
             key={key}

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -186,9 +186,7 @@ const PieCharts: React.FC<PieChartsProps> = ({ problems, title }) => (
     </Row>
     <Row className="my-3">
       {problems.map(({ solved, rejected, total }, i) => {
-        const key;
-        if(i<=6)key = "ABCDEFG".charAt(i);
-        if(i==7)key = "H/Ex";
+        const key = (i<=6? "ABCDEFG".charAt(i):"H/Ex");
         return (
           <Col
             key={key}

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -53,7 +53,8 @@ const solvedCountForPieChart = (
       case "G": {
         return 6;
       }
-      case "H": {
+      case "H": 
+      case "Ex": {
         return 7;
       }
       default: {


### PR DESCRIPTION
close #1091
勝手に進めてしまったので、問題があったらCloseします。
## 変更内容
・ABC-ExがABC-Aとして集計されているバグを修正し、ABC-HとABC-Exをまとめて集計するように変更
・UserPageのPieChartsでProblem H/Exと表示するよう変更
![image](https://user-images.githubusercontent.com/76619232/147393363-6603e443-6197-472b-8449-a0a11cb75876.png)
