### PR TITLE
LanguageNormalizer.ts を 2023年8月の言語アップデートで増えた新形式の言語選択肢に対応しました。

### DIFF
--- a/atcoder-problems-frontend/src/utils/LanguageNormalizer.test.ts
+++ b/atcoder-problems-frontend/src/utils/LanguageNormalizer.test.ts
@@ -5,6 +5,12 @@ test("normalize language", () => {
   expect(normalizeLanguage("Perl6 (rakudo-star 2016.01)")).toBe("Raku");
   expect(normalizeLanguage("Rust (1.42.0)")).toBe("Rust");
   expect(normalizeLanguage("C++11 (Clang++ 3.4)")).toBe("C++");
+  expect(normalizeLanguage("C++ 20 (gcc 12.2)")).toBe("C++");
   expect(normalizeLanguage("Scala (2.11.7)")).toBe("Scala");
+  expect(normalizeLanguage("Scala 3.3.0 (Scala Native 0.4.14)")).toBe("Scala");
   expect(normalizeLanguage("Fortran(GNU Fortran 9.2.1)")).toBe("Fortran");
+  expect(normalizeLanguage("C# 11.9 (.NET 7.0.7)")).toBe("C#");
+  expect(normalizeLanguage("F# 7.0 (.NET 7.0.7)")).toBe("F#");
+  expect(normalizeLanguage("Visual Basic 16.9 (.NET 7.0.7)")).toBe("Visual Basic");
+  expect(normalizeLanguage("TypeScript 5.1 (Node.js 18.16.1)")).toBe("TypeScript");
 });

--- a/atcoder-problems-frontend/src/utils/LanguageNormalizer.ts
+++ b/atcoder-problems-frontend/src/utils/LanguageNormalizer.ts
@@ -2,6 +2,6 @@ export const normalizeLanguage = (language: string): string => {
   if (language.startsWith("Perl6")) {
     return "Raku";
   } else {
-    return language.replace(/\d*\s*\(.*\)$/, "");
+    return language.replace(/\s*(\d+(\.\d+)*)*\s*\(.*\)$/, "");
   }
 };


### PR DESCRIPTION
2023年8月の言語アップデートによって、言語選択肢の括弧書きの外側にバージョン番号が入るケースがみられるようになりました。（例："C++ 20 (gcc 12.2)", "C# 11.9 (.NET 7.0.7)" など）

これらの言語選択肢は、RankingのLanguage Ownersなどで利用されている 既存の LanguageNormalizer によって、
"C++ 20 (gcc 12.2)"  -> "C++ "　// 末尾に半角スペースが残っている
"C# 11.9 (.NET 7.0.7)" -> "C# 11."
と正規化され、ランキングもその形式で集計・表示が行われています。
https://kenkoooo.com/atcoder/#/lang

LanguageNormalizer で用いられている正規表現に変更を加えることで、これらの形式の言語選択肢を
"C++ 20 (gcc 12.2)"  -> "C++"
"C# 11.9 (.NET 7.0.7)" -> "C#"
と、(おそらく)望ましく正規化するようにしました。

合わせて、LanguageNormalizer.testに、この修正によって正規化が変更される言語選択肢のテストを追加しました。
旧言語のテストもそのままにしてあるので後方互換性の検証も同様に行われます。

この変更は、 Issue #1424 の解決を含みます。