### PR TITLE
フロントエンドでのalgo-ratedの判定条件を修正

### DIFF
--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -27,7 +27,7 @@ export const isRatedContest = (
   return (
     contest.rate_change !== "-" &&
     contest.start_epoch_second >= AGC_001_START &&
-    problemCount >= 2
+    problemCount >= 3
   );
 };
 


### PR DESCRIPTION
fix #1464

#1439 で漏れていたフロントエンドの変更を行いました。ついでにAchievementページのリファクタリングを行っています。