### PR TITLE
virtual contest の FA が正しく表示されないバグを修正

### DIFF
--- a/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
+++ b/atcoder-problems-frontend/src/pages/Internal/VirtualContest/ShowContest/ResultCalcUtil.ts
@@ -43,7 +43,7 @@ export function reduceUserContestResult<
       const currentBest = result.get(submission.problem_id);
       const lastUpdatedEpochSecond = submission.epoch_second;
       if (currentBest) {
-        if (currentBest.point < point) {
+        if (currentBest.point < point || (!currentBest.accepted && accepted)) {
           result.set(problemId, {
             trials: currentBest.trials + 1,
             accepted: accepted || currentBest.accepted,


### PR DESCRIPTION
resolves #1123 
点数が更新されなくても、非AC から AC になった時も状態を更新するようにしました。
![image](https://user-images.githubusercontent.com/63996969/155331958-984bd787-5f69-441d-b90a-35ed0807644e.png)
