### PR TITLE
show difficulty subボタンの追加

### DIFF
--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -38,7 +38,7 @@ export const ProblemLink: React.FC<Props> = (props) => {
     ? `${problemIndex}. ${problemName}`
     : problemName;
 
-  const link = (
+  const simpleLink = (
     <NewTabLink
       href={Url.formatProblemUrl(problemId, contestId)}
       className={props.className}
@@ -49,11 +49,11 @@ export const ProblemLink: React.FC<Props> = (props) => {
 
   const difficulty = problemModel?.difficulty;
   if (
-    !showDifficulty ||
+    showDifficulty === undefined ||
     problemModel === undefined ||
     (difficulty === undefined && !showDifficultyUnavailable)
   ) {
-    return link;
+    return simpleLink;
   }
 
   const uniqueId = problemId + "-" + contestId;
@@ -61,44 +61,61 @@ export const ProblemLink: React.FC<Props> = (props) => {
   const ratingColorClass =
     difficulty === undefined ? undefined : getRatingColorClass(difficulty);
 
-  return (
+  const explicitDifficultyCircle = (
+    <DifficultyCircle
+      id={uniqueId}
+      problemModel={problemModel}
+      userRatingInfo={userRatingInfo}
+    />
+  );
+  const experimentalDifficultySymbol = (
     <>
-      <DifficultyCircle
-        id={uniqueId}
-        problemModel={problemModel}
-        userRatingInfo={userRatingInfo}
-      />
-      {isExperimentalDifficulty ? (
-        <>
-          <span id={experimentalIconId} role="img" aria-label="experimental">
-            🧪
-          </span>
-          <Tooltip
-            placement="top"
-            target={experimentalIconId}
-            isOpen={tooltipOpen}
-            toggle={(): void => setTooltipOpen(!tooltipOpen)}
-          >
-            This estimate is experimental.
-          </Tooltip>
-        </>
-      ) : null}
-      {
-        // Don't add rel="noreferrer" to AtCoder links
-        // to allow AtCoder get the referral information.
-        // eslint-disable-next-line react/jsx-no-target-blank
-        <a
-          href={Url.formatProblemUrl(problemId, contestId)}
-          // Don't add rel="noreferrer" to AtCoder links
-          // to allow AtCoder get the referral information.
-          // eslint-disable-next-line react/jsx-no-target-blank
-          target="_blank"
-          rel="noopener"
-          className={ratingColorClass}
-        >
-          {problemTitle}
-        </a>
-      }
+      <span id={experimentalIconId} role="img" aria-label="experimental">
+        🧪
+      </span>
+      <Tooltip
+        placement="top"
+        target={experimentalIconId}
+        isOpen={tooltipOpen}
+        toggle={(): void => setTooltipOpen(!tooltipOpen)}
+      >
+        This estimate is experimental.
+      </Tooltip>
     </>
   );
+  const difficultyColoredLink = (
+    // Don't add rel="noreferrer" to AtCoder links
+    // to allow AtCoder get the referral information.
+    // eslint-disable-next-line react/jsx-no-target-blank
+    <a
+      href={Url.formatProblemUrl(problemId, contestId)}
+      // Don't add rel="noreferrer" to AtCoder links
+      // to allow AtCoder get the referral information.
+      // eslint-disable-next-line react/jsx-no-target-blank
+      target="_blank"
+      rel="noopener"
+      className={ratingColorClass}
+    >
+      {problemTitle}
+    </a>
+  );
+
+  if (showDifficulty) {
+    return (
+      <>
+        {explicitDifficultyCircle}
+        {isExperimentalDifficulty ? experimentalDifficultySymbol : null}
+        {difficultyColoredLink}
+      </>
+    );
+  } else {
+    return (
+      <>
+        {/* ここを、implicitにすればok */}
+        {explicitDifficultyCircle}
+        {isExperimentalDifficulty ? experimentalDifficultySymbol : null}
+        {simpleLink}
+      </>
+    );
+  }
 };

--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -21,7 +21,17 @@ interface Props {
 }
 
 export const ProblemLink: React.FC<Props> = (props) => {
-  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const [
+    experimentalDifficultyTooltipOpen,
+    setExperimentalDifficultyTooltipOpen,
+  ] = useState(false);
+  const [implicitDifficultyClicked, setImplicitDifficultyClicked] = useState(
+    false
+  );
+  const [
+    implicitDifficultyTooltipOpen,
+    setImplicitDifficultyTooltipOpen,
+  ] = useState(false);
 
   const {
     contestId,
@@ -58,16 +68,10 @@ export const ProblemLink: React.FC<Props> = (props) => {
 
   const uniqueId = problemId + "-" + contestId;
   const experimentalIconId = "experimental-" + uniqueId;
+  const implicitDifficultyIconId = "implicit-difficulty-" + uniqueId;
   const ratingColorClass =
     difficulty === undefined ? undefined : getRatingColorClass(difficulty);
 
-  const explicitDifficultyCircle = (
-    <DifficultyCircle
-      id={uniqueId}
-      problemModel={problemModel}
-      userRatingInfo={userRatingInfo}
-    />
-  );
   const experimentalDifficultySymbol = (
     <>
       <span id={experimentalIconId} role="img" aria-label="experimental">
@@ -76,13 +80,42 @@ export const ProblemLink: React.FC<Props> = (props) => {
       <Tooltip
         placement="top"
         target={experimentalIconId}
-        isOpen={tooltipOpen}
-        toggle={(): void => setTooltipOpen(!tooltipOpen)}
+        isOpen={experimentalDifficultyTooltipOpen}
+        toggle={(): void =>
+          setExperimentalDifficultyTooltipOpen(
+            !experimentalDifficultyTooltipOpen
+          )
+        }
       >
         This estimate is experimental.
       </Tooltip>
     </>
   );
+  const implicitDifficultySymbol = (
+    <>
+      <span
+        id={implicitDifficultyIconId}
+        role="img"
+        aria-label="implicit-difficulty"
+        onClick={(): void =>
+          setImplicitDifficultyClicked(!implicitDifficultyClicked)
+        }
+      >
+        {"👉 "}
+      </span>
+      <Tooltip
+        placement="top"
+        target={implicitDifficultyIconId}
+        isOpen={implicitDifficultyTooltipOpen}
+        toggle={(): void =>
+          setImplicitDifficultyTooltipOpen(!implicitDifficultyTooltipOpen)
+        }
+      >
+        Show Difficulty.
+      </Tooltip>
+    </>
+  );
+
   const difficultyColoredLink = (
     // Don't add rel="noreferrer" to AtCoder links
     // to allow AtCoder get the referral information.
@@ -99,22 +132,30 @@ export const ProblemLink: React.FC<Props> = (props) => {
       {problemTitle}
     </a>
   );
+  const difficultySymbol = (
+    <>
+      <DifficultyCircle
+        id={uniqueId}
+        problemModel={problemModel}
+        userRatingInfo={userRatingInfo}
+      />
+      {isExperimentalDifficulty ? experimentalDifficultySymbol : null}
+    </>
+  );
 
   if (showDifficulty) {
     return (
       <>
-        {explicitDifficultyCircle}
-        {isExperimentalDifficulty ? experimentalDifficultySymbol : null}
+        {difficultySymbol}
         {difficultyColoredLink}
       </>
     );
   } else {
     return (
       <>
-        {/* ここを、implicitにすればok */}
-        {explicitDifficultyCircle}
-        {isExperimentalDifficulty ? experimentalDifficultySymbol : null}
-        {simpleLink}
+        {implicitDifficultySymbol}
+        {implicitDifficultyClicked ? difficultySymbol : null}
+        {implicitDifficultyClicked ? difficultyColoredLink : simpleLink}
       </>
     );
   }

--- a/atcoder-problems-frontend/src/components/ProblemLink.tsx
+++ b/atcoder-problems-frontend/src/components/ProblemLink.tsx
@@ -25,12 +25,12 @@ export const ProblemLink: React.FC<Props> = (props) => {
     experimentalDifficultyTooltipOpen,
     setExperimentalDifficultyTooltipOpen,
   ] = useState(false);
-  const [implicitDifficultyClicked, setImplicitDifficultyClicked] = useState(
+  const [showDifficultySubClicked, setshowDifficultySubClicked] = useState(
     false
   );
   const [
-    implicitDifficultyTooltipOpen,
-    setImplicitDifficultyTooltipOpen,
+    showDifficultySubTooltipOpen,
+    setShowDifficultySubTooltipOpen,
   ] = useState(false);
 
   const {
@@ -68,7 +68,7 @@ export const ProblemLink: React.FC<Props> = (props) => {
 
   const uniqueId = problemId + "-" + contestId;
   const experimentalIconId = "experimental-" + uniqueId;
-  const implicitDifficultyIconId = "implicit-difficulty-" + uniqueId;
+  const showDifficultySubIconId = "show-difficulty-sub-" + uniqueId;
   const ratingColorClass =
     difficulty === undefined ? undefined : getRatingColorClass(difficulty);
 
@@ -91,24 +91,24 @@ export const ProblemLink: React.FC<Props> = (props) => {
       </Tooltip>
     </>
   );
-  const implicitDifficultySymbol = (
+  const showDifficultySubSymbol = (
     <>
       <span
-        id={implicitDifficultyIconId}
+        id={showDifficultySubIconId}
         role="img"
-        aria-label="implicit-difficulty"
+        aria-label="show-difficulty-sub"
         onClick={(): void =>
-          setImplicitDifficultyClicked(!implicitDifficultyClicked)
+          setshowDifficultySubClicked(!showDifficultySubClicked)
         }
       >
         {"👉 "}
       </span>
       <Tooltip
         placement="top"
-        target={implicitDifficultyIconId}
-        isOpen={implicitDifficultyTooltipOpen}
+        target={showDifficultySubIconId}
+        isOpen={showDifficultySubTooltipOpen}
         toggle={(): void =>
-          setImplicitDifficultyTooltipOpen(!implicitDifficultyTooltipOpen)
+          setShowDifficultySubTooltipOpen(!showDifficultySubTooltipOpen)
         }
       >
         Show Difficulty.
@@ -153,9 +153,9 @@ export const ProblemLink: React.FC<Props> = (props) => {
   } else {
     return (
       <>
-        {implicitDifficultySymbol}
-        {implicitDifficultyClicked ? difficultySymbol : null}
-        {implicitDifficultyClicked ? difficultyColoredLink : simpleLink}
+        {showDifficultySubSymbol}
+        {showDifficultySubClicked ? difficultySymbol : null}
+        {showDifficultySubClicked ? difficultyColoredLink : simpleLink}
       </>
     );
   }


### PR DESCRIPTION
https://github.com/kenkoooo/AtCoderProblems/issues/1468 

show difficulty = off かつ subボタン = off 
<img width="466" alt="image" src="https://github.com/kenkoooo/AtCoderProblems/assets/37322539/9f311a41-681f-4d16-9b7d-d7a28d9a6046">

show difficulty = off かつ subボタン = on
<img width="466" alt="image" src="https://github.com/kenkoooo/AtCoderProblems/assets/37322539/69665c54-492b-401a-b914-f31337eecb79">

show difficulty = on (as-isと同じ)
<img width="466" alt="image" src="https://github.com/kenkoooo/AtCoderProblems/assets/37322539/dfb5b387-db03-4133-8020-72bfe12ecca6">

各問題ごとにon/offボタンを設置したことで、見た目の影響が大きい...？
show difficultyボタンそのものを、on/offの2値ではなく、full/sub/noneみたいな3値にした方が、ユーザビリティ高かったりする？要議論。

reactは得意ではないので実装方針変だったらすみません。