### PR TITLE
Pie Chartsの表示をRatedとAllで切り替え可能にする

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -1,8 +1,9 @@
-import { Col, Row } from "reactstrap";
-import React from "react";
+import { Col, Row, Button, ButtonGroup } from "reactstrap";
+import React, { useState } from "react";
 import {
   useContestToProblems,
   useUserSubmission,
+  useContestMap,
 } from "../../../api/APIClient";
 import Problem from "../../../interfaces/Problem";
 import Submission from "../../../interfaces/Submission";
@@ -12,6 +13,7 @@ import {
   isAccepted,
   isValidResult,
 } from "../../../utils";
+import { isRatedContest } from "../../../utils/ContestClassifier";
 import { SmallPieChart } from "./SmallPieChart";
 
 enum SubmissionStatus {
@@ -143,18 +145,26 @@ export const PieChartBlock = (props: Props) => {
   );
   const contestToProblems =
     useContestToProblems() ?? new Map<ContestId, Problem[]>();
+  const [onlyRated, setOnlyRated] = useState(true);
+  const contestMap = useContestMap();
 
   const abcSolved = solvedCountForPieChart(
-    Array.from(contestToProblems).filter(([contestId]) =>
-      contestId.startsWith("abc")
-    ),
+    Array.from(contestToProblems)
+      .filter(([contestId]) => contestId.startsWith("abc"))
+      .filter(
+        ([contestId]) =>
+          isRatedContest(contestMap.get(contestId), 2) || !onlyRated
+      ),
     submissionsMap,
     props.userId
   );
   const arcSolved = solvedCountForPieChart(
-    Array.from(contestToProblems).filter(([contestId]) =>
-      contestId.startsWith("arc")
-    ),
+    Array.from(contestToProblems)
+      .filter(([contestId]) => contestId.startsWith("arc"))
+      .filter(
+        ([contestId]) =>
+          isRatedContest(contestMap.get(contestId), 2) || !onlyRated
+      ),
     submissionsMap,
     props.userId
   );
@@ -167,9 +177,24 @@ export const PieChartBlock = (props: Props) => {
   );
   return (
     <>
-      <PieCharts problems={abcSolved} title="AtCoder Beginner Contest" />
-      <PieCharts problems={arcSolved} title="AtCoder Regular Contest" />
-      <PieCharts problems={agcSolved} title="AtCoder Grand Contest" />
+      <PieCharts
+        problems={abcSolved}
+        title="AtCoder Beginner Contest"
+        setOnlyRated={setOnlyRated}
+        onlyRated={onlyRated}
+      />
+      <PieCharts
+        problems={arcSolved}
+        title="AtCoder Regular Contest"
+        setOnlyRated={setOnlyRated}
+        onlyRated={onlyRated}
+      />
+      <PieCharts
+        problems={agcSolved}
+        title="AtCoder Grand Contest"
+        setOnlyRated={setOnlyRated}
+        onlyRated={onlyRated}
+      />
     </>
   );
 };
@@ -177,13 +202,25 @@ export const PieChartBlock = (props: Props) => {
 interface PieChartsProps {
   problems: { total: number; solved: number; rejected: number }[];
   title: string;
+  setOnlyRated: (onlyRated: boolean) => void;
+  onlyRated: boolean;
 }
 
-const PieCharts: React.FC<PieChartsProps> = ({ problems, title }) => (
+const PieCharts: React.FC<PieChartsProps> = ({
+  problems,
+  title,
+  setOnlyRated,
+  onlyRated,
+}) => (
   <div>
     <Row className="my-2 border-bottom">
       <h1>{title}</h1>
     </Row>
+    <ButtonGroup className="mb-2">
+      <Button onClick={(): void => setOnlyRated(!onlyRated)}>
+        {onlyRated ? "Only Rated Contests" : "All Contests"}
+      </Button>
+    </ButtonGroup>
     <Row className="my-3">
       {problems.map(({ solved, rejected, total }, i) => {
         const key = i <= 6 ? "ABCDEFG".charAt(i) : "H/Ex";


### PR DESCRIPTION
## 該当するIssue
https://github.com/kenkoooo/AtCoderProblems/issues/1312
Can we have an option to limit the different pie chart pages to just the English problems? Right now if you don't speak japanese it is impossible to get to 100% on the pie charts :(

## 実装方針

UserPageにある3つのPie Chartのタブについて，それぞれ変更を行う．
全てのコンテストとRatedコンテストの表示を切り替えられるボタンを追加し，isRatedContest()を用いて数えるコンテストを変更する．

## スクリーンショット

<details>

<summary>AtCoder Pie Chartsタブ (Only Rated Contests)</summary>

![AtCoder_onlyRated](https://user-images.githubusercontent.com/61626658/221372206-3a1d6251-8616-401e-9891-ae957bd01593.png)

</details>

<details>
<summary>AtCoder Pie Chartsタブ (All Contests)</summary>

![AtCoder_all](https://user-images.githubusercontent.com/61626658/221372225-f81d5e73-feeb-45f6-8386-357392c6e380.png)

</details>

<details>

<summary>Diffculty Piesタブ (Only Rated Contests)</summary>

![Diff_onlyRated](https://user-images.githubusercontent.com/61626658/221372348-0b404b05-9305-4e6b-9194-b08cc4ea7709.png)

</details>

<details>
<summary>Diffculty Piesタブ (All Contests)</summary>

![Diff_all](https://user-images.githubusercontent.com/61626658/221372342-1452b999-7969-4269-9fec-de926a0a76db.png)

</details>

<details>

<summary>Category Piesタブ (Only Rated Contests)</summary>

![Category_onlyRated](https://user-images.githubusercontent.com/61626658/221372394-8a61b199-ccbf-4a53-83c3-d7e89fb43f93.png)

</details>

<details>
<summary>Category Piesタブ (All Contests)</summary>

![Category_all](https://user-images.githubusercontent.com/61626658/221372390-a599bcfb-287a-4e75-a614-0418eef5c0f1.png)

</details>

## 相談したいこと

- Category PiesタブでonlyRatedContestsにするとアルゴ以外が0になってしまうので見栄えが悪い
  - isRatedContestがRated Point Sum向けに作られたもので，rated contestとされず問題数が0になってしまう
  - 0の場合は非表示にするなどの処理を入れた方が良いか？

- AtCoder Pie Chartsタブでコンテストごとにボタンを置くのが見栄え悪い
  - 他のタブと統一感を出すためにh1より上にボタンを置くのはやめてここにしました
  - 他に良いデザインがあれば教えてください
