### PR TITLE
Submissions タブで問題名の検索をできるようにする

### DIFF
--- a/atcoder-problems-frontend/src/components/SubmissionListTable.tsx
+++ b/atcoder-problems-frontend/src/components/SubmissionListTable.tsx
@@ -14,6 +14,12 @@ import {
 } from "./ListPaginationPanel";
 import { NewTabLink } from "./NewTabLink";
 
+const problemTitle = (
+  problemName: string | undefined,
+  { problemIndex }: { problemIndex?: string }
+): string =>
+  problemIndex ? `${problemIndex}. ${problemName || ""}` : problemName || "";
+
 interface Props {
   submissions: Submission[];
   userRatingInfo?: RatingInfo;
@@ -113,7 +119,7 @@ export const SubmissionListTable: React.FC<Props> = (props) => {
         Date
       </TableHeaderColumn>
       <TableHeaderColumn
-        filterFormatted
+        filterValue={problemTitle}
         dataSort
         dataField="name"
         dataFormat={(


### PR DESCRIPTION
問題名で検索ができなくなっていたのを修正しました