### PR TITLE
change RPS Ranking API response

### DIFF
--- a/atcoder-problems-backend/src/server/ranking/language.rs
+++ b/atcoder-problems-backend/src/server/ranking/language.rs
@@ -1,5 +1,6 @@
 use super::{
-    UserRankResponseFormat, RankingRequestFormat, RankingResponse, RankingSelector, UserRankRequest, UserRankSelector,
+    RankingRequestFormat, RankingResponse, RankingSelector, UserRankRequest,
+    UserRankResponseFormat, UserRankSelector,
 };
 use crate::server::AppData;
 
@@ -8,7 +9,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sql_client::language_count::LanguageCountClient;
 use std::ops::Range;
-
 
 #[derive(Deserialize)]
 pub(crate) struct LanguageRankingRequest {

--- a/atcoder-problems-backend/src/server/ranking/language.rs
+++ b/atcoder-problems-backend/src/server/ranking/language.rs
@@ -1,12 +1,36 @@
 use super::{
-    LanguageRankingRequest, LanguageUserRankResponse, RankingRequestFormat, RankingResponse,
-    RankingSelector, UserRankRequest, UserRankSelector,
+    UserRankResponseFormat, RankingRequestFormat, RankingResponse, RankingSelector, UserRankRequest, UserRankSelector,
 };
 use crate::server::AppData;
 
 use actix_web::{error, web, Result};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use sql_client::language_count::LanguageCountClient;
+use std::ops::Range;
+
+
+#[derive(Deserialize)]
+pub(crate) struct LanguageRankingRequest {
+    from: usize,
+    to: usize,
+    language: String,
+}
+
+impl RankingRequestFormat for LanguageRankingRequest {
+    fn range(&self) -> Range<usize> {
+        (self.from)..(self.to)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LanguageUserRankResponse {
+    language: String,
+    count: i64,
+    rank: i64,
+}
+
+impl UserRankResponseFormat for LanguageUserRankResponse {}
 
 pub(crate) struct LanguageRanking;
 

--- a/atcoder-problems-backend/src/server/ranking/mod.rs
+++ b/atcoder-problems-backend/src/server/ranking/mod.rs
@@ -3,7 +3,6 @@ use crate::server::AppData;
 use actix_web::{web, HttpRequest, HttpResponse, Result};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sql_client::models::UserSum;
 use std::ops::Range;
 
 pub(crate) mod ac_count;
@@ -77,7 +76,6 @@ pub(crate) trait UserRankSelector<A: Sync + Send + Clone + 'static> {
     }
 }
 
-// ranking requests
 #[derive(Deserialize)]
 pub(crate) struct RankingRequest {
     from: usize,
@@ -90,20 +88,6 @@ impl RankingRequestFormat for RankingRequest {
     }
 }
 
-#[derive(Deserialize)]
-pub(crate) struct LanguageRankingRequest {
-    from: usize,
-    to: usize,
-    language: String,
-}
-
-impl RankingRequestFormat for LanguageRankingRequest {
-    fn range(&self) -> Range<usize> {
-        (self.from)..(self.to)
-    }
-}
-
-// ranking responses
 #[derive(Serialize)]
 pub(crate) struct RankingResponse {
     user_id: String,
@@ -112,9 +96,6 @@ pub(crate) struct RankingResponse {
 
 impl RankingResponseFormat for RankingResponse {}
 
-impl RankingResponseFormat for UserSum {}
-
-// user rank requests
 #[derive(Deserialize)]
 pub(crate) struct UserRankRequest {
     user: String,
@@ -122,7 +103,6 @@ pub(crate) struct UserRankRequest {
 
 impl UserRankRequestFormat for UserRankRequest {}
 
-// user rank responses
 #[derive(Serialize)]
 pub(crate) struct UserRankResponse {
     count: i64,
@@ -130,12 +110,3 @@ pub(crate) struct UserRankResponse {
 }
 
 impl UserRankResponseFormat for UserRankResponse {}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct LanguageUserRankResponse {
-    language: String,
-    count: i64,
-    rank: i64,
-}
-
-impl UserRankResponseFormat for LanguageUserRankResponse {}

--- a/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
+++ b/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use serde::Serialize;
 use sql_client::rated_point_sum::RatedPointSumClient;
 
-// will be deprecated and replaced with super::RankingResponse
+#[deprecated(note = "this special Response type will be deprecated and replaced with super::RankingResponse")]
 #[derive(Debug, Serialize)]
 pub(crate) struct RPSRankingResponse {
     user_id: String,

--- a/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
+++ b/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use serde::Serialize;
 use sql_client::rated_point_sum::RatedPointSumClient;
 
-#[deprecated(note = "this special Response type will be deprecated and replaced with super::RankingResponse")]
+#[deprecated(
+    note = "this special Response type is deprecated and will be replaced with super::RankingResponse"
+)]
 #[derive(Debug, Serialize)]
 pub(crate) struct RPSRankingResponse {
     user_id: String,

--- a/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
+++ b/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs
@@ -1,12 +1,13 @@
 use super::{
-    RankingRequest, RankingRequestFormat, RankingSelector, UserRankRequest, UserRankResponse, UserRankSelector, RankingResponseFormat
+    RankingRequest, RankingRequestFormat, RankingResponseFormat, RankingSelector, UserRankRequest,
+    UserRankResponse, UserRankSelector,
 };
 use crate::server::AppData;
 
 use actix_web::{error, web, Result};
 use async_trait::async_trait;
+use serde::Serialize;
 use sql_client::rated_point_sum::RatedPointSumClient;
-use serde::{Serialize};
 
 // will be deprecated and replaced with super::RankingResponse
 #[derive(Debug, Serialize)]

--- a/atcoder-problems-backend/tests/test_server_e2e_rated_point_sum_ranking.rs
+++ b/atcoder-problems-backend/tests/test_server_e2e_rated_point_sum_ranking.rs
@@ -61,9 +61,9 @@ async fn test_rated_point_sum_ranking() {
     assert_eq!(
         response,
         json!([
-            {"user_id":"u2","point_sum":2},
-            {"user_id":"u1","point_sum":1},
-            {"user_id":"u3","point_sum":1}
+            {"user_id":"u2","point_sum":2,"count":2},
+            {"user_id":"u1","point_sum":1,"count":1},
+            {"user_id":"u3","point_sum":1,"count":1}
         ])
     );
 
@@ -79,8 +79,8 @@ async fn test_rated_point_sum_ranking() {
     assert_eq!(
         response,
         json!([
-            {"user_id":"u1","point_sum":1},
-            {"user_id":"u3","point_sum":1}
+            {"user_id":"u1","point_sum":1,"count":1},
+            {"user_id":"u3","point_sum":1,"count":1}
         ])
     );
     let response = reqwest::get(url(
@@ -95,7 +95,7 @@ async fn test_rated_point_sum_ranking() {
     assert_eq!(
         response,
         json!([
-            {"user_id":"u2","point_sum":2}
+            {"user_id":"u2","point_sum":2,"count":2}
         ])
     );
 

--- a/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
+++ b/atcoder-problems-frontend/public/static_data/backend/hidden_contests.json
@@ -1,44 +1,44 @@
 [
-  { 
-    "id": "ukuku09", 
-    "start_epoch_second": 1530939600, 
-    "duration_second": 10800, 
-    "title": "ウクーニャたんお誕生日コンテスト", 
+  {
+    "id": "ukuku09",
+    "start_epoch_second": 1530939600,
+    "duration_second": 10800,
+    "title": "ウクーニャたんお誕生日コンテスト",
     "rate_change": "-"
-  }, 
-  { 
-    "id": "summerfes2018-div1", 
-    "start_epoch_second": 1535175000, 
-    "duration_second": 7200, 
-    "title": "Summer Festival Contest 2018 (Division 1)", 
+  },
+  {
+    "id": "summerfes2018-div1",
+    "start_epoch_second": 1535175000,
+    "duration_second": 7200,
+    "title": "Summer Festival Contest 2018 (Division 1)",
     "rate_change": "-"
-  }, 
-  { 
-    "id": "summerfes2018-div2", 
-    "start_epoch_second": 1535175000, 
-    "duration_second": 7200, 
-    "title": "Summer Festival Contest 2018 (Division 2)", 
+  },
+  {
+    "id": "summerfes2018-div2",
+    "start_epoch_second": 1535175000,
+    "duration_second": 7200,
+    "title": "Summer Festival Contest 2018 (Division 2)",
     "rate_change": "-"
-  }, 
-  { 
-    "id": "monamieHB2021", 
-    "start_epoch_second": 1618920000, 
-    "duration_second": 7200, 
-    "title": "えびまのお誕生日コンテスト 2021 Day 1", 
+  },
+  {
+    "id": "monamieHB2021",
+    "start_epoch_second": 1618920000,
+    "duration_second": 7200,
+    "title": "えびまのお誕生日コンテスト 2021 Day 1",
     "rate_change": "-"
-  }, 
-  { 
-    "id": "tkppc6-1", 
-    "start_epoch_second": 1629604800, 
-    "duration_second": 10800, 
-    "title": "技術室奥プログラミングコンテスト#6 Day1", 
+  },
+  {
+    "id": "tkppc6-1",
+    "start_epoch_second": 1629604800,
+    "duration_second": 10800,
+    "title": "技術室奥プログラミングコンテスト#6 Day1",
     "rate_change": "-"
-  }, 
-  { 
-    "id": "genocon2021", 
-    "start_epoch_second": 1629720000, 
-    "duration_second": 2429940, 
-    "title": "ゲノコン2021 ー DNA配列解析チャレンジ", 
+  },
+  {
+    "id": "genocon2021",
+    "start_epoch_second": 1629720000,
+    "duration_second": 2429940,
+    "title": "ゲノコン2021 ー DNA配列解析チャレンジ",
     "rate_change": "-"
   }
 ]

--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -99,18 +99,8 @@ export const useUserStreakRank = (user: string) => {
 };
 
 export const useSumRanking = (from: number, to: number) => {
-  const fetcher = async (url: string) => {
-    const ranking = await fetchTypedArray<SumRankingEntry>(
-      url,
-      isSumRankingEntry
-    );
-    return ranking.map((entry) => ({
-      count: entry.point_sum,
-      user_id: entry.user_id,
-    }));
-  };
   const url = `${ATCODER_API_URL}/v3/rated_point_sum_ranking?from=${from}&to=${to}`;
-  return useSWRData(url, fetcher);
+  return useRankingV3(url);
 };
 
 export const useUserSumRank = (user: string) => {

--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -4,12 +4,7 @@ import { isContestParticipation } from "../interfaces/ContestParticipation";
 import MergedProblem, { isMergedProblem } from "../interfaces/MergedProblem";
 import Problem, { isProblem } from "../interfaces/Problem";
 import ProblemModel, { isProblemModel } from "../interfaces/ProblemModel";
-import {
-  isRankingEntry,
-  isSumRankingEntry,
-  RankingEntry,
-  SumRankingEntry,
-} from "../interfaces/RankingEntry";
+import { isRankingEntry, RankingEntry } from "../interfaces/RankingEntry";
 import { ContestId, ProblemId, UserId } from "../interfaces/Status";
 import { isSubmission } from "../interfaces/Submission";
 import { isUserRankEntry, UserRankEntry } from "../interfaces/UserRankEntry";

--- a/atcoder-problems-frontend/src/interfaces/RankingEntry.ts
+++ b/atcoder-problems-frontend/src/interfaces/RankingEntry.ts
@@ -9,15 +9,6 @@ export const isRankingEntry = (obj: unknown): obj is RankingEntry =>
   hasPropertyAsType(obj, "count", isNumber) &&
   hasPropertyAsType(obj, "user_id", isString);
 
-export interface SumRankingEntry {
-  readonly user_id: string;
-  readonly point_sum: number;
-}
-
-export const isSumRankingEntry = (obj: unknown): obj is SumRankingEntry =>
-  hasPropertyAsType(obj, "user_id", isString) &&
-  hasPropertyAsType(obj, "point_sum", isNumber);
-
 export interface LangRankingEntry {
   user_id: string;
   count: number;


### PR DESCRIPTION
resolves #1104

バックエンド側は [コード中のコメント](https://github.com/kenkoooo/AtCoderProblems/blob/9e62b8df9fdb8e15828222bec5c45369388415eb/atcoder-problems-backend/src/server/ranking/rated_point_sum.rs#L12) にあるように、移行完了時には共通のResponse型 `RankingResponse` に差し替えます。
また、ranking モジュールがごちゃついていたのが気になっていたので、引数や返り値に特殊な型を用いるもの（Languageなど）は自身のモジュール内でその型の定義を行うようにしました。

フロントエンド側は `count` のフィールドが増えたことで返り値を直に変換できるようになったので、特別な対応を行わない共通の関数に差し替えました。