### PR TITLE
ABCの問題表のヘッダーのExをH/Exに

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -40,8 +40,12 @@ interface Props {
 const getProblemHeaderAlphabet = (problem: MergedProblem, contest: Contest) => {
   const list = problem.title.split(".");
   if (list.length === 0) return "";
-  if (list[0] === "H" && classifyContest(contest).startsWith("ABC"))
-    return "Ex";
+  console.log(list);
+  if (
+    (list[0] === "H" || list[0] === "Ex") &&
+    classifyContest(contest).startsWith("ABC")
+  )
+    return "H/Ex";
   return list[0];
 };
 

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -40,7 +40,6 @@ interface Props {
 const getProblemHeaderAlphabet = (problem: MergedProblem, contest: Contest) => {
   const list = problem.title.split(".");
   if (list.length === 0) return "";
-  console.log(list);
   if (
     (list[0] === "H" || list[0] === "Ex") &&
     classifyContest(contest).startsWith("ABC")


### PR DESCRIPTION
ABCの最後の問題はHの方が多くてExだと違和感を感じるのでH/Exのようにした方が自然かなと感じましたのでPR送らさせて頂きました。
↓修正前
![image](https://user-images.githubusercontent.com/60128781/147906075-f9f958f3-b56d-4748-967a-d4cb2f4d9aa4.png)
↓修正後
![image](https://user-images.githubusercontent.com/60128781/147906117-5441d683-dca0-4ebd-b6bc-959488955a3b.png)
