### PR TITLE
Login Alert Sequence Correction - LoginAdvice Component

### DIFF
--- a/atcoder-problems-frontend/src/pages/TrainingPage/LoginAdvice.tsx
+++ b/atcoder-problems-frontend/src/pages/TrainingPage/LoginAdvice.tsx
@@ -12,15 +12,15 @@ interface Props {
 export const LoginAdvice: React.FC<Props> = (props) => {
   const loginLink = useLoginLink();
 
-  if (props.loading) {
-    return <Alert color="primary">Loading user info...</Alert>;
-  }
   if (!props.user) {
     return (
       <Alert color="danger">
         <a href={loginLink}>Login</a> to record your progress.
       </Alert>
     );
+  }
+  if (props.loading) {
+    return <Alert color="primary">Loading user info...</Alert>;
   }
   if (!props.user.atcoder_user_id) {
     return (


### PR DESCRIPTION
In Login Advice component, the **sequence of showing the alert is loading then user** but if the user is not logged in then it will be better to show user to login first then we can load the data of the user.

I was not logged in and it was showing me loading user info ...

<img width="1438" alt="Screenshot 2024-07-07 at 7 33 17 PM" src="https://github.com/kenkoooo/AtCoderProblems/assets/167893076/4fe9c933-e87a-4fc7-a519-d53a5e35d4e3">

After changes in sequence - 
<img width="1440" alt="Screenshot 2024-07-07 at 7 33 39 PM" src="https://github.com/kenkoooo/AtCoderProblems/assets/167893076/147b9a43-e345-4c97-9f71-e1caf19286bc">
