### PR TITLE
スポンサー名に関するパターンマッチの修正

### DIFF
--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -78,7 +78,7 @@ export const classifyContest = (
   }
 
   if (
-    /(^Chokudai Contest|ハーフマラソン|^HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
+    /(^Chokudai Contest|ハーフマラソン|HACK TO THE FUTURE|Asprova|Heuristics Contest)/.exec(
       contest.title
     ) ||
     /(^future-meets-you-contest|^hokudai-hitachi|^toyota-hc)/.exec(
@@ -97,15 +97,16 @@ export const classifyContest = (
     return "Marathon";
   }
   if (
-    /(ドワンゴ|^Mujin|SoundHound|^codeFlyer|^COLOCON|みんなのプロコン|CODE THANKS FESTIVAL)/.exec(
+    /(ドワンゴ|^Mujin|SoundHound|^codeFlyer|^COLOCON|みんなのプロコン|CODE THANKS FESTIVAL)/i.exec(
       contest.title
     ) ||
-    /(CODE FESTIVAL|^DISCO|日本最強プログラマー学生選手権|全国統一プログラミング王|Indeed)/.exec(
+    /(CODE FESTIVAL|^DISCO|日本最強プログラマー学生選手権|全国統一プログラミング王|Indeed)/i.exec(
       contest.title
     ) ||
-    /(^Donuts|^dwango|^DigitalArts|^Code Formula|天下一プログラマーコンテスト|^Toyota)/.exec(
+    /(^Donuts|^dwango|^DigitalArts|^Code Formula|天下一プログラマーコンテスト|^Toyota)/i.exec(
       contest.title
-    )
+    ) ||
+    /(^Recruit|^CodeQUEEN)/i.exec(contest.title)
   ) {
     return "Other Sponsored";
   }


### PR DESCRIPTION
## 該当Issue
#1350 （MUJIN プログラミングチャレンジ Programming Challenge を Other Sponsored に移したい）

## スクリーンショット
![MUJIN](https://github.com/kenkoooo/AtCoderProblems/assets/51841084/a4514a27-2808-47ae-9cd3-9966ee76a04b)

## 補足
パターンマッチを変更し、以下も一緒にOther Sponsoredに移動しています
- Code Festival
- code thanks festival
- Recruit Programming Contest 模擬練習会
- CodeQUEEN 2023 決勝（オープンコンテスト）

以下をMarathonに移動しています
- デジタルの日特別イベント「HACK TO THE FUTURE for Youth+」
- デジタルの日特別イベント「HACK TO THE FUTURE for Youth+」 open