### PR TITLE
fix: 提出ページが404のコンテストは即スキップしてクロールを高速化する

### DIFF
--- a/atcoder-problems-backend/crawler/src/client.rs
+++ b/atcoder-problems-backend/crawler/src/client.rs
@@ -125,6 +125,9 @@ impl CrawlerClient {
         );
         let request = self.client.get(&url);
         let response = request.send().await?;
+        if response.status() == 404 {
+            return Err(CrawlerError::NotFound);
+        }
         if !response.status().is_success() {
             return Err(CrawlerError::HttpError(response.text().await?));
         }

--- a/atcoder-problems-backend/src/crawler_utils.rs
+++ b/atcoder-problems-backend/src/crawler_utils.rs
@@ -23,6 +23,14 @@ pub async fn fetch_submissions(
             Ok(submissions) => {
                 return submissions;
             }
+            Err(CrawlerError::NotFound) => {
+                tracing::warn!(
+                    "Submissions page not found for contest {} page {} (404), skipping",
+                    contest_id,
+                    page
+                );
+                return vec![];
+            }
             Err(e) => {
                 retry_count += 1;
                 tracing::warn!(


### PR DESCRIPTION
## 背景 / 原因

issue #1518 / #1520 で「abc308 / abc358 / abc410(CodeQUEEN 予選に流用された回)への 2026-01 以降の提出が反映されない」と報告されている。AWS(ECS + CloudWatch Logs)で本番クローラのログを確認したところ、コンテスト固有の問題ではなく **古い全コンテスト共通の取りこぼし**であり、原因は提出クロールの周回が遅すぎることだった。

submissions のクロール (`crawler_utils::fetch_submissions`) は **すべてのエラーを一律に最大10回・指数バックオフ(2s→4s→…→1024s, 合計約34分)でリトライ**する。提出ページが **404** を返す古い/非公開コンテストに対してもこのリトライが走るため、該当コンテスト1件につき最大約34分を空費していた。

実際のログでは:
- `crawl-new` が起動から5時間以上経っても1周目の途中で、404 を返すコンテストのリトライ(`attempt 10/10`)で延々と待たされていた
- `crawl-all` は別要因(巨大コンテストの全ページクロール)で詰まる

その結果、古いコンテストを唯一カバーできる `crawl-new` / `crawl-all` が1周しきれず、abc308 等への新規提出が反映されなかった。

なお `fetch_problems` 側はすでに 404 を `CrawlerError::NotFound` で即スキップしており、submissions 側だけこの分岐が欠けていた。

## 変更

- `crawler/src/client.rs` の `fetch_submissions`: 404 を `CrawlerError::NotFound` として返す(`fetch_problems` と同じ扱い)
- `crawler_utils.rs` の `fetch_submissions`(リトライ層): `NotFound` はリトライせず即スキップ。429(Too Many Requests) や 5xx など他のエラーは従来どおりリトライする

## 効果

404 コンテストでの最大約34分の浪費がなくなり、`crawl-new` の1周時間が大幅に短縮される。古いコンテスト(abc308/358/410 含む)への提出も現実的な周期で拾われるようになる。レート制限/一時障害に対するリトライ耐性は維持。

## 確認

- `cargo build --bin crawl-submissions` パス
- `cargo clippy -p crawler --all-targets -- -D warnings` / `cargo clippy --bin crawl-submissions -- -D warnings` パス

(関連) #1518
(関連) #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**注記:** 当初 `Closes #1518 / #1520` としていたが、調査の結果これらの2コンテスト群(abc308/358/410=CodeQUEEN合同開催回)の未反映は **404ではなく「HTTP 200 だが提出一覧が空で返る(クローラ視点)」** という別原因と判明したため、このPRでは解消しない。本PRは404コンテストでの無駄なリトライ(最大~34分/件)を除去する一般的な高速化として独立して有効。#1518/#1520 は別途対応が必要。
