### PR TITLE
Add ADT Category

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -146,8 +146,6 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "AtCoder Regular Contest"
               : activeTab === "AGC"
               ? "AtCoder Grand Contest"
-              : activeTab === "ADT"
-              ? "AtCoder Daily Training"
               : activeTab === "PAST"
               ? "PAST"
               : `${activeTab} Contest`

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -132,6 +132,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
         "ABC-Like",
         "ARC-Like",
         "AGC-Like",
+        "ADT",
         "PAST",
       ].includes(activeTab) ? (
         <AtCoderRegularTable
@@ -146,6 +147,8 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "AtCoder Regular Contest"
               : activeTab === "AGC"
               ? "AtCoder Grand Contest"
+              : activeTab === "ADT"
+              ? "AtCoder Daily Training"
               : activeTab === "PAST"
               ? "PAST"
               : `${activeTab} Contest`

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -132,7 +132,6 @@ export const TablePage: React.FC<OuterProps> = (props) => {
         "ABC-Like",
         "ARC-Like",
         "AGC-Like",
-        "ADT",
         "PAST",
       ].includes(activeTab) ? (
         <AtCoderRegularTable
@@ -153,6 +152,21 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "PAST"
               : `${activeTab} Contest`
           }
+          contestToProblems={contestToProblems}
+          statusLabelMap={statusLabelMap}
+          showPenalties={showPenalties}
+          selectedLanguages={selectedLanguages}
+          userRatingInfo={userRatingInfo}
+        />
+      ) : activeTab === "ADT" ? (
+        <AtCoderRegularTable
+          showDifficulty={showDifficulty}
+          hideCompletedContest={hideCompletedContest}
+          colorMode={colorMode}
+          contests={filteredContests.filter((contest) => {
+            return /^adt_all/g.test(contest.id);
+          })}
+          title="AtCoder Daily Training"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
           showPenalties={showPenalties}

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -8,6 +8,7 @@ export const ContestCategories = [
   "ABC-Like",
   "ARC-Like",
   "AGC-Like",
+  "ADT",
   "PAST",
   "JOI",
   "JAG",
@@ -67,6 +68,9 @@ export const classifyContest = (
     return classifyOtherRatedContest(contest);
   }
 
+  if (contest.id.startsWith("adt")) {
+    return "ADT";
+  }
   if (contest.id.startsWith("past")) {
     return "PAST";
   }


### PR DESCRIPTION
resolve #1447 

AtCoder Daily Training のコンテストが Other Contest に分類されていたため、新たに ADT のカテゴリを追加し分類するようにしました。
EASY, MEDIUM, HARD の問題はすべて ALL に含まれているため、ALL のみを表示するようにしています。

![image](https://github.com/kenkoooo/AtCoderProblems/assets/59227194/a955d554-89ad-4096-b43a-29179285e881)
