### PR TITLE
メソッド名をisLikeContestからisLikeContestCategoryに変更

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/TableTab.tsx
@@ -4,7 +4,7 @@ import {
   ContestCategories,
   ContestCategory,
 } from "../../utils/ContestClassifier";
-import { isLikeContest } from "../../utils/LikeContestUtils";
+import { isLikeContestCategory } from "../../utils/LikeContestUtils";
 
 interface Props {
   active: ContestCategory;
@@ -17,7 +17,7 @@ export const TableTabButtons: React.FC<Props> = (props) => {
 
   const filteredCategories = useMemo(() => {
     return ContestCategories.filter(
-      (category) => !mergeLikeContest || !isLikeContest(category)
+      (category) => !mergeLikeContest || !isLikeContestCategory(category)
     );
   }, [mergeLikeContest]);
 

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.test.ts
@@ -1,4 +1,7 @@
-import { getLikeContestCategory } from "./LikeContestUtils";
+import {
+  getLikeContestCategory,
+  isLikeContestCategory,
+} from "./LikeContestUtils";
 import { ContestCategory } from "./ContestClassifier";
 
 type GetLikeContestTestType = [ContestCategory, ContestCategory | undefined];
@@ -16,6 +19,25 @@ test.each<GetLikeContestTestType>([
   ["Marathon", undefined],
   ["Other Sponsored", undefined],
   ["Other Contests", undefined],
-])("Get Like Contest", (contest, result) => {
+])("Get Like Contest Category", (contest, result) => {
   expect(getLikeContestCategory(contest)).toBe(result);
+});
+
+type IsLikeContestCategoryTestType = [ContestCategory, boolean];
+test.each<IsLikeContestCategoryTestType>([
+  ["ABC", false],
+  ["ARC", false],
+  ["AGC", false],
+  ["ABC-Like", true],
+  ["ARC-Like", true],
+  ["AGC-Like", true],
+  ["PAST", false],
+  ["JOI", false],
+  ["JAG", false],
+  ["AHC", false],
+  ["Marathon", false],
+  ["Other Sponsored", false],
+  ["Other Contests", false],
+])("Is Like Contest Category", (contest, result) => {
+  expect(isLikeContestCategory(contest)).toBe(result);
 });

--- a/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
+++ b/atcoder-problems-frontend/src/utils/LikeContestUtils.ts
@@ -20,6 +20,6 @@ const LikeContestCategories: readonly ContestCategory[] = [
   "ARC-Like",
   "AGC-Like",
 ];
-export const isLikeContest = (category: ContestCategory) => {
+export const isLikeContestCategory = (category: ContestCategory) => {
   return LikeContestCategories.includes(category);
 };


### PR DESCRIPTION
## やったこと
- `isLikeContest`→`isLikeContestCategory`にメソッド名を変更
- `isLikeContestCategory`のUnit Test導入

## PR作成の経緯
https://github.com/kenkoooo/AtCoderProblems/pull/1272#discussion_r958553621