### PR TITLE
常設コンテストの開催日が空欄になるように修正 #1190

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -140,9 +140,10 @@ export const ListTable: React.FC<Props> = (props) => {
     .map(
       (p: MergedProblem): ProblemRowData => {
         const contest = contestMap?.get(p.contest_id);
-        const contestDate = contest
-          ? formatMomentDate(parseSecond(contest.start_epoch_second))
-          : "";
+        const contestDate =
+          contest && contest.start_epoch_second > 0
+            ? formatMomentDate(parseSecond(contest.start_epoch_second))
+            : "";
         const contestTitle = contest ? contest.title : "";
 
         const status = statusLabelMap.get(p.id) ?? noneStatus();


### PR DESCRIPTION
## 変更の概要

* ListページのProblem ListのDate欄に「1970-01-01」と表示されている箇所が空欄になるように修正

## 変更内容

* formatMomentDateに渡す前のチェックにcontest.start_epoch_secondが0より大きいかどうかのチェックを追加