### PR TITLE
add: Add TEE In Those Days Chart to UserPage.

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
@@ -27,6 +27,7 @@ import { useLocalStorage } from "../../../utils/LocalStorage";
 import {
   countUniqueAcByDate,
   countTeeByDate,
+  countTeeInTheOldDays,
 } from "../../../utils/StreakCounter";
 import Submission from "../../../interfaces/Submission";
 import { ProblemId } from "../../../interfaces/Status";
@@ -145,6 +146,8 @@ export const ProgressChartBlock: React.FC<Props> = (props) => {
     }
     return list;
   }, [] as { dateSecond: number; count: number }[]);
+
+  const teeInTheOldDays = countTeeInTheOldDays(dailyTeeCount);
 
   const dateColorCountMap = Array.from(submissionsByProblem.values())
     .map((submissionsOfProblem) => {
@@ -276,6 +279,11 @@ export const ProgressChartBlock: React.FC<Props> = (props) => {
         <h1>TEE Climbing</h1>
       </Row>
       <TeeChart climbingData={teeClimbing} />
+
+      <Row className="my-2 border-bottom">
+        <h1>TEE In The Old Days</h1>
+      </Row>
+      <TeeChart climbingData={teeInTheOldDays} />
 
       <Row className="my-2 border-bottom">
         <h1>Heatmap</h1>

--- a/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/ProgressChartBlock/index.tsx
@@ -27,7 +27,7 @@ import { useLocalStorage } from "../../../utils/LocalStorage";
 import {
   countUniqueAcByDate,
   countTeeByDate,
-  countTeeInTheOldDays,
+  countTeeMovingAverage,
 } from "../../../utils/StreakCounter";
 import Submission from "../../../interfaces/Submission";
 import { ProblemId } from "../../../interfaces/Status";
@@ -147,7 +147,7 @@ export const ProgressChartBlock: React.FC<Props> = (props) => {
     return list;
   }, [] as { dateSecond: number; count: number }[]);
 
-  const teeInTheOldDays = countTeeInTheOldDays(dailyTeeCount);
+  const teeMovingAverage = countTeeMovingAverage(dailyTeeCount);
 
   const dateColorCountMap = Array.from(submissionsByProblem.values())
     .map((submissionsOfProblem) => {
@@ -281,9 +281,9 @@ export const ProgressChartBlock: React.FC<Props> = (props) => {
       <TeeChart climbingData={teeClimbing} />
 
       <Row className="my-2 border-bottom">
-        <h1>TEE In The Old Days</h1>
+        <h1>TEE Moving Average (30 days)</h1>
       </Row>
-      <TeeChart climbingData={teeInTheOldDays} />
+      <TeeChart climbingData={teeMovingAverage} />
 
       <Row className="my-2 border-bottom">
         <h1>Heatmap</h1>

--- a/atcoder-problems-frontend/src/utils/StreakCounter.ts
+++ b/atcoder-problems-frontend/src/utils/StreakCounter.ts
@@ -111,3 +111,43 @@ export const countTeeByDate = (
     .map(([dateLabel, count]) => ({ dateLabel, count }))
     .sort((a, b) => a.dateLabel.localeCompare(b.dateLabel));
 };
+
+export const countTeeInTheOldDays = (
+  dailyTeeCount: {
+    dateLabel: string;
+    count: number;
+  }[]
+) => {
+  const DURATION = 30;
+
+  const minDateLabel = dailyTeeCount[0].dateLabel;
+  const maxDateLabel = dailyTeeCount[dailyTeeCount.length - 1].dateLabel;
+  const dateDelta =
+    (+new Date(maxDateLabel) - +new Date(minDateLabel)) / 1000 / 86400;
+
+  const differentiatedTees = Array.from(Array(dateDelta)).map((__, i) => {
+    const nextDate = new Date(minDateLabel);
+    nextDate.setDate(nextDate.getDate() + i);
+    const nextDateLabel = nextDate.toISOString().substring(0, 10);
+    const found = dailyTeeCount.find((tee) => tee.dateLabel === nextDateLabel);
+    if (found) {
+      return found;
+    } else {
+      return { dateLabel: nextDateLabel, count: 0 };
+    }
+  });
+
+  return differentiatedTees
+    .map(({ dateLabel }, i) => {
+      const dateSecond = parseDateLabel(dateLabel).unix();
+      const begin = Math.max(i - (DURATION - 1), 0);
+      const total = differentiatedTees
+        .slice(begin, i + 1)
+        .reduce((tot, data) => data.count + tot, 0);
+      if (!total) {
+        return null;
+      }
+      return { dateSecond, count: total };
+    })
+    .filter((data) => !!data) as { dateSecond: number; count: number }[];
+};

--- a/atcoder-problems-frontend/src/utils/StreakCounter.ts
+++ b/atcoder-problems-frontend/src/utils/StreakCounter.ts
@@ -112,18 +112,24 @@ export const countTeeByDate = (
     .sort((a, b) => a.dateLabel.localeCompare(b.dateLabel));
 };
 
-export const countTeeInTheOldDays = (
+export const countTeeMovingAverage = (
   dailyTeeCount: {
     dateLabel: string;
     count: number;
   }[]
 ) => {
   const DURATION = 30;
+  if (!Array.isArray(dailyTeeCount) || dailyTeeCount.length === 0) {
+    return [];
+  }
 
   const minDateLabel = dailyTeeCount[0].dateLabel;
   const maxDateLabel = dailyTeeCount[dailyTeeCount.length - 1].dateLabel;
   const dateDelta =
-    (+new Date(maxDateLabel) - +new Date(minDateLabel)) / 1000 / 86400;
+    1 +
+    (new Date(maxDateLabel).getTime() - new Date(minDateLabel).getTime()) /
+      1000 /
+      86400;
 
   const differentiatedTees = Array.from(Array(dateDelta)).map((__, i) => {
     const nextDate = new Date(minDateLabel);
@@ -147,7 +153,7 @@ export const countTeeInTheOldDays = (
       if (!total) {
         return null;
       }
-      return { dateSecond, count: total };
+      return { dateSecond, count: total / DURATION };
     })
-    .filter((data) => !!data) as { dateSecond: number; count: number }[];
+    .filter((data): data is { dateSecond: number; count: number } => !!data);
 };


### PR DESCRIPTION
こんにちは。はじめまして。かえると言います。いつもatcoder problems使わせていただいています。ありがとうございます。

---

日付をxとしたときに、`[max(x - 29, 0), x]`の間に解いたTEEの合計をグラフにしてみました。

趣旨は「TEEの30日移動平均 ✕ 30」をプロットするものです。コロナの7日移動平均線の気持ちです。

「過去の指定日からそれより1ヶ月前までの間、自分はどれだけTEEを達成していたか」を直近の自分と比較して、昔(in the old days)はどのぐらい頑張っていたかを示して「うおおおお！あの頃はもっとやっていたのかあああ！」となるためのものです。

<img width="1641" alt="image" src="https://user-images.githubusercontent.com/5797788/205299630-bd426ea1-2d42-44a8-9eac-3089d3d29bb8.png">


↓以下を拝見して、一応趣旨には反していなさそうだと判断してPRを作らせていただきました。もしよろしければレビューしてもらえるとありがたいですm(_ _)m `O(N^2)` ですが、データ量的には10年分の日付で10^7なので、いったん問題ないと判断しています。

https://github.com/kenkoooo/AtCoderProblems/issues/848

https://github.com/kenkoooo/AtCoderProblems/issues/1192