### PR TITLE
Fix number of problems in only rated at Difficulty Pies

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Row, Col, Button, ButtonGroup } from "reactstrap";
 import {
+  useProblemMap,
   useProblemModelMap,
   useUserSubmission,
   useContestMap,
@@ -36,6 +37,7 @@ const getPieChartTitle = (ratingColor: RatingColor): string => {
 export const DifficultyPieChart: React.FC<Props> = (props) => {
   const [onlyRated, setOnlyRated] = useState(true);
   const contestMap = useContestMap();
+  const problemMap = useProblemMap();
   const problemModels = useProblemModelMap();
   const colorCount = new Map<RatingColor, number>();
   const allSubmissions = useUserSubmission(props.userId) ?? [];
@@ -43,7 +45,13 @@ export const DifficultyPieChart: React.FC<Props> = (props) => {
     (submission) =>
       isRatedContest(contestMap.get(submission.contest_id), 2) || !onlyRated
   );
-  Array.from(problemModels?.values() ?? []).forEach((model) => {
+  Array.from(problemModels?.keys() ?? []).forEach((problemId) => {
+    const problem = problemMap?.get(problemId);
+    const contest = contestMap?.get(problem?.contest_id);
+    if (onlyRated && (contest === undefined || !isRatedContest(contest, 2))) {
+      return;
+    }
+    const model = problemModels?.get(problemId);
     if (model.difficulty !== undefined) {
       const color = getRatingColor(model.difficulty);
       const curCount = colorCount.get(color) ?? 0;

--- a/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
@@ -41,10 +41,15 @@ export const DifficultyPieChart: React.FC<Props> = (props) => {
   const problemModels = useProblemModelMap();
   const colorCount = new Map<RatingColor, number>();
   const allSubmissions = useUserSubmission(props.userId) ?? [];
-  const submissions = allSubmissions.filter(
-    (submission) =>
-      isRatedContest(contestMap.get(submission.contest_id), 2) || !onlyRated
-  );
+  const submissions = allSubmissions.filter((submission) => {
+    if (!onlyRated) {
+      return true;
+    }
+    if (contestMap === undefined) {
+      return false;
+    }
+    return isRatedContest(contestMap.get(submission.contest_id), 2);
+  });
   Array.from(problemModels?.keys() ?? []).forEach((problemId) => {
     const problem = problemMap?.get(problemId);
     const contest = contestMap?.get(problem?.contest_id);


### PR DESCRIPTION
fix #1444 

### 概要

- DifficultyPies の問題数を数える時、各問題が rated かどうかをチェックしました
- `problemModelMap` のキーである `problemId` から `Problem` を引っ張り、そこから `Contest` を取得して rated かどうかを判定しています
- (issueと別の対応) このタブを開いているときにリロードをするなどした場合、 `contestMap` が undefined になることがあったので チェックするようにしました

### 相談したい事項

- `isRatedContest` で判定するために、 `Problem` を経由させていますが、これが妥当かは検討しきれていないです
- issue でない内容が含まれていますが、簡単な対応と思い今回のプルリクに混ぜています（分けたほうが良ければ分割して出し直します）