### PR TITLE
オンサイトの問題のリンク先がオープンコンテストになる問題を修正

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/ContestTable.tsx
@@ -120,7 +120,7 @@ export const ContestTable: React.FC<Props> = (props) => {
                             )}
                             showDifficulty={props.showDifficulty}
                             problemId={problem.id}
-                            contestId={problem.contest_id}
+                            contestId={contest.id}
                             problemIndex={problem.problem_index}
                             problemName={problem.name}
                             problemModel={model}


### PR DESCRIPTION
#1274 で報告されていた問題のリンク先がオープンコンテストになってしまうのを本来のコンテストページに遷移するように修正したので確認をお願いします。