### PR TITLE
Add support for AWC

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -129,6 +129,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
         "ABC",
         "ARC",
         "AGC",
+        "AWC",
         "ABC-Like",
         "ARC-Like",
         "AGC-Like",
@@ -146,6 +147,8 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "AtCoder Regular Contest"
               : activeTab === "AGC"
               ? "AtCoder Grand Contest"
+              : activeTab === "AWC"
+              ? "AtCoder Weekday Contest"
               : activeTab === "PAST"
               ? "PAST"
               : `${activeTab} Contest`

--- a/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
+++ b/atcoder-problems-frontend/src/pages/UserPage/PieChartBlock/index.tsx
@@ -165,11 +165,19 @@ export const PieChartBlock = (props: Props) => {
     submissionsMap,
     props.userId
   );
+  const awcSolved = solvedCountForPieChart(
+    Array.from(contestToProblems).filter(([contestId]) =>
+      contestId.startsWith("awc")
+    ),
+    submissionsMap,
+    props.userId
+  );
   return (
     <>
       <PieCharts problems={abcSolved} title="AtCoder Beginner Contest" />
       <PieCharts problems={arcSolved} title="AtCoder Regular Contest" />
       <PieCharts problems={agcSolved} title="AtCoder Grand Contest" />
+      <PieCharts problems={awcSolved} title="AtCoder Weekday Contest" />
     </>
   );
 };

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -5,6 +5,7 @@ export const ContestCategories = [
   "ABC",
   "ARC",
   "AGC",
+  "AWC",
   "ABC-Like",
   "ARC-Like",
   "AGC-Like",
@@ -55,6 +56,9 @@ export const classifyContest = (
   }
   if (/^agc\d{3}$/.exec(contest.id)) {
     return "AGC";
+  }
+  if (/^awc\d{4}$/.exec(contest.id)) {
+    return "AWC";
   }
   if (
     /^ahc\d{3}$/.exec(contest.id) ||


### PR DESCRIPTION
#1523 を main に取り込むための PR です。

元 PR は base が `master` で main と履歴が異なり、そのままマージできないため、コミットを cherry-pick して取り込みました（作者 @monerinngu0 を保持、`git log` に残ります）。

## 変更点（元PRより）
- カテゴリータブに AWC を追加
- `awc` コンテストを判別する接頭辞（`/^awc\d{4}$/`）を追加
- アチーブ（PieChart）に AtCoder Weekday Contest を追加

## 元PRから除外したもの
- ルートの空の `yarn.lock`（自動生成・不要。このリポジトリは pnpm 管理のため main には含めません）

元PR: #1523