### PR TITLE
Fixes #1448 (Pie Chartのデフォルト表示をAll Contestsにする).

### DIFF
--- a/atcoder-problems-frontend/src/pages/UserPage/CategoryPieChart/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/CategoryPieChart/index.tsx
@@ -138,7 +138,7 @@ export const CategoryPieChart: React.FC<Props> = (props) => {
   const contestToProblems =
     useContestToProblems() ?? new Map<ContestId, Problem[]>();
   const userSubmissions = useUserSubmission(props.userId) ?? [];
-  const [onlyRated, setOnlyRated] = useState(true);
+  const [onlyRated, setOnlyRated] = useState(false);
 
   const categoryCounts = makeCategoryCounts(
     contests,

--- a/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/DifficultyPieChart/index.tsx
@@ -34,7 +34,7 @@ const getPieChartTitle = (ratingColor: RatingColor): string => {
 };
 
 export const DifficultyPieChart: React.FC<Props> = (props) => {
-  const [onlyRated, setOnlyRated] = useState(true);
+  const [onlyRated, setOnlyRated] = useState(false);
   const contestMap = useContestMap();
   const problemModels = useProblemModelMap();
   const colorCount = new Map<RatingColor, number>();

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -145,7 +145,7 @@ export const PieChartBlock = (props: Props) => {
   );
   const contestToProblems =
     useContestToProblems() ?? new Map<ContestId, Problem[]>();
-  const [onlyRated, setOnlyRated] = useState(true);
+  const [onlyRated, setOnlyRated] = useState(false);
   const contestMap = useContestMap();
 
   const abcSolved = solvedCountForPieChart(


### PR DESCRIPTION
stateのデフォルト値を`true`から`false`に変更するだけのPRとなります。
#1369 のdiffがかなり少なかったため、まずそれを全て確認し、修正部分を特定しました。

