### PR TITLE
update_language_countの速度改善

### DIFF
--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "opaque-debug"
@@ -2744,7 +2744,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "lazy_static",
+ "once_cell",
  "regex",
  "serde",
  "sqlx",

--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "lazy_static",
  "regex",
  "serde",
  "sqlx",

--- a/atcoder-problems-backend/Cargo.lock
+++ b/atcoder-problems-backend/Cargo.lock
@@ -2744,7 +2744,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "once_cell",
  "regex",
  "serde",
  "sqlx",

--- a/atcoder-problems-backend/sql-client/Cargo.toml
+++ b/atcoder-problems-backend/sql-client/Cargo.toml
@@ -16,3 +16,4 @@ anyhow = "1.0"
 tokio = { version = "1.16", features = ["macros"] }
 regex = "1"
 chrono = "0.4"
+lazy_static = "1.4.0"

--- a/atcoder-problems-backend/sql-client/Cargo.toml
+++ b/atcoder-problems-backend/sql-client/Cargo.toml
@@ -16,4 +16,4 @@ anyhow = "1.0"
 tokio = { version = "1.16", features = ["macros"] }
 regex = "1"
 chrono = "0.4"
-lazy_static = "1.4.0"
+once_cell = "1.12.0"

--- a/atcoder-problems-backend/sql-client/Cargo.toml
+++ b/atcoder-problems-backend/sql-client/Cargo.toml
@@ -16,4 +16,3 @@ anyhow = "1.0"
 tokio = { version = "1.16", features = ["macros"] }
 regex = "1"
 chrono = "0.4"
-once_cell = "1.12.0"

--- a/atcoder-problems-backend/sql-client/src/language_count.rs
+++ b/atcoder-problems-backend/sql-client/src/language_count.rs
@@ -2,6 +2,7 @@ use crate::models::{Submission, UserLanguageCount, UserLanguageCountRank, UserPr
 use crate::{PgPool, MAX_INSERT_ROWS};
 use anyhow::Result;
 use async_trait::async_trait;
+use lazy_static::lazy_static;
 use regex::Regex;
 use sqlx::postgres::PgRow;
 use sqlx::Row;
@@ -190,11 +191,13 @@ impl LanguageCountClient for PgPool {
 }
 
 fn simplify_language(lang: &str) -> String {
-    let re = Regex::new(r"\d*\s*\(.*\)").unwrap();
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r"\d*\s*\(.*\)").unwrap();
+    }
     if lang.starts_with("Perl6") {
         "Raku".to_string()
     } else {
-        re.replace(lang, "").to_string()
+        RE.replace(lang, "").to_string()
     }
 }
 


### PR DESCRIPTION
update_language_countで使用されているsimplify_language内の正規表現のコンパイルが1度だけ実行されるように修正してみました。ローカルで試してみたところ約50000件のsubmissionsで数十秒かかっていたところがすぐに終わるようになり、ある程度改善できるのではないかと思うので一度確認をお願い致します。