### PR TITLE
Case insensitive漏れを修正

### DIFF
--- a/atcoder-problems-backend/sql-client/src/models.rs
+++ b/atcoder-problems-backend/sql-client/src/models.rs
@@ -18,7 +18,7 @@ pub struct Problem {
     pub title: String,
 }
 
-#[derive(Debug, Clone, Serialize, Default, Deserialize, sqlx::FromRow)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default, Deserialize, sqlx::FromRow)]
 pub struct Submission {
     pub id: i64,
     pub epoch_second: i64,

--- a/atcoder-problems-backend/sql-client/src/submission_client.rs
+++ b/atcoder-problems-backend/sql-client/src/submission_client.rs
@@ -121,7 +121,7 @@ impl SubmissionClient for PgPool {
                 r"
                     SELECT * FROM submissions
                     WHERE result = 'AC'
-                    AND LOWER(user_id) = ANY($1)
+                    AND LOWER(user_id) = ANY(SELECT LOWER(u) FROM UNNEST($1) AS a(u))
                     ",
             )
             .bind(user_ids)
@@ -163,7 +163,7 @@ impl SubmissionClient for PgPool {
             } => sqlx::query_as(
                 r"
                     SELECT * FROM submissions
-                    WHERE LOWER(user_id) = ANY($1)
+                    WHERE LOWER(user_id) = ANY(SELECT LOWER(u) FROM UNNEST($1) AS a(u))
                     AND problem_id = ANY($2)
                     AND epoch_second >= $3
                     AND epoch_second <= $4


### PR DESCRIPTION
#1337 において、`SubmissionClient`がcase insensitiveになるように変更を行いました。しかし、`UsersProblemsTime`、`UsersAccepted`のリクエストが来た際に発行されるSQLに誤りがあり、不十分なことが分かりました。#1353 の原因になっている可能性があります。

具体的には、

```SQL
LOWER(user_id) = ANY(SELECT LOWER(u) FROM UNNEST($1) AS a(u))
```

とするべき部分が、

```SQL
LOWER(user_id) = ANY($1)
```

という、誤った状態になっており、対象のユーザー名に大文字が含まれる場合に妙な返答をしてしまいます(https://github.com/kenkoooo/AtCoderProblems/issues/1353#issuecomment-1440089332 )。

変更が不十分だった箇所: https://github.com/kenkoooo/AtCoderProblems/pull/1337/commits/26a01881166f18a518832a1638799c9d03a3cae6#diff-b99c1b312c4e1377b1cb4ab2bafda8553b72d55f19e65a7f5984febd45af1385
