### PR TITLE
update: Update `backend/AtCoderClient` for #1497

### DIFF
--- a/atcoder-problems-backend/src/bin/crawl_all_submissions.rs
+++ b/atcoder-problems-backend/src/bin/crawl_all_submissions.rs
@@ -15,8 +15,7 @@ async fn main() {
     info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL is not set.");
 
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
 
     loop {
         info!("Start new loop");
@@ -24,7 +23,7 @@ async fn main() {
         match load_contest(&url).await {
             Ok(contests) => {
                 for contest in contests {
-                    finish_one_contest(&url, &contest.id, &username, &password).await;
+                    finish_one_contest(&url, &contest.id, &revel_session).await;
                 }
             }
             Err(e) => {
@@ -35,10 +34,10 @@ async fn main() {
     }
 }
 
-async fn finish_one_contest(url: &str, contest_id: &str, username: &str, password: &str) {
+async fn finish_one_contest(url: &str, contest_id: &str, revel_session: &str) {
     loop {
         info!("Starting {}", contest_id);
-        match crawl_one_contest(url, contest_id, username, password).await {
+        match crawl_one_contest(url, contest_id, revel_session).await {
             Ok(_) => {
                 info!("Finished {}", contest_id);
                 return;
@@ -54,11 +53,10 @@ async fn finish_one_contest(url: &str, contest_id: &str, username: &str, passwor
 async fn crawl_one_contest(
     url: &str,
     contest_id: &str,
-    username: &str,
-    password: &str,
+    revel_session: &str,
 ) -> Result<()> {
     let db = initialize_pool(url).await?;
-    let client = AtCoderClient::new(username, password).await?;
+    let client = AtCoderClient::new(revel_session).await?;
     let crawler = WholeContestCrawler::new(db, client.clone(), contest_id);
     crawler.crawl().await?;
     Ok(())

--- a/atcoder-problems-backend/src/bin/crawl_for_virtual_contests.rs
+++ b/atcoder-problems-backend/src/bin/crawl_for_virtual_contests.rs
@@ -13,10 +13,10 @@ use std::{
 
 const FIX_RANGE_SECOND: i64 = 10 * 60;
 
-async fn crawl<R: Rng>(url: &str, rng: &mut R, username: &str, password: &str) -> Result<()> {
+async fn crawl<R: Rng>(url: &str, rng: &mut R, revel_session: &str) -> Result<()> {
     log::info!("Start crawling...");
     let pg_pool = initialize_pool(&url).await?;
-    let client = AtCoderClient::new(username, password).await?;
+    let client = AtCoderClient::new(revel_session).await?;
     let mut crawler = VirtualContestCrawler::new(pg_pool.clone(), client.clone(), rng);
     crawler.crawl().await?;
     log::info!("Finished crawling");
@@ -34,8 +34,7 @@ async fn crawl<R: Rng>(url: &str, rng: &mut R, username: &str, password: &str) -
 async fn main() {
     init_log_config().unwrap();
     let url = env::var("SQL_URL").expect("SQL_URL must be set.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
     log::info!("Started");
 
     let mut rng = thread_rng();
@@ -44,7 +43,7 @@ async fn main() {
         log::info!("Start new loop...");
         let now = Instant::now();
 
-        if let Err(e) = crawl(&url, &mut rng, &username, &password).await {
+        if let Err(e) = crawl(&url, &mut rng, &revel_session).await {
             log::error!("{:?}", e);
         }
 

--- a/atcoder-problems-backend/src/bin/crawl_from_new_contests.rs
+++ b/atcoder-problems-backend/src/bin/crawl_from_new_contests.rs
@@ -10,9 +10,9 @@ use std::{env, time::Duration};
 
 const NEW_CONTEST_NUM: usize = 5;
 
-async fn iteration(url: &str, username: &str, password: &str) -> Result<()> {
+async fn iteration(url: &str, revel_session: &str) -> Result<()> {
     let db = initialize_pool(&url).await?;
-    let client = AtCoderClient::new(username, password).await?;
+    let client = AtCoderClient::new(revel_session).await?;
     let mut contests = db.load_contests().await?;
     contests.sort_by_key(|c| c.start_epoch_second);
     contests.reverse();
@@ -30,12 +30,11 @@ async fn main() {
     init_log_config().unwrap();
     info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL is not set.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
 
     loop {
         info!("Start new loop");
-        if let Err(e) = iteration(&url, &username, &password).await {
+        if let Err(e) = iteration(&url, &revel_session).await {
             log::error!("{:?}", e);
             time::sleep(Duration::from_secs(1)).await;
         }

--- a/atcoder-problems-backend/src/bin/crawl_problems.rs
+++ b/atcoder-problems-backend/src/bin/crawl_problems.rs
@@ -9,11 +9,10 @@ async fn main() {
     init_log_config().unwrap();
     log::info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL is not set.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
 
     let db = initialize_pool(&url).await.unwrap();
-    let client = AtCoderClient::new(&username, &password)
+    let client = AtCoderClient::new(&revel_session)
         .await
         .expect("AtCoder authentication failure");
     let crawler = ProblemCrawler::new(db, client);

--- a/atcoder-problems-backend/src/bin/crawl_recent_submissions.rs
+++ b/atcoder-problems-backend/src/bin/crawl_recent_submissions.rs
@@ -6,9 +6,9 @@ use atcoder_problems_backend::utils::init_log_config;
 use sql_client::initialize_pool;
 use std::{env, time::Duration};
 
-async fn crawl(url: &str, username: &str, password: &str) -> Result<()> {
+async fn crawl(url: &str, revel_session: &str) -> Result<()> {
     let db = initialize_pool(url).await?;
-    let client = AtCoderClient::new(username, password).await?;
+    let client = AtCoderClient::new(revel_session).await?;
     let crawler = RecentCrawler::new(db, client);
     crawler.crawl().await
 }
@@ -18,12 +18,11 @@ async fn main() {
     init_log_config().unwrap();
     log::info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL must be set.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
 
     loop {
         log::info!("Start new loop");
-        if let Err(e) = crawl(&url, &username, &password).await {
+        if let Err(e) = crawl(&url, &revel_session).await {
             log::error!("{:?}", e);
             time::sleep(Duration::from_secs(1)).await;
         }

--- a/atcoder-problems-backend/src/bin/crawl_whole_contest.rs
+++ b/atcoder-problems-backend/src/bin/crawl_whole_contest.rs
@@ -11,13 +11,12 @@ async fn main() -> Result<()> {
     init_log_config()?;
     info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL should be set as environmental variable.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
     let contest_id = env::args()
         .nth(1)
         .expect("contest_id is not set.\nUsage: cargo run --bin crawl_whole_contest <contest_id>");
     let db = initialize_pool(&url).await?;
-    let client = AtCoderClient::new(&username, &password).await?;
+    let client = AtCoderClient::new(&revel_session).await?;
     let crawler = WholeContestCrawler::new(db, client, contest_id);
     crawler.crawl().await?;
     Ok(())

--- a/atcoder-problems-backend/src/bin/fix_invalid_submissions.rs
+++ b/atcoder-problems-backend/src/bin/fix_invalid_submissions.rs
@@ -13,12 +13,11 @@ async fn main() {
     init_log_config().unwrap();
     info!("Started");
     let url = env::var("SQL_URL").expect("SQL_URL must be set.");
-    let username = env::var("ATCODER_USERNAME").expect("ATCODER_USERNAME is not set.");
-    let password = env::var("ATCODER_PASSWORD").expect("ATCODER_PASSWORD is not set.");
+    let revel_session = env::var("ATCODER_SESSION").expect("ATCODER_SESSION is not set.");
 
     let db = initialize_pool(&url).await.unwrap();
     let now = Utc::now().timestamp();
-    let client = AtCoderClient::new(&username, &password)
+    let client = AtCoderClient::new(&revel_session)
         .await
         .expect("AtCoder authentication failure");
     let crawler = FixCrawler::new(db, client, now - ONE_DAY);


### PR DESCRIPTION
Make the class `AtCoderClient` (`atcoder-problems-backend/atcoder-client/src/atcoder/client.rs`) use cookie `REVEL_SESSION`.