### PR TITLE
ContestProblem に problem_index を追加する

### DIFF
--- a/atcoder-problems-backend/atcoder-client/src/atcoder/problem.rs
+++ b/atcoder-problems-backend/atcoder-client/src/atcoder/problem.rs
@@ -89,4 +89,35 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn test_scrape_atc002() {
+        let mut file = File::open("test_resources/atc002_tasks").unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        let problems = scrape(&contents, "atc002").unwrap();
+        assert_eq!(
+            problems,
+            vec![
+                AtCoderProblem {
+                    id: "abc007_3".to_owned(),
+                    contest_id: "atc002".to_owned(),
+                    title: "幅優先探索".to_owned(),
+                    position: "A".to_owned(),
+                },
+                AtCoderProblem {
+                    id: "atc002_b".to_owned(),
+                    contest_id: "atc002".to_owned(),
+                    title: "n^p mod m".to_owned(),
+                    position: "B".to_owned(),
+                },
+                AtCoderProblem {
+                    id: "atc002_c".to_owned(),
+                    contest_id: "atc002".to_owned(),
+                    title: "最適二分探索木".to_owned(),
+                    position: "C".to_owned(),
+                },
+            ]
+        )
+    }
 }

--- a/atcoder-problems-backend/atcoder-client/test_resources/atc002_tasks
+++ b/atcoder-problems-backend/atcoder-client/test_resources/atc002_tasks
@@ -1,0 +1,379 @@
+
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Tasks - AtCoder Typical Contest 002</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta http-equiv="Content-Language" content="en">
+	<meta name="viewport" content="width=device-width,initial-scale=1.0">
+	<meta name="format-detection" content="telephone=no">
+	<meta name="google-site-verification" content="nXGC_JxO0yoP1qBzMnYD_xgufO6leSLw1kyNo2HZltM" />
+
+	
+	<meta name="description" content="AtCoder is a programming contest site for anyone from beginners to experts. We hold weekly programming contests online.">
+	<meta name="author" content="AtCoder Inc.">
+
+	<meta property="og:site_name" content="AtCoder">
+	
+	<meta property="og:title" content="Tasks - AtCoder Typical Contest 002" />
+	<meta property="og:description" content="AtCoder is a programming contest site for anyone from beginners to experts. We hold weekly programming contests online." />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://atcoder.jp/contests/atc002/tasks" />
+	<meta property="og:image" content="https://img.atcoder.jp/assets/atcoder.png" />
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:site" content="@atcoder" />
+	
+	<meta property="twitter:title" content="Tasks - AtCoder Typical Contest 002" />
+
+	<link href="//fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
+	<link rel="stylesheet" type="text/css" href="//img.atcoder.jp/public/4432a1b/css/bootstrap.min.css">
+	<link rel="stylesheet" type="text/css" href="//img.atcoder.jp/public/4432a1b/css/base.css">
+	<link rel="shortcut icon" type="image/png" href="//img.atcoder.jp/assets/favicon.png">
+	<link rel="apple-touch-icon" href="//img.atcoder.jp/assets/atcoder.png">
+	<script src="//img.atcoder.jp/public/4432a1b/js/lib/jquery-1.9.1.min.js"></script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/lib/bootstrap.min.js"></script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/cdn/js.cookie.min.js"></script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/cdn/moment.min.js"></script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/cdn/moment_js-ja.js"></script>
+	<script>
+		var LANG = "en";
+		var userScreenName = "southball";
+		var csrfToken = "0OhlGn64VX1TtiJgQ0iNp7JWaUCJTPdkLh84D1xsMl4="
+	</script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/utils.js"></script>
+	
+	
+		<script src="//img.atcoder.jp/public/4432a1b/js/contest.js"></script>
+		<link href="//img.atcoder.jp/public/4432a1b/css/contest.css" rel="stylesheet" />
+		<script>
+			var contestScreenName = "atc002";
+			var remainingText = "Remaining Time";
+			var countDownText = "Contest begins in";
+			var startTime = moment("2016-04-10T21:00:00+09:00");
+			var endTime = moment("2016-04-10T22:30:00+09:00");
+		</script>
+		<style></style>
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	<script src="//img.atcoder.jp/public/4432a1b/js/base.js"></script>
+	<script src="//img.atcoder.jp/public/4432a1b/js/ga.js"></script>
+</head>
+
+<body>
+
+<script type="text/javascript">
+	var __pParams = __pParams || [];
+	__pParams.push({client_id: '468', c_1: 'atcodercontest', c_2: 'ClientSite'});
+</script>
+<script type="text/javascript" src="https://cdn.d2-apps.net/js/tr.js" async></script>
+
+
+<div id="modal-contest-start" class="modal fade" tabindex="-1" role="dialog">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+				<h4 class="modal-title">Contest started</h4>
+			</div>
+			<div class="modal-body">
+				<p>AtCoder Typical Contest 002 has begun.</p>
+			</div>
+			<div class="modal-footer">
+				
+					<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+				
+			</div>
+		</div>
+	</div>
+</div>
+<div id="modal-contest-end" class="modal fade" tabindex="-1" role="dialog">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+				<h4 class="modal-title">Contest is over</h4>
+			</div>
+			<div class="modal-body">
+				<p>AtCoder Typical Contest 002 has ended.</p>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+			</div>
+		</div>
+	</div>
+</div>
+<div id="main-div" class="float-container">
+
+
+	<nav class="navbar navbar-inverse navbar-fixed-top">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+					<span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span>
+				</button>
+				<a class="navbar-brand" href="/home"></a>
+			</div>
+			<div class="collapse navbar-collapse" id="navbar-collapse">
+				<ul class="nav navbar-nav">
+				
+					<li><a class="contest-title" href="/contests/atc002">AtCoder Typical Contest 002</a></li>
+				
+				</ul>
+				<ul class="nav navbar-nav navbar-right">
+					
+					<li class="dropdown">
+						<a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+							<img src='//img.atcoder.jp/assets/top/img/flag-lang/en.png'> English <span class="caret"></span>
+						</a>
+						<ul class="dropdown-menu">
+							<li><a href="/contests/atc002/tasks?lang=ja"><img src='//img.atcoder.jp/assets/top/img/flag-lang/ja.png'> 日本語</a></li>
+							<li><a href="/contests/atc002/tasks?lang=en"><img src='//img.atcoder.jp/assets/top/img/flag-lang/en.png'> English</a></li>
+						</ul>
+					</li>
+					
+					
+						<li class="dropdown">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+								<span class="glyphicon glyphicon-cog" aria-hidden="true"></span> southball (Guest) <span class="caret"></span>
+							</a>
+							<ul class="dropdown-menu">
+								<li><a href="/users/southball"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> My Profile</a></li>
+								<li class="divider"></li>
+								<li><a href="/settings"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> General Settings</a></li>
+								<li><a href="/settings/icon"><span class="glyphicon glyphicon-picture" aria-hidden="true"></span> Change Photo</a></li>
+								<li><a href="/settings/password"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span> Change Password</a></li>
+								<li><a href="/settings/fav"><span class="glyphicon glyphicon-star" aria-hidden="true"></span> Manage Fav</a></li>
+								
+								
+								
+								<li class="divider"></li>
+								<li><a href="javascript:void(form_logout.submit())"><span class="glyphicon glyphicon-log-out" aria-hidden="true"></span> Sign Out</a></li>
+							</ul>
+						</li>
+					
+				</ul>
+			</div>
+		</div>
+	</nav>
+
+	<form method="POST" name="form_logout" action="/logout?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Fatc002%2Ftasks">
+		<input type="hidden" name="csrf_token" value="0OhlGn64VX1TtiJgQ0iNp7JWaUCJTPdkLh84D1xsMl4=" />
+	</form>
+	<div id="main-container" class="container"
+		 	style="padding-top:50px;">
+		
+
+
+<div class="row">
+	<div id="contest-nav-tabs" class="col-sm-12 mb-2 cnvtb-fixed">
+	<div>
+		<small class="contest-duration">
+			
+				Contest Duration:
+				<a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20160410T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2016-04-10 21:00:00+0900</time></a> - <a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20160410T2230&p1=248' target='blank'><time class='fixtime fixtime-full'>2016-04-10 22:30:00+0900</time></a> (local time)
+				(90 minutes)
+			
+		</small>
+		<small class="back-to-home pull-right"><a href="/home">Back to Home</a></small>
+	</div>
+	<ul class="nav nav-tabs">
+		<li><a href="/contests/atc002"><span class="glyphicon glyphicon-home" aria-hidden="true"></span> Top</a></li>
+		
+			<li class="active"><a href="/contests/atc002/tasks"><span class="glyphicon glyphicon-tasks" aria-hidden="true"></span> Tasks</a></li>
+		
+
+		
+			<li><a href="/contests/atc002/clarifications"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span> Clarifications <span id="clar-badge" class="badge"></span></a></li>
+		
+
+		
+			<li><a href="/contests/atc002/submit"><span class="glyphicon glyphicon-send" aria-hidden="true"></span> Submit</a></li>
+		
+
+		
+			<li>
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-list" aria-hidden="true"></span> Results<span class="caret"></span></a>
+				<ul class="dropdown-menu">
+					<li><a href="/contests/atc002/submissions"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> All Submissions</a></li>
+					
+						<li><a href="/contests/atc002/submissions/me"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> My Submissions</a></li>
+						<li class="divider"></li>
+						<li><a href="/contests/atc002/score"><span class="glyphicon glyphicon-dashboard" aria-hidden="true"></span> My Score</a></li>
+					
+				</ul>
+			</li>
+		
+
+		
+			
+				
+					<li><a href="/contests/atc002/standings"><span class="glyphicon glyphicon-sort-by-attributes-alt" aria-hidden="true"></span> Standings</a></li>
+				
+			
+				
+					<li><a href="/contests/atc002/standings/virtual"><span class="glyphicon glyphicon-sort-by-attributes-alt" aria-hidden="true"></span> Virtual Standings</a></li>
+				
+			
+		
+
+		
+			<li><a href="/contests/atc002/custom_test"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Custom Test</a></li>
+		
+
+		
+			<li><a href="/contests/atc002/editorial"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Editorial</a></li>
+		
+		
+			
+			
+		
+
+		<li class="pull-right"><a id="fix-cnvtb" href="javascript:void(0)"><span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span></a></li>
+	</ul>
+</div>
+	<div class="col-sm-12">
+		<h2>Tasks</h2>
+		<hr>
+		
+			<div class="panel panel-default table-responsive"><table class="table table-bordered table-striped">
+				<thead>
+					<tr>
+						<th width="3%" class="text-center"></th>
+						<th>Task Name</th>
+						<th width="10%" class="text-right no-break">Time Limit</th>
+						<th width="10%" class="text-right no-break">Memory Limit</th>
+						<th width="5%"></th>
+					</tr>
+				</thead>
+				<tbody>
+					
+						<tr>
+							<td class="text-center no-break"><a href="/contests/atc002/tasks/abc007_3">A</a></td>
+							<td><a href="/contests/atc002/tasks/abc007_3">幅優先探索</a></td>
+							<td class="text-right">2 sec</td>
+							<td class="text-right">256 MB</td>
+							
+								<td class="no-break text-center">
+									
+										<a href="/contests/atc002/submit?taskScreenName=abc007_3">Submit</a>
+									
+									
+								</td>
+							
+						</tr>
+					
+						<tr>
+							<td class="text-center no-break"><a href="/contests/atc002/tasks/atc002_b">B</a></td>
+							<td><a href="/contests/atc002/tasks/atc002_b">n^p mod m</a></td>
+							<td class="text-right">2 sec</td>
+							<td class="text-right">256 MB</td>
+							
+								<td class="no-break text-center">
+									
+										<a href="/contests/atc002/submit?taskScreenName=atc002_b">Submit</a>
+									
+									
+								</td>
+							
+						</tr>
+					
+						<tr>
+							<td class="text-center no-break"><a href="/contests/atc002/tasks/atc002_c">C</a></td>
+							<td><a href="/contests/atc002/tasks/atc002_c">最適二分探索木</a></td>
+							<td class="text-right">2 sec</td>
+							<td class="text-right">256 MB</td>
+							
+								<td class="no-break text-center">
+									
+										<a href="/contests/atc002/submit?taskScreenName=atc002_c">Submit</a>
+									
+									
+								</td>
+							
+						</tr>
+					
+				</tbody>
+			</table></div>
+		
+		<p class="btn-text-group">
+			
+			
+				<a class="btn-text" href="/contests/atc002/score">My Score</a>
+				<span class="divider"></span>
+			
+			<a class="btn-text" href="/contests/atc002/tasks_print">Tasks for printing</a>
+		</p>
+		
+		
+		
+	</div>
+</div>
+
+
+
+
+		
+			<hr>
+			
+			
+			
+<div class="a2a_kit a2a_kit_size_20 a2a_default_style pull-right" data-a2a-url="https://atcoder.jp/contests/atc002/tasks?lang=en" data-a2a-title="Tasks - AtCoder Typical Contest 002">
+	<a class="a2a_button_facebook"></a>
+	<a class="a2a_button_twitter"></a>
+	
+		<a class="a2a_button_telegram"></a>
+	
+	<a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+</div>
+
+		
+		<script async src="//static.addtoany.com/menu/page.js"></script>
+		
+	</div> 
+	<hr>
+</div> 
+
+	<div class="container" style="margin-bottom: 80px;">
+			<footer class="footer">
+			
+				<ul>
+					<li><a href="/contests/atc002/rules">Rule</a></li>
+					<li><a href="/contests/atc002/glossary">Glossary</a></li>
+					
+				</ul>
+			
+			<ul>
+				<li><a href="/tos">Terms of service</a></li>
+				<li><a href="/privacy">Privacy Policy</a></li>
+				<li><a href="/personal">Information Protection Policy</a></li>
+				<li><a href="/company">Company</a></li>
+				<li><a href="/faq">FAQ</a></li>
+				<li><a href="/contact">Contact</a></li>
+				
+			</ul>
+			<div class="text-center">
+					<small id="copyright">Copyright Since 2012 &copy;<a href="http://atcoder.co.jp">AtCoder Inc.</a> All rights reserved.</small>
+			</div>
+			</footer>
+	</div>
+	<p id="fixed-server-timer" class="contest-timer"></p>
+	<div id="scroll-page-top" style="display:none;"><span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span> Page Top</div>
+
+</body>
+</html>
+
+

