### PR TITLE
Feature#1194 Merge like contest toggle

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
@@ -30,7 +30,7 @@ interface Props {
   toggleLanguage: (language: string) => void;
   active: ContestCategory;
   mergeLikeContest: boolean;
-  setMergeLikeContest: (showLikeContest: boolean) => void;
+  setMergeLikeContest: (mergeLikeContest: boolean) => void;
 }
 
 export const Options: React.FC<Props> = (props) => {

--- a/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
@@ -14,6 +14,8 @@ import {
 } from "reactstrap";
 import { HelpBadgeTooltip } from "../../components/HelpBadgeTooltip";
 import { ColorMode } from "../../utils/TableColor";
+import { ContestCategory } from "../../utils/ContestClassifier";
+import { getLikeContest } from "../../utils/LikeContestUtils";
 
 interface Props {
   hideCompletedContest: boolean;
@@ -27,9 +29,22 @@ interface Props {
   selectableLanguages: Set<string>;
   selectedLanguages: Set<string>;
   toggleLanguage: (language: string) => void;
+  active: ContestCategory;
+  setSelectedContests: (contest: ContestCategory[]) => void;
+  showableShowLikeContest: boolean;
+  showLikeContest: boolean;
+  setShowLikeContest: (showLikeContest: boolean) => void;
 }
 
 export const Options: React.FC<Props> = (props) => {
+  const changeShowLikeContest = (checked: boolean) => {
+    const likeContest = getLikeContest(props.active);
+    if (checked && likeContest) {
+      props.setSelectedContests([props.active, likeContest]);
+    } else {
+      props.setSelectedContests([props.active]);
+    }
+  };
   return (
     <>
       <Row className="my-4">
@@ -59,6 +74,22 @@ export const Options: React.FC<Props> = (props) => {
             Internal rating to have 50% Solve Probability
           </HelpBadgeTooltip>
         </FormGroup>
+        {props.showableShowLikeContest && (
+          <FormGroup check inline class="my-4">
+            <Label check>
+              <CustomInput
+                type="switch"
+                id="showLikeContest"
+                label="Show Like Contest"
+                checked={props.showLikeContest}
+                onChange={(e) => {
+                  changeShowLikeContest(e.target.checked);
+                  props.setShowLikeContest(!props.showLikeContest);
+                }}
+              />
+            </Label>
+          </FormGroup>
+        )}
         {props.colorMode === ColorMode.ContestResult && (
           <FormGroup check inline>
             <Label check>

--- a/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/Options.tsx
@@ -15,7 +15,6 @@ import {
 import { HelpBadgeTooltip } from "../../components/HelpBadgeTooltip";
 import { ColorMode } from "../../utils/TableColor";
 import { ContestCategory } from "../../utils/ContestClassifier";
-import { getLikeContest } from "../../utils/LikeContestUtils";
 
 interface Props {
   hideCompletedContest: boolean;
@@ -30,21 +29,11 @@ interface Props {
   selectedLanguages: Set<string>;
   toggleLanguage: (language: string) => void;
   active: ContestCategory;
-  setSelectedContests: (contest: ContestCategory[]) => void;
-  showableShowLikeContest: boolean;
-  showLikeContest: boolean;
-  setShowLikeContest: (showLikeContest: boolean) => void;
+  mergeLikeContest: boolean;
+  setMergeLikeContest: (showLikeContest: boolean) => void;
 }
 
 export const Options: React.FC<Props> = (props) => {
-  const changeShowLikeContest = (checked: boolean) => {
-    const likeContest = getLikeContest(props.active);
-    if (checked && likeContest) {
-      props.setSelectedContests([props.active, likeContest]);
-    } else {
-      props.setSelectedContests([props.active]);
-    }
-  };
   return (
     <>
       <Row className="my-4">
@@ -74,22 +63,19 @@ export const Options: React.FC<Props> = (props) => {
             Internal rating to have 50% Solve Probability
           </HelpBadgeTooltip>
         </FormGroup>
-        {props.showableShowLikeContest && (
-          <FormGroup check inline class="my-4">
-            <Label check>
-              <CustomInput
-                type="switch"
-                id="showLikeContest"
-                label="Show Like Contest"
-                checked={props.showLikeContest}
-                onChange={(e) => {
-                  changeShowLikeContest(e.target.checked);
-                  props.setShowLikeContest(!props.showLikeContest);
-                }}
-              />
-            </Label>
-          </FormGroup>
-        )}
+        <FormGroup check inline class="my-4">
+          <Label check>
+            <CustomInput
+              type="switch"
+              id="mergeLikeContest"
+              label="Merge Like Contest"
+              checked={props.mergeLikeContest}
+              onChange={() => {
+                props.setMergeLikeContest(!props.mergeLikeContest);
+              }}
+            />
+          </Label>
+        </FormGroup>
         {props.colorMode === ColorMode.ContestResult && (
           <FormGroup check inline>
             <Label check>

--- a/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
@@ -4,14 +4,24 @@ import {
   ContestCategories,
   ContestCategory,
 } from "../../utils/ContestClassifier";
+import { getLikeContest } from "../../utils/LikeContestUtils";
 
 interface Props {
   active: ContestCategory;
   setActive: (next: ContestCategory) => void;
+  setSelectedContests: (contest: ContestCategory[]) => void;
+  showLikeContest: boolean;
 }
 
 export const TableTabButtons: React.FC<Props> = (props) => {
-  const { active, setActive } = props;
+  const { active, setActive, setSelectedContests, showLikeContest } = props;
+
+  const resetSelectedContests = (category: ContestCategory) => {
+    const selectContests = [category];
+    const likeContest = getLikeContest(category);
+    if (likeContest && showLikeContest) selectContests.push(likeContest);
+    setSelectedContests(selectContests);
+  };
   return (
     <Row>
       <ButtonGroup className="table-tab">
@@ -21,6 +31,7 @@ export const TableTabButtons: React.FC<Props> = (props) => {
             color="secondary"
             onClick={(): void => {
               setActive(category);
+              resetSelectedContests(category);
             }}
             active={active === category}
           >

--- a/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
@@ -4,34 +4,33 @@ import {
   ContestCategories,
   ContestCategory,
 } from "../../utils/ContestClassifier";
-import { getLikeContest } from "../../utils/LikeContestUtils";
+import { LikeContestCategories } from "../../utils/LikeContestUtils";
 
 interface Props {
   active: ContestCategory;
   setActive: (next: ContestCategory) => void;
-  setSelectedContests: (contest: ContestCategory[]) => void;
-  showLikeContest: boolean;
+  mergeLikeContest: boolean;
 }
 
 export const TableTabButtons: React.FC<Props> = (props) => {
-  const { active, setActive, setSelectedContests, showLikeContest } = props;
+  const { active, setActive, mergeLikeContest } = props;
 
-  const resetSelectedContests = (category: ContestCategory) => {
-    const selectContests = [category];
-    const likeContest = getLikeContest(category);
-    if (likeContest && showLikeContest) selectContests.push(likeContest);
-    setSelectedContests(selectContests);
+  const filterLikeContest = (contestCategories: readonly ContestCategory[]) => {
+    if (!mergeLikeContest) return contestCategories;
+
+    return contestCategories.filter(
+      (category) => !LikeContestCategories.includes(category)
+    );
   };
   return (
     <Row>
       <ButtonGroup className="table-tab">
-        {ContestCategories.map((category, i) => (
+        {filterLikeContest(ContestCategories).map((category, i) => (
           <Button
-            key={i}
+            key={String(i)}
             color="secondary"
             onClick={(): void => {
               setActive(category);
-              resetSelectedContests(category);
             }}
             active={active === category}
           >

--- a/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const TableTabButtons: React.FC<Props> = (props) => {
   const { active, setActive, mergeLikeContest } = props;
 
-  const filterLikeContest = (contestCategories: readonly ContestCategory[]) => {
+  const filterCategories = (contestCategories: readonly ContestCategory[]) => {
     if (!mergeLikeContest) return contestCategories;
 
     return contestCategories.filter(
@@ -25,7 +25,7 @@ export const TableTabButtons: React.FC<Props> = (props) => {
   return (
     <Row>
       <ButtonGroup className="table-tab">
-        {filterLikeContest(ContestCategories).map((category, i) => (
+        {filterCategories(ContestCategories).map((category, i) => (
           <Button
             key={String(i)}
             color="secondary"

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -58,13 +58,6 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     false
   );
   const [selectedLanguages, setSelectedLanguages] = useState(new Set<string>());
-
-  const selectedContestCategories = [activeTab];
-  const likeContestCategory = getLikeContestCategory(activeTab);
-  if (likeContestCategory && mergeLikeContest) {
-    selectedContestCategories.push(likeContestCategory);
-  }
-
   const userRatingInfo = useRatingInfo(props.userId);
   const contestToProblems =
     useContestToMergedProblems() ?? new Map<ContestId, MergedProblem[]>();
@@ -88,6 +81,12 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     filteredSubmissions,
     props.userId
   );
+
+  const selectedContestCategories = [activeTab];
+  const likeContestCategory = getLikeContestCategory(activeTab);
+  if (likeContestCategory && mergeLikeContest) {
+    selectedContestCategories.push(likeContestCategory);
+  }
   const filteredContests =
     contests?.filter((c) =>
       selectedContestCategories.includes(classifyContest(c))

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -21,6 +21,7 @@ import {
   classifyContest,
   ContestCategory,
 } from "../../utils/ContestClassifier";
+import { hasLikeContest, getLikeContest } from "../../utils/LikeContestUtils";
 import { TableTabButtons } from "./TableTab";
 import { Options } from "./Options";
 import { ContestTable } from "./ContestTable";
@@ -52,7 +53,17 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     "showPenalties",
     false
   );
+  const [showLikeContest, setShowLikeContest] = useLocalStorage(
+    "showLikeContest",
+    false
+  );
   const [selectedLanguages, setSelectedLanguages] = useState(new Set<string>());
+  const selectContests = [activeTab];
+  const likeContest = getLikeContest(activeTab);
+  if (likeContest && showLikeContest) selectContests.push(likeContest);
+  const [selectedContests, setSelectedContests] = useState<ContestCategory[]>([
+    ...selectContests,
+  ]);
   const userRatingInfo = useRatingInfo(props.userId);
   const contestToProblems =
     useContestToMergedProblems() ?? new Map<ContestId, MergedProblem[]>();
@@ -77,7 +88,8 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     props.userId
   );
   const filteredContests =
-    contests?.filter((c) => classifyContest(c) === activeTab) ?? [];
+    contests?.filter((c) => selectedContests.includes(classifyContest(c))) ??
+    [];
 
   return (
     <div>
@@ -99,8 +111,18 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           newSet.has(language) ? newSet.delete(language) : newSet.add(language);
           setSelectedLanguages(newSet);
         }}
+        active={activeTab}
+        setSelectedContests={setSelectedContests}
+        showableShowLikeContest={hasLikeContest(activeTab)}
+        showLikeContest={showLikeContest}
+        setShowLikeContest={setShowLikeContest}
       />
-      <TableTabButtons active={activeTab} setActive={setActiveTab} />
+      <TableTabButtons
+        active={activeTab}
+        setActive={setActiveTab}
+        setSelectedContests={setSelectedContests}
+        showLikeContest={showLikeContest}
+      />
       {[
         "ABC",
         "ARC",

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -21,7 +21,7 @@ import {
   classifyContest,
   ContestCategory,
 } from "../../utils/ContestClassifier";
-import { getLikeContest } from "../../utils/LikeContestUtils";
+import { getLikeContestCategory } from "../../utils/LikeContestUtils";
 import { TableTabButtons } from "./TableTab";
 import { Options } from "./Options";
 import { ContestTable } from "./ContestTable";
@@ -59,9 +59,11 @@ export const TablePage: React.FC<OuterProps> = (props) => {
   );
   const [selectedLanguages, setSelectedLanguages] = useState(new Set<string>());
 
-  const selectedContests = [activeTab];
-  const likeContest = getLikeContest(activeTab);
-  if (likeContest && mergeLikeContest) selectedContests.push(likeContest);
+  const selectedContestCategories = [activeTab];
+  const likeContestCategory = getLikeContestCategory(activeTab);
+  if (likeContestCategory && mergeLikeContest) {
+    selectedContestCategories.push(likeContestCategory);
+  }
 
   const userRatingInfo = useRatingInfo(props.userId);
   const contestToProblems =
@@ -87,8 +89,9 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     props.userId
   );
   const filteredContests =
-    contests?.filter((c) => selectedContests.includes(classifyContest(c))) ??
-    [];
+    contests?.filter((c) =>
+      selectedContestCategories.includes(classifyContest(c))
+    ) ?? [];
 
   return (
     <div>

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -21,7 +21,7 @@ import {
   classifyContest,
   ContestCategory,
 } from "../../utils/ContestClassifier";
-import { hasLikeContest, getLikeContest } from "../../utils/LikeContestUtils";
+import { getLikeContest } from "../../utils/LikeContestUtils";
 import { TableTabButtons } from "./TableTab";
 import { Options } from "./Options";
 import { ContestTable } from "./ContestTable";
@@ -53,17 +53,16 @@ export const TablePage: React.FC<OuterProps> = (props) => {
     "showPenalties",
     false
   );
-  const [showLikeContest, setShowLikeContest] = useLocalStorage(
-    "showLikeContest",
+  const [mergeLikeContest, setMergeLikeContest] = useLocalStorage(
+    "MergeLikeContest",
     false
   );
   const [selectedLanguages, setSelectedLanguages] = useState(new Set<string>());
-  const selectContests = [activeTab];
+
+  const selectedContests = [activeTab];
   const likeContest = getLikeContest(activeTab);
-  if (likeContest && showLikeContest) selectContests.push(likeContest);
-  const [selectedContests, setSelectedContests] = useState<ContestCategory[]>([
-    ...selectContests,
-  ]);
+  if (likeContest && mergeLikeContest) selectedContests.push(likeContest);
+
   const userRatingInfo = useRatingInfo(props.userId);
   const contestToProblems =
     useContestToMergedProblems() ?? new Map<ContestId, MergedProblem[]>();
@@ -112,16 +111,13 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           setSelectedLanguages(newSet);
         }}
         active={activeTab}
-        setSelectedContests={setSelectedContests}
-        showableShowLikeContest={hasLikeContest(activeTab)}
-        showLikeContest={showLikeContest}
-        setShowLikeContest={setShowLikeContest}
+        mergeLikeContest={mergeLikeContest}
+        setMergeLikeContest={setMergeLikeContest}
       />
       <TableTabButtons
         active={activeTab}
         setActive={setActiveTab}
-        setSelectedContests={setSelectedContests}
-        showLikeContest={showLikeContest}
+        mergeLikeContest={mergeLikeContest}
       />
       {[
         "ABC",

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
@@ -1,0 +1,40 @@
+import { getLikeContest, hasLikeContest } from "./LikeContestUtils";
+import { ContestCategory } from "./ContestClassifier";
+
+type GetLikeContestTestType = [ContestCategory, ContestCategory | undefined];
+test.each<GetLikeContestTestType>([
+  ["ABC", "ABC-Like"],
+  ["ARC", "ARC-Like"],
+  ["AGC", "AGC-Like"],
+  ["ABC-Like", undefined],
+  ["ARC-Like", undefined],
+  ["AGC-Like", undefined],
+  ["PAST", undefined],
+  ["JOI", undefined],
+  ["JAG", undefined],
+  ["AHC", undefined],
+  ["Marathon", undefined],
+  ["Other Sponsored", undefined],
+  ["Other Contests", undefined],
+])("Get Like Contest", (contest, result) => {
+  expect(getLikeContest(contest)).toBe(result);
+});
+
+type HasLikeContestTestType = [ContestCategory, boolean];
+test.each<HasLikeContestTestType>([
+  ["ABC", true],
+  ["ARC", true],
+  ["AGC", true],
+  ["ABC-Like", false],
+  ["ARC-Like", false],
+  ["AGC-Like", false],
+  ["PAST", false],
+  ["JOI", false],
+  ["JAG", false],
+  ["AHC", false],
+  ["Marathon", false],
+  ["Other Sponsored", false],
+  ["Other Contests", false],
+])(`Has Like Contest`, (contest, result) => {
+  expect(hasLikeContest(contest)).toBe(result);
+});

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
@@ -1,4 +1,4 @@
-import { getLikeContest, hasLikeContest } from "./LikeContestUtils";
+import { getLikeContest } from "./LikeContestUtils";
 import { ContestCategory } from "./ContestClassifier";
 
 type GetLikeContestTestType = [ContestCategory, ContestCategory | undefined];
@@ -18,23 +18,4 @@ test.each<GetLikeContestTestType>([
   ["Other Contests", undefined],
 ])("Get Like Contest", (contest, result) => {
   expect(getLikeContest(contest)).toBe(result);
-});
-
-type HasLikeContestTestType = [ContestCategory, boolean];
-test.each<HasLikeContestTestType>([
-  ["ABC", true],
-  ["ARC", true],
-  ["AGC", true],
-  ["ABC-Like", false],
-  ["ARC-Like", false],
-  ["AGC-Like", false],
-  ["PAST", false],
-  ["JOI", false],
-  ["JAG", false],
-  ["AHC", false],
-  ["Marathon", false],
-  ["Other Sponsored", false],
-  ["Other Contests", false],
-])(`Has Like Contest`, (contest, result) => {
-  expect(hasLikeContest(contest)).toBe(result);
 });

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
@@ -1,4 +1,4 @@
-import { getLikeContest } from "./LikeContestUtils";
+import { getLikeContestCategory } from "./LikeContestUtils";
 import { ContestCategory } from "./ContestClassifier";
 
 type GetLikeContestTestType = [ContestCategory, ContestCategory | undefined];
@@ -17,5 +17,5 @@ test.each<GetLikeContestTestType>([
   ["Other Sponsored", undefined],
   ["Other Contests", undefined],
 ])("Get Like Contest", (contest, result) => {
-  expect(getLikeContest(contest)).toBe(result);
+  expect(getLikeContestCategory(contest)).toBe(result);
 });

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
@@ -15,6 +15,8 @@ export const getLikeContest = (
   }
 };
 
-export const hasLikeContest = (contestCategory: ContestCategory): boolean => {
-  return ["ABC", "ARC", "AGC"].includes(contestCategory);
-};
+export const LikeContestCategories: readonly ContestCategory[] = [
+  "ABC-Like",
+  "ARC-Like",
+  "AGC-Like",
+];

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
@@ -1,6 +1,6 @@
 import { ContestCategory } from "./ContestClassifier";
 
-export const getLikeContest = (
+export const getLikeContestCategory = (
   contestCategory: ContestCategory
 ): ContestCategory | undefined => {
   switch (contestCategory) {

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
@@ -1,0 +1,20 @@
+import { ContestCategory } from "./ContestClassifier";
+
+export const getLikeContest = (
+  contestCategory: ContestCategory
+): ContestCategory | undefined => {
+  switch (contestCategory) {
+    case "ABC":
+      return "ABC-Like";
+    case "ARC":
+      return "ARC-Like";
+    case "AGC":
+      return "AGC-Like";
+    default:
+      break;
+  }
+};
+
+export const hasLikeContest = (contestCategory: ContestCategory): boolean => {
+  return ["ABC", "ARC", "AGC"].includes(contestCategory);
+};

--- a/atcoder-problems-frontend/src/utils/LocalStorage.tsx
+++ b/atcoder-problems-frontend/src/utils/LocalStorage.tsx
@@ -17,7 +17,7 @@ const LocalStorageKeys = [
   "recommendOption",
   "recommendExperimental",
   "recoomendExcludeOption",
-  "showLikeContest",
+  "MergeLikeContest",
 ] as const;
 type LocalStorageKey = typeof LocalStorageKeys[number];
 

--- a/atcoder-problems-frontend/src/utils/LocalStorage.tsx
+++ b/atcoder-problems-frontend/src/utils/LocalStorage.tsx
@@ -17,6 +17,7 @@ const LocalStorageKeys = [
   "recommendOption",
   "recommendExperimental",
   "recoomendExcludeOption",
+  "showLikeContest",
 ] as const;
 type LocalStorageKey = typeof LocalStorageKeys[number];
 


### PR DESCRIPTION
Feature #1194 

## 方針
- issues #1194 で提案されていた機能に関して「トグルボタンを用意してそれをONにした時にAC-likeをなくしてACにいれる」の実現を目指し実装した
PRを作成した
  - Likeコンテストを通常コンテストにmergeするトグルボタンを表示する
  - 追加したトグルボタン ONの場合、A`*`C-likeを隠し A`*`C にlikeコンテストの内容を含めて表示する

## QA
- 追加したトグルボタンがON場合、LikeコンテストがtableTabから消える ○
- 追加したトグルボタンがON場合、通常コンテストにLikeコンテストの内容が含まれた状態で表示される
  - ABC ○
  - ARC ○
  - AGC ○
- 追加したトグルボタンは画面のリロード時にリロード前の結果が保持されている
  - 追加したトグルボタンがON場合 ○
  - 追加したトグルボタンがOFF場合 ○

## 画像（2022/08/28更新済み）
| トグルボタンがOFF | トグルボタンがON |
| --- | --- |
| ![スクリーンショット 2022-08-28 1 54 41](https://user-images.githubusercontent.com/55447682/187040188-49ac97ee-6978-4a13-9c50-d76ea7bf4d2e.png) | ![スクリーンショット 2022-08-28 1 54 52](https://user-images.githubusercontent.com/55447682/187040196-954d8cc0-9bb8-4838-92a7-5c35760f960b.png) |