### PR TITLE
Create indexes on the ranking tables

### DIFF
--- a/atcoder-problems-backend/sql-client/src/internal/virtual_contest_manager.rs
+++ b/atcoder-problems-backend/sql-client/src/internal/virtual_contest_manager.rs
@@ -157,7 +157,7 @@ impl VirtualContestManager for PgPool {
     async fn get_own_contests(&self, internal_user_id: &str) -> Result<Vec<VirtualContestInfo>> {
         let contests = sqlx::query_as(
             r"
-            SELECT 
+            SELECT
                 id,
                 title,
                 memo,
@@ -184,7 +184,7 @@ impl VirtualContestManager for PgPool {
     ) -> Result<Vec<VirtualContestInfo>> {
         let contests = sqlx::query_as(
             r"
-            SELECT 
+            SELECT
                 a.id,
                 a.title,
                 a.memo,
@@ -234,7 +234,7 @@ impl VirtualContestManager for PgPool {
     async fn get_single_contest_participants(&self, contest_id: &str) -> Result<Vec<String>> {
         let participants = sqlx::query(
             r"
-            SELECT 
+            SELECT
                 b.atcoder_user_id
             FROM (
                 SELECT internal_user_id
@@ -280,7 +280,7 @@ impl VirtualContestManager for PgPool {
     async fn get_recent_contest_info(&self) -> Result<Vec<VirtualContestInfo>> {
         let contests = sqlx::query_as(
             r"
-            SELECT 
+            SELECT
                 id,
                 title,
                 memo,

--- a/atcoder-problems-backend/sql-client/src/language_count.rs
+++ b/atcoder-problems-backend/sql-client/src/language_count.rs
@@ -113,7 +113,7 @@ impl LanguageCountClient for PgPool {
     async fn load_language_count(&self) -> Result<Vec<UserLanguageCount>> {
         let count = sqlx::query_as(
             r"
-            SELECT 
+            SELECT
                 user_id,
                 simplified_language,
                 problem_count

--- a/atcoder-problems-backend/sql-client/src/language_count.rs
+++ b/atcoder-problems-backend/sql-client/src/language_count.rs
@@ -150,7 +150,7 @@ impl LanguageCountClient for PgPool {
         let count = sqlx::query_as(
             r"
             SELECT user_id, simplified_language, problem_count FROM language_count
-            WHERE user_id = $1
+            WHERE LOWER(user_id) = LOWER($1)
             ORDER BY simplified_language
             ",
         )
@@ -171,7 +171,7 @@ impl LanguageCountClient for PgPool {
                 OVER(PARTITION BY simplified_language ORDER BY problem_count DESC) AS rank
                 FROM language_count
             )
-            AS s2 WHERE user_id = $1
+            AS s2 WHERE LOWER(user_id) = LOWER($1)
             ORDER BY simplified_language
             ",
         )

--- a/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
+++ b/atcoder-problems-backend/sql-client/src/rated_point_sum.rs
@@ -27,7 +27,7 @@ impl RatedPointSumClient for PgPool {
                 GROUP BY contest_id
             ) AS contest_problem_count
             JOIN contests ON contests.id=contest_problem_count.contest_id
-            WHERE 
+            WHERE
                 contests.start_epoch_second >= $1
                 AND contests.rate_change != $2
                 AND contest_problem_count.problem_count >= 2

--- a/atcoder-problems-backend/sql-client/src/simple_client.rs
+++ b/atcoder-problems-backend/sql-client/src/simple_client.rs
@@ -114,7 +114,7 @@ impl SimpleClient for PgPool {
     async fn load_contests(&self) -> Result<Vec<Contest>> {
         let contests = sqlx::query_as(
             r"
-                 SELECT 
+                 SELECT
                     id,
                     start_epoch_second,
                     duration_second,

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -121,7 +121,7 @@ impl SubmissionClient for PgPool {
                 r"
                     SELECT * FROM submissions
                     WHERE result = 'AC'
-                    AND user_id = ANY($1)
+                    AND LOWER(user_id) = ANY($1)
                     ",
             )
             .bind(user_ids)
@@ -163,7 +163,7 @@ impl SubmissionClient for PgPool {
             } => sqlx::query_as(
                 r"
                     SELECT * FROM submissions
-                    WHERE user_id = ANY($1)
+                    WHERE LOWER(user_id) = ANY($1)
                     AND problem_id = ANY($2)
                     AND epoch_second >= $3
                     AND epoch_second <= $4

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -136,11 +136,11 @@ impl SubmissionClient for PgPool {
             SubmissionRequest::InvalidResult { from_second } => sqlx::query_as(
                 r"
                     SELECT * FROM submissions
-                    WHERE 
+                    WHERE
                         result != ALL(
                             ARRAY['AC', 'WA', 'TLE', 'CE', 'RE', 'MLE', 'OLE', 'QLE', 'IE', 'NG']
                         )
-                    AND 
+                    AND
                         epoch_second >= $1
                     ORDER BY id DESC
                     ",

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -186,7 +186,7 @@ CREATE INDEX ON internal_virtual_contest_items (internal_virtual_contest_id);
 CREATE TABLE internal_virtual_contest_participants (
   internal_virtual_contest_id VARCHAR(255) REFERENCES internal_virtual_contests(id) ON DELETE CASCADE ON UPDATE CASCADE,
   internal_user_id      VARCHAR(255) REFERENCES internal_users ON DELETE CASCADE ON UPDATE CASCADE,
-  PRIMARY KEY (internal_virtual_contest_id, internal_user_id)  
+  PRIMARY KEY (internal_virtual_contest_id, internal_user_id)
 );
 CREATE INDEX ON internal_virtual_contest_participants (internal_user_id);
 

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -16,8 +16,6 @@ CREATE TABLE submissions (
   execution_time  INT,
   PRIMARY KEY (id)
 );
-CREATE INDEX ON submissions (user_id);
-CREATE INDEX ON submissions (LOWER(user_id));
 CREATE INDEX ON submissions (epoch_second);
 CREATE INDEX ON submissions (user_id, epoch_second ASC);
 CREATE INDEX ON submissions (LOWER(user_id), epoch_second ASC);

--- a/config/database-definition.sql
+++ b/config/database-definition.sql
@@ -79,6 +79,8 @@ CREATE TABLE accepted_count (
   problem_count INT           NOT NULL,
   PRIMARY KEY (user_id)
 );
+CREATE INDEX ON accepted_count (LOWER(user_id));
+CREATE INDEX ON accepted_count (problem_count DESC, user_id);
 
 DROP TABLE IF EXISTS points;
 CREATE TABLE points (
@@ -94,6 +96,8 @@ CREATE TABLE rated_point_sum (
   point_sum       BIGINT NOT NULL,
   PRIMARY KEY (user_id)
 );
+CREATE INDEX ON rated_point_sum (LOWER(user_id));
+CREATE INDEX ON rated_point_sum (point_sum DESC, user_id);
 
 DROP TABLE IF EXISTS language_count;
 CREATE TABLE language_count (
@@ -102,6 +106,8 @@ CREATE TABLE language_count (
   problem_count         INT NOT NULL,
   PRIMARY KEY (user_id, simplified_language)
 );
+CREATE INDEX ON language_count (LOWER(user_id));
+CREATE INDEX ON language_count (simplified_language, problem_count DESC, user_id);
 
 DROP TABLE IF EXISTS predicted_rating;
 CREATE TABLE predicted_rating (
@@ -124,6 +130,8 @@ CREATE TABLE max_streaks (
   streak                BIGINT NOT NULL,
   PRIMARY KEY (user_id)
 );
+CREATE INDEX ON max_streaks (LOWER(user_id));
+CREATE INDEX ON max_streaks (streak DESC, user_id);
 
 -- For internal services:
 DROP TABLE IF EXISTS internal_problem_list_items;


### PR DESCRIPTION
いくつかのテーブルでインデックスを張るようにしました。

`submissions`テーブルの重複しているインデックスを削除しました(2023/01/13追加)

ユーザー名の大文字小文字を区別するSQLを見つけたので、区別しないようついでに修正しました。

## 背景

ブラウザの開発者ツールを眺めていて、ランキング関連のエンドポイントからの応答が遅い事に気が付きました。

Rated Point Sumのランキング（`/v3/user/rated_point_sum_rank`）が500ms前後、言語別AC数のランキング（`/v3/language_ranking`）は1.5秒～3秒の時間がかかっており、開発者ツール曰く、遅いとされる部類のようです。

`database-definition.sql`を確認したところ、インデックスが張られていないことに気が付きました。ランキングのテーブルは頻繁に参照されるので、インデックスを張った方が良いと思いました。

![image](https://user-images.githubusercontent.com/44938840/210150262-406793ea-5e6b-44c1-ba87-29a24b250c91.png)
![image](https://user-images.githubusercontent.com/44938840/210150053-546b3a7d-7b5e-4cf2-a690-06f1b9963f28.png)

## Before After

```SQL
-- ユーザーのRated Point Sumを取得する
EXPLAIN ANALYSE
SELECT
    point_sum
FROM
    rated_point_sum
WHERE
    LOWER(user_id) = 'hotate29';
```

張る前

```text
Gather  (cost=1000.00..4870.15 rows=1264 width=17) (actual time=39.381..40.907 rows=1 loops=1)
  Workers Planned: 1
  Workers Launched: 1
  ->  Parallel Seq Scan on rated_point_sum  (cost=0.00..3743.75 rows=744 width=17) (actual time=28.255..38.239 rows=0 loops=2)
        Filter: (lower((user_id)::text) = 'hotate29'::text)
        Rows Removed by Filter: 126352
Planning Time: 0.213 ms
Execution Time: 40.920 ms
```

張った後

```SQL
CREATE INDEX ON rated_point_sum (LOWER(user_id));
```

```text
Bitmap Heap Scan on rated_point_sum  (cost=30.22..1563.15 rows=1264 width=17) (actual time=0.021..0.021 rows=1 loops=1)
  Recheck Cond: (lower((user_id)::text) = 'hotate29'::text)
  Heap Blocks: exact=1
  ->  Bitmap Index Scan on rated_point_sum_lower_idx  (cost=0.00..29.90 rows=1264 width=0) (actual time=0.009..0.009 rows=1 loops=1)
        Index Cond: (lower((user_id)::text) = 'hotate29'::text)
Planning Time: 0.252 ms
Execution Time: 0.029 ms
```

---

```SQL
-- C++でのAC数上位3人を取得
EXPLAIN ANALYSE
SELECT
    user_id, problem_count
FROM
    language_count
WHERE
    simplified_language = 'C++'
ORDER BY
    problem_count DESC, user_id ASC
OFFSET 0 LIMIT 3;
```

張る前

```text
Limit  (cost=8187.44..8187.79 rows=3 width=13) (actual time=33.363..33.364 rows=3 loops=1)
  ->  Gather Merge  (cost=8187.44..22404.89 rows=123630 width=13) (actual time=33.362..35.349 rows=3 loops=1)
        Workers Planned: 1
        Workers Launched: 1
        ->  Sort  (cost=7187.43..7496.51 rows=123630 width=13) (actual time=32.402..32.403 rows=2 loops=2)
              Sort Key: problem_count DESC, user_id
              Sort Method: top-N heapsort  Memory: 25kB
              Worker 0:  Sort Method: top-N heapsort  Memory: 25kB
              ->  Parallel Seq Scan on language_count  (cost=0.00..5589.54 rows=123630 width=13) (actual time=0.006..21.847 rows=104200 loops=2)
                    Filter: ((simplified_language)::text = 'C++'::text)
                    Rows Removed by Filter: 103780
Planning Time: 0.070 ms
Execution Time: 35.371 ms
```

張った後

```SQL
CREATE INDEX ON language_count (simplified_language, problem_count DESC, user_id);
```

```text
Limit  (cost=0.42..0.67 rows=3 width=13) (actual time=0.031..0.033 rows=3 loops=1)
  ->  Index Only Scan using language_count_simplified_language_problem_count_user_id_idx on language_count  (cost=0.42..17073.12 rows=210171 width=13) (actual time=0.030..0.033 rows=3 loops=1)
        Index Cond: (simplified_language = 'C++'::text)
        Heap Fetches: 3
Planning Time: 0.072 ms
Execution Time: 0.042 ms
```