--- a/atcoder-problems-backend/sql-client/src/contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/src/contest_problem.rs
@@ -14,23 +14,33 @@ pub trait ContestProblemClient {
 #[async_trait]
 impl ContestProblemClient for PgPool {
     async fn insert_contest_problem(&self, contest_problems: &[ContestProblem]) -> Result<()> {
-        let (contest_ids, problem_ids): (Vec<&str>, Vec<&str>) = contest_problems
+        let contest_ids: Vec<&str> = contest_problems
             .iter()
-            .map(|c| (c.contest_id.as_str(), c.problem_id.as_str()))
-            .unzip();
+            .map(|c| c.contest_id.as_str())
+            .collect();
+        let problem_ids: Vec<&str> = contest_problems
+            .iter()
+            .map(|c| c.problem_id.as_str())
+            .collect();
+        let problem_indexes: Vec<&str> = contest_problems
+            .iter()
+            .map(|c| c.problem_index.as_str())
+            .collect();
 
         sqlx::query(
             r"
-            INSERT INTO contest_problem (contest_id, problem_id)
+            INSERT INTO contest_problem (contest_id, problem_id, problem_index)
             VALUES (
                 UNNEST($1::VARCHAR(255)[]),
-                UNNEST($2::VARCHAR(255)[])
+                UNNEST($2::VARCHAR(255)[]),
+                UNNEST($3::VARCHAR(255)[])
             )
             ON CONFLICT DO NOTHING
             ",
         )
         .bind(contest_ids)
         .bind(problem_ids)
+        .bind(problem_indexes)
         .execute(self)
         .await?;
 
@@ -38,17 +48,20 @@ impl ContestProblemClient for PgPool {
     }
 
     async fn load_contest_problem(&self) -> Result<Vec<ContestProblem>> {
-        let problems = sqlx::query("SELECT contest_id, problem_id FROM contest_problem")
-            .try_map(|row: PgRow| {
-                let contest_id: String = row.try_get("contest_id")?;
-                let problem_id: String = row.try_get("problem_id")?;
-                Ok(ContestProblem {
-                    contest_id,
-                    problem_id,
+        let problems =
+            sqlx::query("SELECT contest_id, problem_id, problem_index FROM contest_problem")
+                .try_map(|row: PgRow| {
+                    let contest_id: String = row.try_get("contest_id")?;
+                    let problem_id: String = row.try_get("problem_id")?;
+                    let problem_index: String = row.try_get("problem_index")?;
+                    Ok(ContestProblem {
+                        contest_id,
+                        problem_id,
+                        problem_index,
+                    })
                 })
-            })
-            .fetch_all(self)
-            .await?;
+                .fetch_all(self)
+                .await?;
 
         Ok(problems)
     }

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -23,6 +23,8 @@ impl Contest {
 pub struct Problem {
     pub id: String,
     pub contest_id: String,
+    pub problem_index: String,
+    pub name: String,
     pub title: String,
 }
 

--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -104,6 +104,7 @@ pub struct UserSum {
 pub struct ContestProblem {
     pub contest_id: String,
     pub problem_id: String,
+    pub problem_index: String,
 }
 
 #[derive(PartialEq, Debug, Serialize)]

--- a/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
@@ -33,13 +33,15 @@ impl RatedPointSumClient for PgPool {
         .fetch_all(self);
 
         let rated_problem_ids_fut =
-            sqlx::query("SELECT contest_id, problem_id FROM contest_problem")
+            sqlx::query("SELECT contest_id, problem_id, problem_index FROM contest_problem")
                 .try_map(|row: PgRow| {
                     let contest_id: String = row.try_get("contest_id")?;
                     let problem_id: String = row.try_get("problem_id")?;
+                    let problem_index: String = row.try_get("problem_index")?;
                     Ok(ContestProblem {
                         contest_id,
                         problem_id,
+                        problem_index,
                     })
                 })
                 .fetch_all(self);

--- a/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_contest_problem.rs
@@ -7,6 +7,7 @@ fn create_problem(id: i32) -> ContestProblem {
     ContestProblem {
         contest_id: format!("contest{}", id),
         problem_id: format!("problem{}", id),
+        problem_index: format!("{}", id),
     }
 }
 

--- a/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_rated_point_sum.rs
@@ -80,26 +80,32 @@ async fn setup_contest_problems(pool: &PgPool) {
     let problems = vec![
         ContestProblem {
             problem_id: "problem1".to_string(),
+            problem_index: "1".to_string(),
             contest_id: RATED_CONTEST.to_string(),
         },
         ContestProblem {
             problem_id: "problem2".to_string(),
+            problem_index: "2".to_string(),
             contest_id: UNRATED_CONTEST1.to_string(),
         },
         ContestProblem {
             problem_id: "problem3".to_string(),
+            problem_index: "3".to_string(),
             contest_id: UNRATED_CONTEST1.to_string(),
         },
         ContestProblem {
             problem_id: "problem4".to_string(),
+            problem_index: "4".to_string(),
             contest_id: RATED_CONTEST.to_string(),
         },
         ContestProblem {
             problem_id: "problem5".to_string(),
+            problem_index: "5".to_string(),
             contest_id: SAME_CONTEST_RATED.to_string(),
         },
         ContestProblem {
             problem_id: "problem5".to_string(),
+            problem_index: "5".to_string(),
             contest_id: SAME_CONTEST_UNRATED.to_string(),
         },
     ];
@@ -107,11 +113,12 @@ async fn setup_contest_problems(pool: &PgPool) {
     for problem in problems {
         sqlx::query(
             r"
-            INSERT INTO contest_problem (problem_id, contest_id)
-            VALUES ($1, $2)
+            INSERT INTO contest_problem (problem_id, problem_index, contest_id)
+            VALUES ($1, $2, $3)
             ",
         )
         .bind(problem.problem_id)
+        .bind(problem.problem_index)
         .bind(problem.contest_id)
         .execute(pool)
         .await

--- a/atcoder-problems-backend/sql-client/tests/test_simple_client.rs
+++ b/atcoder-problems-backend/sql-client/tests/test_simple_client.rs
@@ -38,6 +38,8 @@ async fn test_insert_problems() {
     pool.insert_problems(&[Problem {
         id: "problem1".to_string(),
         contest_id: "".to_string(),
+        problem_index: "".to_string(),
+        name: "".to_string(),
         title: "".to_string(),
     }])
     .await
@@ -49,6 +51,8 @@ async fn test_insert_problems() {
     pool.insert_problems(&[Problem {
         id: "problem1".to_string(),
         contest_id: "".to_string(),
+        problem_index: "".to_string(),
+        name: "".to_string(),
         title: "".to_string(),
     }])
     .await

--- a/atcoder-problems-backend/src/bin/dump_json.rs
+++ b/atcoder-problems-backend/src/bin/dump_json.rs
@@ -124,6 +124,8 @@ async fn main() -> Result<()> {
             SELECT
                 problems.id AS merged_problem_id,
                 problems.contest_id AS merged_contest_id,
+                problems.problem_index AS merged_problem_index,
+                problems.name AS merged_problem_name,
                 problems.title AS merged_problem_title,
 
                 shortest.submission_id AS shortest_submission_id,
@@ -158,6 +160,8 @@ async fn main() -> Result<()> {
     .map(|row: PgRow| {
         let id: String = row.get("merged_problem_id");
         let contest_id: String = row.get("merged_contest_id");
+        let problem_index: String = row.get("merged_problem_index");
+        let name: String = row.get("merged_problem_name");
         let title: String = row.get("merged_problem_title");
 
         let shortest_submission_id: Option<i64> = row.get("shortest_submission_id");
@@ -180,6 +184,9 @@ async fn main() -> Result<()> {
         MergedProblem {
             id,
             contest_id,
+            problem_index,
+            name,
+
             title,
             shortest_submission_id,
             shortest_contest_id,
@@ -236,6 +243,8 @@ struct UserStreak {
 struct MergedProblem {
     id: String,
     contest_id: String,
+    problem_index: String,
+    name: String,
     title: String,
     shortest_submission_id: Option<i64>,
     shortest_contest_id: Option<String>,

--- a/atcoder-problems-backend/src/crawler/mod.rs
+++ b/atcoder-problems-backend/src/crawler/mod.rs
@@ -79,17 +79,18 @@ impl AtCoderFetcher for AtCoderClient {
         contest_id: &str,
     ) -> Result<(Vec<Problem>, Vec<ContestProblem>)> {
         info!("Fetching problems from {} ...", contest_id);
-        let problems = self.fetch_problem_list(contest_id).await?;
-        let problems = problems
-            .into_iter()
-            .map(convert_problem)
-            .collect::<Vec<_>>();
-        let contest_problem = problems
+        let atcoder_problems = self.fetch_problem_list(contest_id).await?;
+        let contest_problem = atcoder_problems
             .iter()
             .map(|problem| ContestProblem {
-                problem_id: problem.id.clone(),
                 contest_id: problem.contest_id.clone(),
+                problem_id: problem.id.clone(),
+                problem_index: problem.position.clone(),
             })
+            .collect::<Vec<_>>();
+        let problems = atcoder_problems
+            .into_iter()
+            .map(convert_problem)
             .collect::<Vec<_>>();
         Ok((problems, contest_problem))
     }

--- a/atcoder-problems-backend/src/crawler/mod.rs
+++ b/atcoder-problems-backend/src/crawler/mod.rs
@@ -126,7 +126,9 @@ fn convert_problem(p: AtCoderProblem) -> Problem {
     Problem {
         id: p.id,
         contest_id: p.contest_id,
+        problem_index: p.position.to_string(),
         title: p.position + ". " + p.title.as_str(),
+        name: p.title.to_string(),
     }
 }
 

--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -10,7 +10,12 @@ import {
   RankingEntry,
   SumRankingEntry,
 } from "../interfaces/RankingEntry";
-import { ContestId, ProblemId, UserId } from "../interfaces/Status";
+import {
+  ContestId,
+  ProblemId,
+  ProblemIndex,
+  UserId,
+} from "../interfaces/Status";
 import { isSubmission } from "../interfaces/Submission";
 import { isUserRankEntry, UserRankEntry } from "../interfaces/UserRankEntry";
 import { clipDifficulty, isValidResult } from "../utils";
@@ -203,18 +208,28 @@ export const useContestToProblems = () => {
   const contestIdToProblemIdArray = useSWRData(url, (url) =>
     fetchTypedArray(
       url,
-      (obj): obj is { contest_id: ContestId; problem_id: ProblemId } =>
+      (
+        obj
+      ): obj is {
+        contest_id: ContestId;
+        problem_id: ProblemId;
+        problem_index: ProblemIndex;
+      } =>
         hasPropertyAsType(obj, "contest_id", isString) &&
-        hasPropertyAsType(obj, "problem_id", isString)
+        hasPropertyAsType(obj, "problem_id", isString) &&
+        hasPropertyAsType(obj, "problem_index", isString)
     )
   );
   const problemMap = useProblemMap();
   return contestIdToProblemIdArray.data?.reduce(
-    (map, { contest_id, problem_id }) => {
+    (map, { contest_id, problem_id, problem_index }) => {
       const problem = problemMap?.get(problem_id);
       if (problem) {
         const problems = map.get(contest_id) ?? [];
-        problems.push(problem);
+        problems.push({
+          ...problem,
+          title: `${problem_index}. ${problem.title.replace(/^.+?\. */, "")}`,
+        });
         map.set(contest_id, problems);
       }
       return map;
@@ -228,18 +243,28 @@ export const useContestToMergedProblems = () => {
   const contestIdToProblemIdArray = useSWRData(url, (url) =>
     fetchTypedArray(
       url,
-      (obj): obj is { contest_id: ContestId; problem_id: ProblemId } =>
+      (
+        obj
+      ): obj is {
+        contest_id: ContestId;
+        problem_id: ProblemId;
+        problem_index: ProblemIndex;
+      } =>
         hasPropertyAsType(obj, "contest_id", isString) &&
-        hasPropertyAsType(obj, "problem_id", isString)
+        hasPropertyAsType(obj, "problem_id", isString) &&
+        hasPropertyAsType(obj, "problem_index", isString)
     )
   );
   const { data: problemMap } = useMergedProblemMap();
   return contestIdToProblemIdArray.data?.reduce(
-    (map, { contest_id, problem_id }) => {
+    (map, { contest_id, problem_id, problem_index }) => {
       const problem = problemMap?.get(problem_id);
       if (problem) {
         const problems = map.get(contest_id) ?? [];
-        problems.push(problem);
+        problems.push({
+          ...problem,
+          title: `${problem_index}. ${problem.title.replace(/^..*?\./, "")}`,
+        });
         map.set(contest_id, problems);
       }
       return map;

--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -226,10 +226,7 @@ export const useContestToProblems = () => {
       const problem = problemMap?.get(problem_id);
       if (problem) {
         const problems = map.get(contest_id) ?? [];
-        problems.push({
-          ...problem,
-          title: `${problem_index}. ${problem.title.replace(/^.+?\. */, "")}`,
-        });
+        problems.push({ ...problem, problem_index });
         map.set(contest_id, problems);
       }
       return map;
@@ -261,10 +258,7 @@ export const useContestToMergedProblems = () => {
       const problem = problemMap?.get(problem_id);
       if (problem) {
         const problems = map.get(contest_id) ?? [];
-        problems.push({
-          ...problem,
-          title: `${problem_index}. ${problem.title.replace(/^..*?\./, "")}`,
-        });
+        problems.push({ ...problem, problem_index });
         map.set(contest_id, problems);
       }
       return map;

--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -11,7 +11,8 @@ interface Props {
   className?: string;
   problemId: string;
   contestId: string;
-  problemTitle: string;
+  problemIndex?: string;
+  problemName: string;
   showDifficulty?: boolean;
   isExperimentalDifficulty?: boolean;
   showDifficultyUnavailable?: boolean;
@@ -25,13 +26,18 @@ export const ProblemLink: React.FC<Props> = (props) => {
   const {
     contestId,
     problemId,
-    problemTitle,
+    problemIndex,
+    problemName,
     showDifficulty,
     isExperimentalDifficulty,
     showDifficultyUnavailable,
     problemModel,
     userRatingInfo,
   } = props;
+  const problemTitle = problemIndex
+    ? `${problemIndex}. ${problemName}`
+    : problemName;
+
   const link = (
     <NewTabLink
       href={Url.formatProblemUrl(problemId, contestId)}

--- a/atcoder-problems-frontend/src/components/ProblemSearchBox.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemSearchBox.tsx
@@ -17,7 +17,7 @@ const problemMatch = (text: string, problem: Problem): boolean => {
       .every(
         (word) =>
           (word.trim().length > 0 &&
-            problem.title.toLowerCase().includes(word.toLowerCase())) ||
+            problem.name.toLowerCase().includes(word.toLowerCase())) ||
           formatProblemUrl(problem.id, problem.contest_id)
             .toLowerCase()
             .includes(word.toLowerCase())
@@ -76,7 +76,9 @@ export const ProblemSearchBox: React.FC<Props> = (props) => {
               setFocusingId(-1);
             }}
           >
-            <ListGroupItemHeading>{problem.title}</ListGroupItemHeading>
+            <ListGroupItemHeading>
+              {problem.problem_index}. {problem.name}
+            </ListGroupItemHeading>
             <ListGroupItemText>
               {formatProblemUrl(problem.id, problem.contest_id)}
             </ListGroupItemText>

--- a/atcoder-problems-frontend/src/components/SubmissionListTable.tsx
+++ b/atcoder-problems-frontend/src/components/SubmissionListTable.tsx
@@ -23,10 +23,14 @@ export const SubmissionListTable: React.FC<Props> = (props) => {
   const { submissions, userRatingInfo } = props;
   const problems = useProblems() ?? [];
   const problemModels = useProblemModelMap();
-  const titleMap = problems.reduce((map, p) => {
-    map.set(p.id, p.title);
-    return map;
-  }, new Map<string, string>());
+  const [problemIndexMap, nameMap] = problems.reduce(
+    ([problemIndexMap, nameMap], p) => {
+      problemIndexMap.set(p.id, p.problem_index);
+      nameMap.set(p.id, p.name);
+      return [problemIndexMap, nameMap];
+    },
+    [new Map<string, string>(), new Map<string, string>()]
+  );
 
   const verdictOptions: { [_: string]: string } = Array.from(
     submissions.reduce((set, s) => {
@@ -56,7 +60,11 @@ export const SubmissionListTable: React.FC<Props> = (props) => {
     <BootstrapTable
       data={submissions
         .sort((a, b) => b.epoch_second - a.epoch_second)
-        .map((s) => ({ title: titleMap.get(s.problem_id), ...s }))}
+        .map((s) => ({
+          problemIndex: problemIndexMap.get(s.problem_id) ?? "",
+          name: nameMap.get(s.problem_id) ?? "",
+          ...s,
+        }))}
       keyField="id"
       height="auto"
       hover
@@ -107,9 +115,9 @@ export const SubmissionListTable: React.FC<Props> = (props) => {
       <TableHeaderColumn
         filterFormatted
         dataSort
-        dataField="title"
+        dataField="name"
         dataFormat={(
-          title: string | undefined,
+          name: string | undefined,
           { problem_id, contest_id }: Submission
         ): React.ReactElement => (
           <ProblemLink
@@ -118,7 +126,8 @@ export const SubmissionListTable: React.FC<Props> = (props) => {
             }
             showDifficulty={true}
             problemId={problem_id}
-            problemTitle={title || ""}
+            problemIndex={problemIndexMap.get(problem_id) || ""}
+            problemName={name || ""}
             contestId={contest_id}
             problemModel={problemModels?.get(problem_id) ?? null}
             userRatingInfo={userRatingInfo}

--- a/atcoder-problems-frontend/src/interfaces/MergedProblem.ts
+++ b/atcoder-problems-frontend/src/interfaces/MergedProblem.ts
@@ -11,7 +11,8 @@ export default interface MergedProblem {
   // Basic information
   readonly id: string;
   readonly contest_id: string;
-  readonly title: string;
+  readonly problem_index: string;
+  readonly name: string;
 
   // Information for first AC
   readonly first_user_id: string | null;
@@ -39,7 +40,8 @@ export const isMergedProblem = (obj: unknown): obj is MergedProblem =>
   obj !== null &&
   hasPropertyAsType(obj, "id", isString) &&
   hasPropertyAsType(obj, "contest_id", isString) &&
-  hasPropertyAsType(obj, "title", isString) &&
+  hasPropertyAsType(obj, "problem_index", isString) &&
+  hasPropertyAsType(obj, "name", isString) &&
   hasPropertyAsTypeOrNull(obj, "first_user_id", isString) &&
   hasPropertyAsTypeOrNull(obj, "first_contest_id", isString) &&
   hasPropertyAsTypeOrNull(obj, "first_submission_id", isNumber) &&

--- a/atcoder-problems-frontend/src/interfaces/Problem.ts
+++ b/atcoder-problems-frontend/src/interfaces/Problem.ts
@@ -4,10 +4,12 @@ import { hasPropertyAsType, isString } from "../utils/TypeUtils";
 export default interface Problem {
   readonly id: string;
   readonly contest_id: string;
-  readonly title: string;
+  readonly problem_index: string;
+  readonly name: string;
 }
 
 export const isProblem = (obj: unknown): obj is Problem =>
   hasPropertyAsType(obj, "id", isString) &&
   hasPropertyAsType(obj, "contest_id", isString) &&
-  hasPropertyAsType(obj, "title", isString);
+  hasPropertyAsType(obj, "problem_index", isString) &&
+  hasPropertyAsType(obj, "name", isString);

--- a/atcoder-problems-frontend/src/interfaces/Status.ts
+++ b/atcoder-problems-frontend/src/interfaces/Status.ts
@@ -2,6 +2,7 @@ import { caseInsensitiveUserId, isAccepted } from "../utils";
 import Submission from "./Submission";
 export type ContestId = string;
 export type ProblemId = string;
+export type ProblemIndex = string;
 export type UserId = string;
 
 export enum StatusLabel {

--- a/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/ResetProgress.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/MyAccountPage/ResetProgress.tsx
@@ -52,7 +52,8 @@ export const ResetProgress: React.FC = () => {
                         <ProblemLink
                           problemId={problem.id}
                           contestId={problem.contest_id}
-                          problemTitle={problem.title}
+                          problemIndex={problem.problem_index}
+                          problemName={problem.name}
                         />
                       ) : (
                         item.problem_id

--- a/atcoder-problems-frontend/src/pages/Internal/ProblemList/SingleProblemList.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/ProblemList/SingleProblemList.tsx
@@ -188,7 +188,7 @@ const ProblemEntry: React.FC<{
       <ListGroupItemHeading>
         {problem ? (
           <NewTabLink href={formatProblemUrl(problem.id, problem.contest_id)}>
-            {problem.title}
+            {problem.problem_index}. {problem.name}
           </NewTabLink>
         ) : (
           item.problem_id

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/DraggableContestConfigProblemTable/ProblemCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/DraggableContestConfigProblemTable/ProblemCell.tsx
@@ -22,7 +22,8 @@ export const ProblemCell: React.FC<ProblemCellProps> = ({
         <ProblemLink
           problemId={problem.id}
           contestId={problem.contest_id}
-          problemTitle={problem.title}
+          problemIndex={problem.problem_index}
+          problemName={problem.name}
           showDifficulty={true}
           problemModel={problemModel}
           isExperimentalDifficulty={problemModel?.is_experimental}

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/DraggableContestConfigProblemTable/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/DraggableContestConfigProblemTable/index.tsx
@@ -87,7 +87,9 @@ export const DraggableContestConfigProblemTable: React.FC<Props> = (props) => {
       compare: (a: VirtualContestItem, b: VirtualContestItem): number => {
         const getTitle = (problemId: ProblemId): string => {
           const problem = problemMap?.get(problemId);
-          const title = problem?.title ? problem.title : "";
+          const title = `${problem?.problem_index ?? ""}. ${
+            problem?.name ?? ""
+          }`;
           return title;
         };
         const aTitle = getTitle(a.id);

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ContestTable.tsx
@@ -262,7 +262,7 @@ export const ContestTable = (props: Props) => {
                   <ProblemLink
                     problemId={p.id}
                     contestId={p.contestId}
-                    problemTitle={`${i + 1}`}
+                    problemName={`${i + 1}`}
                   />
                 ) : (
                   i + 1

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/LockoutContestTable/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/LockoutContestTable/index.tsx
@@ -121,7 +121,7 @@ export const LockoutContestTable: React.FC<Props> = (props) => {
                         <ProblemLink
                           problemId={problem.item.id}
                           contestId={problem.contestId}
-                          problemTitle={problem.title}
+                          problemName={problem.title}
                           className={status ? "text-white" : "text-link"}
                         />
                       ) : (

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/TrainingContestTable/SmallScoreCell.tsx
@@ -49,7 +49,7 @@ export const SmallScoreCell: React.FC<Props> = (props) => {
               <ProblemLink
                 problemId={problem.id}
                 contestId={problem.contestId}
-                problemTitle={problem.title}
+                problemName={problem.title}
               />
             ) : (
               <b>{problem.title}</b>

--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/index.tsx
@@ -136,7 +136,7 @@ const Problems = (props: {
                       <ProblemLink
                         problemId={p.id}
                         contestId={p.contestId}
-                        problemTitle={`${i + 1}`}
+                        problemName={`${i + 1}`}
                       />
                     ) : (
                       i + 1
@@ -147,7 +147,7 @@ const Problems = (props: {
                       <ProblemLink
                         problemId={p.id}
                         contestId={p.contestId}
-                        problemTitle={p.title}
+                        problemName={p.title}
                       />
                     ) : (
                       p.id
@@ -363,7 +363,7 @@ export const ShowContest = (props: Props) => {
         return {
           item,
           contestId: problem.contest_id,
-          title: problem.title,
+          title: `${problem.problem_index}. ${problem.name}`,
         };
       } else {
         return { item };

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -162,7 +162,7 @@ export const ListTable: React.FC<Props> = (props) => {
         const problemModel = problemModels?.get(p.id);
         return {
           id: p.id,
-          title: p.title,
+          title: `${p.problem_index}. ${p.name}`,
           contest,
           contestDate,
           contestTitle,
@@ -257,7 +257,7 @@ export const ListTable: React.FC<Props> = (props) => {
             showDifficulty={true}
             isExperimentalDifficulty={row.problemModel?.is_experimental}
             problemId={row.mergedProblem.id}
-            problemTitle={row.title}
+            problemName={row.title}
             contestId={row.mergedProblem.contest_id}
             problemModel={row.problemModel}
             userRatingInfo={userRatingInfo}

--- a/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
@@ -38,11 +38,12 @@ interface Props {
 }
 
 const getProblemHeaderAlphabet = (problem: MergedProblem, contest: Contest) => {
-  const list = problem.title.split(".");
-  if (list.length === 0) return "";
-  if (list[0] === "H" && classifyContest(contest).startsWith("ABC"))
+  if (
+    problem.problem_index === "H" &&
+    classifyContest(contest).startsWith("ABC")
+  )
     return "Ex";
-  return list[0];
+  return problem.problem_index;
 };
 
 const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
@@ -181,7 +182,8 @@ const AtCoderRegularTableSFC: React.FC<Props> = (props) => {
                       showDifficulty={props.showDifficulty}
                       contestId={contest.id}
                       problemId={problem.problem.id}
-                      problemTitle={problem.problem.title}
+                      problemIndex={problem.problem.problem_index}
+                      problemName={problem.problem.name}
                       problemModel={model}
                       userRatingInfo={userRatingInfo}
                     />

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.test.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.test.tsx
@@ -1,21 +1,21 @@
-import { convertProblemTitleForSorting } from "./ContestTable";
+import { convertProblemIndexForSorting } from "./ContestTable";
 
-describe("Convert a problem title", () => {
+describe("Convert a problem index", () => {
   it("No number", () => {
-    const title = "J. Kuru Kuru Kururin";
-    expect(convertProblemTitleForSorting(title)).toMatchObject(["J", NaN]);
+    const index = "J";
+    expect(convertProblemIndexForSorting(index)).toMatchObject(["J", NaN]);
   });
 
   it("No string", () => {
-    const title = "1000000007. The Most Famous Prime Number";
-    expect(convertProblemTitleForSorting(title)).toMatchObject([
+    const index = "1000000007";
+    expect(convertProblemIndexForSorting(index)).toMatchObject([
       "",
       1000000007,
     ]);
   });
 
   it("Both exists", () => {
-    const title = "EX1. 1.01";
-    expect(convertProblemTitleForSorting(title)).toMatchObject(["EX", 1]);
+    const index = "EX1";
+    expect(convertProblemIndexForSorting(index)).toMatchObject(["EX", 1]);
   });
 });

--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -25,12 +25,11 @@ interface Props {
   userRatingInfo: RatingInfo;
 }
 
-export const convertProblemTitleForSorting = (
-  title: string
+export const convertProblemIndexForSorting = (
+  problem_index: string
 ): [string, number] => {
-  const idx = title.split(".")[0];
-  const str = idx.replace(/[0-9]/g, "");
-  const num = parseInt(idx.replace(/[^0-9]/g, ""), 10);
+  const str = problem_index.replace(/[0-9]/g, "");
+  const num = parseInt(problem_index.replace(/[^0-9]/g, ""), 10);
   return [str, num];
 };
 
@@ -51,8 +50,8 @@ export const ContestTable: React.FC<Props> = (props) => {
     .map((contest) => ({
       contest,
       problems: (contestToProblems.get(contest.id) ?? []).sort((a, b) => {
-        const [str_a, num_a] = convertProblemTitleForSorting(a.title);
-        const [str_b, num_b] = convertProblemTitleForSorting(b.title);
+        const [str_a, num_a] = convertProblemIndexForSorting(a.problem_index);
+        const [str_b, num_b] = convertProblemIndexForSorting(b.problem_index);
         const cmp = str_a.localeCompare(str_b);
         return cmp === 0 ? num_a - num_b : cmp;
       }),
@@ -118,8 +117,9 @@ export const ContestTable: React.FC<Props> = (props) => {
                             showDifficultyUnavailable={isRatedContest(contest)}
                             showDifficulty={props.showDifficulty}
                             problemId={problem.id}
-                            problemTitle={problem.title}
                             contestId={problem.contest_id}
+                            problemIndex={problem.problem_index}
+                            problemName={problem.name}
                             problemModel={model}
                             userRatingInfo={userRatingInfo}
                           />

--- a/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/SingleCourseView.tsx
@@ -51,7 +51,8 @@ const ProblemTable: React.FC<ProblemTableProps> = (props) => {
               <td>
                 <ProblemLink
                   problemId={problem.id}
-                  problemTitle={problem.title}
+                  problemIndex={problem.problem_index}
+                  problemName={problem.name}
                   contestId={problem.contest_id}
                   problemModel={model}
                   isExperimentalDifficulty={!!model && model.is_experimental}

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -80,7 +80,7 @@ const solvedCountForPieChart = (
           : validSubmissions?.find((s) => isAccepted(s.result))
           ? SubmissionStatus.ACCEPTED
           : SubmissionStatus.REJECTED;
-        return { title: problem.title, status };
+        return { title: problem.name, status };
       });
       return { titleStatus };
     })
@@ -104,7 +104,7 @@ const solvedCountForPieChart = (
     );
   const totalCount = contestToProblems
     .map(([, problems]) => {
-      const problemTitles = problems.map((problem) => problem.title);
+      const problemTitles = problems.map((problem) => problem.name);
       return { problemTitles };
     })
     .map(({ problemTitles }) =>

--- a/atcoder-problems-frontend/src/pages/UserPage/Recommendations/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/Recommendations/index.tsx
@@ -153,7 +153,7 @@ export const Recommendations = (props: Props) => {
           <TableHeaderColumn
             dataField="title"
             dataFormat={(
-              title: string,
+              name: string,
               {
                 id,
                 contest_id,
@@ -164,7 +164,7 @@ export const Recommendations = (props: Props) => {
                 isExperimentalDifficulty={is_experimental}
                 showDifficulty={true}
                 problemId={id}
-                problemTitle={title}
+                problemName={name}
                 contestId={contest_id}
                 problemModel={problemModels?.get(id) ?? null}
                 userRatingInfo={userRatingInfo}

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -26,6 +26,8 @@ DROP TABLE IF EXISTS problems;
 CREATE TABLE problems (
   id            VARCHAR(255) NOT NULL,
   contest_id    VARCHAR(255) NOT NULL,
+  problem_index VARCHAR(255) NOT NULL,
+  name          VARCHAR(255) NOT NULL,
   title         VARCHAR(255) NOT NULL,
   PRIMARY KEY (id)
 );

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -112,7 +112,8 @@ DROP TABLE IF EXISTS contest_problem;
 CREATE TABLE contest_problem (
   contest_id            VARCHAR(255) NOT NULL,
   problem_id            VARCHAR(255) NOT NULL,
-  PRIMARY KEY (contest_id, problem_id)
+  problem_index         VARCHAR(255) NOT NULL,
+  PRIMARY KEY (contest_id, problem_id, problem_index)
 );
 
 DROP TABLE IF EXISTS max_streaks;


### PR DESCRIPTION
Fixes #936.

ATC002 のアルファベットが正しく表示できるところまで実装しました。
<img width="878" alt="atc002_screenshot" src="https://user-images.githubusercontent.com/6523469/148414917-5a85eddc-d99a-45ba-ae94-ffc65ccfa5e5.png">

- 一つ確認したいことがありますが、#936 で
  > クローラーが問題インデックスを問題名に含めないようにする。  

  とおっしゃいましたが、それをまだ実装していません。

  実装すると API の `problems.json` および `contest-problems.json` の `title` から問題インデックスが消されるけどそれも大丈夫ですか。（他にこの API を使ってるユーザーのことをちょっと考えています。）

- `contest-problems.json` を変えたので新しいバックエンドを用いて生成した `contest-problems.json` で動作確認しました。
  そのためフロントエンドの結合テストが通りません。

- 念のため Table ページのフルページスクリーンショットを取っておきましたので上げておきます。 
 [AtCoderProblems_Table_Screenshots.zip](https://github.com/kenkoooo/AtCoderProblems/files/7823306/AtCoderProblems_Table_Screenshots.zip)

