### PR TITLE
トヨタコンを適切にふるい分ける

### DIFF
--- a/atcoder-problems-frontend/src/api/APIClient.ts
+++ b/atcoder-problems-frontend/src/api/APIClient.ts
@@ -127,7 +127,7 @@ export const useMergedProblemMap = () => {
       }
 
       const contestType = classifyContest(contest);
-      if (contestType === "AHC") {
+      if (contestType === "AHC" || contestType === "Marathon") {
         map.set(problem.id, { ...problem, point: undefined });
       } else {
         map.set(problem.id, problem);
@@ -303,7 +303,7 @@ export const useProblemModelMap = () => {
         return;
       }
       const contestType = classifyContest(contest);
-      if (contestType === "AHC") {
+      if (contestType === "AHC" || contestType === "Marathon") {
         return;
       }
 

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -78,7 +78,9 @@ export const classifyContest = (
     /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title
     ) ||
-    /(^future-meets-you-contest|^hokudai-hitachi)/.exec(contest.id) ||
+    /(^future-meets-you-contest|^hokudai-hitachi|^toyota-hc)/.exec(
+      contest.id
+    ) ||
     [
       "genocon2021",
       "stage0-2021",
@@ -97,7 +99,7 @@ export const classifyContest = (
     /(CODE FESTIVAL|^DISCO|日本最強プログラマー学生選手権|全国統一プログラミング王|Indeed)/.exec(
       contest.title
     ) ||
-    /(^Donuts|^dwango|^DigitalArts|^Code Formula|天下一プログラマーコンテスト)/.exec(
+    /(^Donuts|^dwango|^DigitalArts|^Code Formula|天下一プログラマーコンテスト|^Toyota)/.exec(
       contest.title
     )
   ) {

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -56,7 +56,10 @@ export const classifyContest = (
   if (/^agc\d{3}$/.exec(contest.id)) {
     return "AGC";
   }
-  if (/^ahc\d{3}$/.exec(contest.id)) {
+  if (
+    /^ahc\d{3}$/.exec(contest.id) ||
+    ["toyota2023summer-final"].includes(contest.id)
+  ) {
     return "AHC";
   }
 
@@ -82,6 +85,7 @@ export const classifyContest = (
       contest.id
     ) ||
     [
+      "toyota2023summer-final-open",
       "genocon2021",
       "stage0-2021",
       "caddi2019",


### PR DESCRIPTION
## 該当Issue
#1383 （トヨタコンがOther Contestsに振り分けられている）

## 修正方針
- ``Toyota Programming Contest 2023 Spring Final`` はOther Sponsoredにふるい分ける
- ``トヨタ自動車 実課題プログラミングコンテスト 2023 Spring`` はMarathonにふるい分ける

## スクリーンショット
### Other_Sponsored
![Other_Sponsored](https://user-images.githubusercontent.com/51841084/229781606-0b428b88-7363-4087-9cb3-dfb28aa08798.png)
### Marathon
![Marathon](https://user-images.githubusercontent.com/51841084/229781592-0d6b416c-9736-4308-a265-262d88ba82c5.png)

## 補足
Issueには記載ありませんでしたがマラソンについてもふるい分けを入れました。
トヨタのマラソンコンテストは今後も開かれる可能性があることから、「``toyota-hc``から始まるコンテストIDであれば」というふるい分けにしました。
OSSコントリビュートが初めてのため、誤りやお作法としてよくないことをしていればご指摘いただけると幸いです。