### PR TITLE
AHC008 が AGC-Like に分類されるバグを修正

### DIFF
--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -49,6 +49,10 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     return "AGC";
   }
 
+  if (/^ahc\d{3}$/.exec(contest.id)) {
+    return "AHC";
+  }
+
   if (isRatedContest(contest)) {
     return classifyOtherRatedContest(contest);
   }
@@ -63,9 +67,6 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     return "JAG";
   }
 
-  if (/^ahc\d{3}$/.exec(contest.id)) {
-    return "AHC";
-  }
   if (
     /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -20,9 +20,15 @@ export type ContestCategory = typeof ContestCategories[number];
 
 export const AGC_001_START = 1468670400;
 
+const isAhc = (contestId: string): boolean => {
+  return Boolean(/^ahc\d{3}$/.exec(contestId));
+};
+
 export const isRatedContest = (contest: Contest): boolean => {
   return (
-    contest.rate_change !== "-" && contest.start_epoch_second >= AGC_001_START
+    contest.rate_change !== "-" &&
+    contest.start_epoch_second >= AGC_001_START &&
+    !isAhc(contest.id)
   );
 };
 
@@ -49,10 +55,6 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     return "AGC";
   }
 
-  if (/^ahc\d{3}$/.exec(contest.id)) {
-    return "AHC";
-  }
-
   if (isRatedContest(contest)) {
     return classifyOtherRatedContest(contest);
   }
@@ -67,6 +69,9 @@ export const classifyContest = (contest: Contest): ContestCategory => {
     return "JAG";
   }
 
+  if (isAhc(contest.id)) {
+    return "AHC";
+  }
   if (
     /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title


### PR DESCRIPTION
#1129 
修正してみました

おそらく[AHCのRated対象が"-"から"All"に変更された](https://atcoder.jp/contests/archive)のが原因だと思います[(過去のWebArchive)](http://web.archive.org/web/20211127033746/https://atcoder.jp/contests/archive)

Rated Point Sumについては未修正です(原因は同じくAHCがRatedになったからだと思われますが...)
![image](https://user-images.githubusercontent.com/71774299/155926778-82a24293-13a4-461c-9a41-bfbf666873a6.png)
