### PR TITLE
Update the workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "atcoder-problems-frontend/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2.2.0
         with:
-          working-directory: ./atcoder-problems-backend
+          workspaces: atcoder-problems-backend -> target
 
       - name: Setup Postgresql
         run: psql ${SQL_URL} < ../config/database-definition.sql
@@ -70,12 +70,15 @@ jobs:
         working-directory: ./atcoder-problems-frontend
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
+
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 16
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         with:
           path: |
             ~/.cache/Cypress
@@ -86,9 +89,9 @@ jobs:
         run: yarn
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1.1.13
+        uses: peaceiris/actions-mdbook@v1.2.0
         with:
-          mdbook-version: 'latest'
+          mdbook-version: "latest"
 
       - name: build
         run: yarn build


### PR DESCRIPTION
GitHub Actionsで「この機能は近いうちに廃止されるぜ！」という警告が出ていたので、諸々のworkflowを更新しました。

今後の更新を楽にするために、dependabotがworkflowを更新するPRを作成するようにしました。

![Screenshot 2023-01-22 at 23-27-49 build(deps) bump async-trait from 0 1 60 to 0 1 62 in _atcoder-problems-backend · kenkoooo_AtCoderProblems@3f2e36e](https://user-images.githubusercontent.com/44938840/213921060-a598cfeb-8136-4dab-8b84-1788cb75b521.png)
