### PR TITLE
Rust 1.63.0へ更新

### DIFF
--- a/atcoder-problems-backend/Dockerfile
+++ b/atcoder-problems-backend/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.57.0 AS development
+FROM rust:1.63.0 AS development
 RUN rustup component add rustfmt
 RUN rustup component add clippy
 
 # Using the official cargo-chef image
-FROM lukemathwalker/cargo-chef:latest-rust-1.61.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.63.0 AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -18,7 +18,7 @@ COPY . .
 RUN cargo build --release
 
 # プロダクション用の Docker イメージをビルドする
-FROM rust:1.61.0 AS production
+FROM rust:1.63.0 AS production
 COPY --from=builder /app/target/release/batch_update                /usr/bin/batch_update
 COPY --from=builder /app/target/release/crawl_all_submissions       /usr/bin/crawl_all_submissions
 COPY --from=builder /app/target/release/crawl_for_virtual_contests  /usr/bin/crawl_for_virtual_contests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "15432:5432"
 
   backend-development:
-    image: rust:1.57
+    image: rust:1.63.0
     environment:
       SQL_URL: postgres://db_user:db_pass@postgresql:5432/test_db
       DATABASE_URL: postgres://db_user:db_pass@postgresql:5432/test_db


### PR DESCRIPTION
`sqlx`を更新するコミット (b4fb7e9349a85324d9c4dcc5603f5cbc85f622bb) 以降、Cargo 1.57のバグによってビルド（正確には依存関係の解決）が通らなくなってるので、バグが修正されている最新のものに更新しました。

バグはCargo 1.58で修正されていますが、今更そのバージョンにするのも妙なので最新のもの（1.63）にしました。

他にRustを使う部分もついでに更新しています。