### PR TITLE
ビルド済みのmdBookをダウンロードするようにした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,14 @@ jobs:
             ./atcoder-problems-frontend/node_modules
           key: ${{ runner.os }}-cargo-${{ hashFiles('atcoder-problems-frontend/yarn.lock') }}
 
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ./atcoder-problems-backend/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('atcoder-problems-backend/Cargo.lock') }}
-
       - name: Install dependencies
         run: yarn
+
       - name: Setup mdBook
-        run: cargo install mdbook
+        uses: peaceiris/actions-mdbook@v1.1.13
+        with:
+          mdbook-version: 'latest'
+
       - name: build
         run: yarn build
       - name: test


### PR DESCRIPTION
`mdbook-action`を使用してビルド済みのmdBookをダウンロードするようにしました。毎回ビルドする必要が無くなり、CIの高速化が見込まれます。バイナリは[mdBookのReleases](https://github.com/rust-lang/mdBook/releases)から取ってきているようです。
https://github.com/marketplace/actions/mdbook-action