### PR TITLE
Add deploy-frontend target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-backend build-estimator build-dbt
+.PHONY: build build-backend build-estimator build-dbt deploy-frontend
 
 build: build-backend build-estimator build-dbt
 
@@ -10,3 +10,13 @@ build-estimator:
 
 build-dbt:
 	docker build -t atcoder-problems-2025-dbt:latest ./dbt
+
+FRONTEND_DIR := atcoder-problems-frontend
+S3_BUCKET ?= kenkoooo.com
+
+# Build the frontend locally and sync the artifacts to S3.
+# Note: --delete is intentionally NOT used because the destination bucket also
+# hosts backend-generated data (e.g. resources/) that is not part of the build.
+deploy-frontend:
+	cd $(FRONTEND_DIR) && pnpm install --frozen-lockfile && pnpm run build
+	aws s3 sync $(FRONTEND_DIR)/build/ s3://$(S3_BUCKET)/


### PR DESCRIPTION
## 概要

フロントエンドをローカルでビルドし、サイトを配信している S3 バケットへ sync する `deploy-frontend` サブコマンドを Makefile に追加しました。

## 使い方

```sh
make deploy-frontend
```

デフォルトの sync 先は `s3://kenkoooo.com/` です。`S3_BUCKET` 変数で上書きできます。

```sh
make deploy-frontend S3_BUCKET=my-bucket
```

## 実装メモ

- `atcoder-problems-frontend` で `pnpm install --frozen-lockfile && pnpm run build` を実行してから、`build/` を `aws s3 sync` します。
- `aws s3 sync` に **`--delete` は意図的に付けていません**。配信バケットのルートにはフロントエンドのビルド成果物だけでなく、バックエンドが生成する API データ（`resources/` 配下の `ac.json` / `contests.json` 等）も同居しているため、`--delete` を付けるとそれらを削除してしまうためです。
- `pnpm run build` は `react-scripts build` に加えて `mdbook` による `md:build`（`guide/` のドキュメント生成）も実行するため、ローカルに `mdbook` が必要です。

## 動作確認

- `make -n deploy-frontend` でレシピが期待通り展開されることを確認しました（実際のデプロイは未実行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)