### PR TITLE
VirtualContest Problems show user acceptances

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -89,7 +89,9 @@ const getPerformanceByUserId = (
   }
 };
 
-const constructPointOverrideMap = <T extends { item: VirtualContestItem }>(
+export const constructPointOverrideMap = <
+  T extends { item: VirtualContestItem }
+>(
   problems: T[]
 ) => {
   const pointOverrideMap = new Map<ProblemId, number>();

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -20,7 +20,11 @@ import {
   NavItem,
   NavLink,
 } from "reactstrap";
-import { useMergedProblemMap } from "../../../../api/APIClient";
+import { FcCancel, FcCheckmark } from "react-icons/all";
+import {
+  useMergedProblemMap,
+  useVirtualContestSubmissions,
+} from "../../../../api/APIClient";
 import {
   useLoginState,
   useVirtualContest,
@@ -45,12 +49,49 @@ import { generatePathWithParams } from "../../../../utils/QueryString";
 import { ProblemLink } from "../../../../components/ProblemLink";
 import { joinContest, leaveContest } from "../ApiClient";
 import { GoogleCalendarButton } from "../../../../components/GoogleCalendarButton";
-import { ContestTable } from "./ContestTable";
+import { ProblemId, UserId } from "../../../../interfaces/Status";
+import { constructPointOverrideMap, ContestTable } from "./ContestTable";
 import { LockoutContestTable } from "./LockoutContestTable";
 import { TrainingContestTable } from "./TrainingContestTable";
 import { compareProblem } from "./util";
+import {
+  ReducedProblemResult,
+  reduceUserContestResult,
+} from "./ResultCalcUtil";
 
-const Problems = (props: { problems: VirtualContestProblem[] }) => {
+const Problems = (props: {
+  readonly problems: VirtualContestProblem[];
+  readonly atCoderUserId: UserId;
+  readonly start: number;
+  readonly end: number;
+}) => {
+  const submissions = useVirtualContestSubmissions(
+    [props.atCoderUserId],
+    props.problems.map((p) => p.item.id),
+    props.start,
+    props.end,
+    false
+  );
+  const pointOverrideMap = constructPointOverrideMap(props.problems);
+  const showUserResults =
+    props.atCoderUserId !== "" &&
+    submissions.data !== null &&
+    submissions.data !== undefined;
+  const results = submissions.data
+    ? reduceUserContestResult(submissions.data, (id) =>
+        pointOverrideMap.get(id)
+      )
+    : new Map<UserId, ReducedProblemResult>();
+  const ResultIcon = (props: { id: ProblemId }) => {
+    const result = results.get(props.id);
+    if (!result) return null;
+    if (result.accepted) {
+      return <FcCheckmark />;
+    } else {
+      return <FcCancel />;
+    }
+  };
+
   const sortedItems = props.problems
     .map((p) => ({
       contestId: p.contestId,
@@ -58,6 +99,7 @@ const Problems = (props: { problems: VirtualContestProblem[] }) => {
       ...p.item,
     }))
     .sort(compareProblem);
+
   return (
     <div className="my-2">
       <Row>
@@ -75,12 +117,13 @@ const Problems = (props: { problems: VirtualContestProblem[] }) => {
       </Row>
       <Row>
         <Col>
-          <Table striped size="sm">
+          <Table striped bordered size="sm">
             <thead>
               <tr>
                 <th> </th>
                 <th>Problem Name</th>
                 <th className="text-center">Score</th>
+                {showUserResults && <th> </th>}
               </tr>
             </thead>
             <tbody>
@@ -109,6 +152,11 @@ const Problems = (props: { problems: VirtualContestProblem[] }) => {
                     )}
                   </td>
                   <td className="text-center">{p.point !== null && p.point}</td>
+                  {showUserResults && (
+                    <td className="text-center">
+                      <ResultIcon id={p.id} />
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>
@@ -218,7 +266,7 @@ const TAB_PARAM = "activeTab";
 
 const NormalContestPage = (props: StandingsProps) => {
   const location = useLocation();
-  const { showProblems, problems } = props;
+  const { showProblems } = props;
   const tabs: NormalContestTabType[] = showProblems
     ? ["Problems", "Standings"]
     : ["Standings"];
@@ -253,7 +301,7 @@ const NormalContestPage = (props: StandingsProps) => {
         </Col>
       </Row>
 
-      {activeTab === "Problems" && <Problems problems={problems} />}
+      {activeTab === "Problems" && <Problems {...props} />}
       {activeTab === "Standings" && <Standings {...props} />}
     </>
   );

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -264,7 +264,13 @@ const NormalContestTabTypes = ["Problems", "Standings"] as const;
 type NormalContestTabType = typeof NormalContestTabTypes[number];
 const TAB_PARAM = "activeTab";
 
-const NormalContestPage = (props: StandingsProps) => {
+interface NormalContestPageProps extends StandingsProps {
+  readonly enableEstimatedPerformances: boolean;
+  readonly atCoderUserId: string;
+  readonly penaltySecond: number;
+}
+
+const NormalContestPage = (props: NormalContestPageProps) => {
   const location = useLocation();
   const { showProblems } = props;
   const tabs: NormalContestTabType[] = showProblems


### PR DESCRIPTION
Support #1077 (Please close this issue manually if requests are satisfied)

# Implementations
- Show user status, {AC, WA, none} , for each problems as iconic images at right-edge.
  Status-Icon column is enabled if user logged in and joined current contest.
- Enable table border to improve visibility and unify design with other UIs.

![scrnli_2021_12_27 3-09-48](https://user-images.githubusercontent.com/8394202/147416652-714ebd55-2e24-4f17-9d91-c7d1940151a3.png)
![scrnli_2021_12_27 3-10-42](https://user-images.githubusercontent.com/8394202/147416655-5a421772-1b03-4f40-abb9-e3f851ceb113.png)

