### PR TITLE
TablePageのAGC-Like で H問題がEx問題になるバグを修正

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -17,11 +17,12 @@ import {
   combineTableColorList,
 } from "../../utils/TableColor";
 import { ProblemLink } from "../../components/ProblemLink";
-import { ContestLink, getRatedTarget } from "../../components/ContestLink";
+import { ContestLink } from "../../components/ContestLink";
 import ProblemModel from "../../interfaces/ProblemModel";
 import { SubmitTimespan } from "../../components/SubmitTimespan";
 import { RatingInfo } from "../../utils/RatingInfo";
 import { ProblemPoint } from "../../components/Problempoint";
+import { classifyContest } from "../../utils/ContestClassifier";
 
 interface Props {
   contests: Contest[];
@@ -39,7 +40,8 @@ interface Props {
 const getProblemHeaderAlphabet = (problem: MergedProblem, contest: Contest) => {
   const list = problem.title.split(".");
   if (list.length === 0) return "";
-  if (list[0] === "H" && getRatedTarget(contest) < 2000) return "Ex";
+  if (list[0] === "H" && classifyContest(contest).startsWith("ABC"))
+    return "Ex";
   return list[0];
 };
 
@@ -116,7 +118,7 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
     )
     .filter((alphabet) => alphabet.length > 0);
 
-  let header = Array.from(new Set(headerList));
+  let header = Array.from(new Set(headerList)).sort();
   if (header.includes("Ex"))
     header = header.filter((c) => c != "Ex").concat("Ex");
 


### PR DESCRIPTION
resolves #1093  
`getRatedTarget(contest)` が `number` でないときに、`getRatedTarget(contest) < 2000` が `true` と評価されていたようです。
contest が ABC かの判定にhttps://github.com/kenkoooo/AtCoderProblems/blob/master/atcoder-problems-frontend/src/utils/ContestClassifier.ts
を使うようにしました。
![image](https://user-images.githubusercontent.com/63996969/147414752-e264385c-e2f6-4b65-9a5d-74a1c64394e2.png)
