### PR TITLE
Node 20対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.2.0
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2.2.0
+        uses: Swatinem/rust-cache@v2.7.3
         with:
           workspaces: atcoder-problems-backend -> target
 
@@ -70,31 +70,36 @@ jobs:
         working-directory: ./atcoder-problems-frontend
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.2.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.0.4
         with:
-          node-version: 16
+          node-version: 20
 
-      - name: Cache node_modules
-        uses: actions/cache@v3.2.3
+      - name: Cache dependencies
+        uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.cache/Cypress
-            ./atcoder-problems-frontend/node_modules
-          key: ${{ runner.os }}-cargo-${{ hashFiles('atcoder-problems-frontend/yarn.lock') }}
+            atcoder-problems-frontend/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('atcoder-problems-frontend/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1.2.0
+        uses: peaceiris/actions-mdbook@v2.0.0
         with:
           mdbook-version: "latest"
 
+      # Node 17でOpenSSLがデフォルトでMD4ハッシュを提供しなくなり、
+      # これに依存していたwebpackに依存するreact-scripts 4.x系でのビルドができなくなってしまった。
+      # --openssl-legacy-providerをオプションとして渡すことで、Node 17以降でもビルドができる。
+      # react-scripts 4.x系から移行したら、このオプションは不要になる。
       - name: build
-        run: yarn build
+        run: env NODE_OPTIONS=--openssl-legacy-provider yarn build
+
       - name: test
         run: yarn test
       - name: lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,15 @@ services:
     command: /bin/sh -c "cargo watch -s 'cargo run --bin run_server'"
 
   frontend-development:
-    image: node:16
+    image: node:20
     ports:
       - "3000:3000"
+    environment:
+      # Node 17でOpenSSLがデフォルトでMD4ハッシュを提供しなくなり、
+      # これに依存していたwebpackに依存するreact-scripts 4.x系でのビルドができなくなってしまった。
+      # --openssl-legacy-providerをオプションとして渡すことで、Node 17以降でもビルドができる。
+      # react-scripts 4.x系から移行したら、このオプションは不要になる。
+      NODE_OPTIONS: --openssl-legacy-provider
     volumes:
       - ./:/app
       - node_modules:/app/atcoder-problems-frontend/node_modules


### PR DESCRIPTION
現在CIで使用しているNode 16が2023年9月11にEOLとなり、GitHub ActionsではNode 20への移行が推奨されています（Summaryでも警告が出ている）。2024年春までが目標とのことで、そろそろです。

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

~~peaceiris/actions-mdbookはまだ対応したバージョンがリリースされていないため、対応PR (https://github.com/peaceiris/actions-mdbook/pull/500 )がマージされるまで保留ということにしています。~~
（2024/04/15編集）リリースされていたので対応しました。

react-scripts 4系がNode 17以降、そのままでは動かなくなってしまいました。CIでは緩和策を導入してしのいでいますが、移行を検討してもいいかもしれません。
