### PR TITLE
fix: リジャッジ権限のあるコンテストの提出がクロールされない問題を修正 (#1518, #1520)

### DIFF
--- a/atcoder-problems-backend/crawler/src/parser.rs
+++ b/atcoder-problems-backend/crawler/src/parser.rs
@@ -251,158 +251,124 @@ pub fn parse_submissions_html(html_content: &str) -> Result<Vec<Submission>, Cra
 
     let mut submissions = Vec::new();
 
-    for row in document.select(&row_selector) {
-        // Extract submission ID from the details link
-        let details_selector = Selector::parse("td:last-child a.submission-details-link")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let details_element = row.select(&details_selector).next();
+    let td_selector =
+        Selector::parse("td").map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
+    let input_selector =
+        Selector::parse("input").map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
+    let time_selector =
+        Selector::parse("time").map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
+    let a_selector =
+        Selector::parse("a").map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
+    let span_selector =
+        Selector::parse("span").map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
+    let details_selector = Selector::parse("a.submission-details-link")
+        .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
 
-        let id = if let Some(details_elem) = details_element {
-            if let Some(href) = details_elem.value().attr("href") {
-                // Extract ID from the URL (e.g., "/contests/abc399/submissions/64188418" -> "64188418")
-                href.split('/')
-                    .next_back()
-                    .unwrap_or("")
-                    .parse::<i64>()
-                    .map_err(|e| {
-                        CrawlerError::ParseError(format!("Failed to parse submission ID: {}", e))
-                    })?
-            } else {
-                continue; // Skip if no URL is found
-            }
-        } else {
-            continue; // Skip if no details link is found
+    for row in document.select(&row_selector) {
+        let tds = row.select(&td_selector).collect::<Vec<_>>();
+
+        // Contests where the crawler's account has rejudge privileges (e.g. an ABC
+        // held jointly with another contest the account staffs) render an extra
+        // leading checkbox column, shifting every other column right by one.
+        // Detect that column so the offsets below stay correct.
+        let offset = match tds.first() {
+            Some(first) if first.select(&input_selector).next().is_some() => 1,
+            _ => 0,
         };
 
-        // Extract submission date
-        let date_selector = Selector::parse("td:first-child time")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let date_element = row.select(&date_selector).next();
+        // Columns after the offset: date, problem, user, language, score,
+        // code length, result, execution time.
+        if tds.len() < offset + 8 {
+            continue; // Not a submission row
+        }
 
-        let epoch_second = if let Some(date_elem) = date_element {
-            let date_str = date_elem.text().collect::<String>();
-            // Parse the date string (e.g., "2024-04-05 12:34:56+0900")
-            let datetime = DateTime::parse_from_str(&date_str, "%Y-%m-%d %H:%M:%S%z")
-                .map_err(|e| CrawlerError::ParseError(format!("Failed to parse date: {}", e)))?;
-            datetime.timestamp()
-        } else {
+        // Submission ID and detail URL come from the details link, located by
+        // class so it is independent of the column offset.
+        let Some(href) = row
+            .select(&details_selector)
+            .next()
+            .and_then(|e| e.value().attr("href"))
+        else {
+            continue; // Skip rows without a submission details link
+        };
+        // Extract ID from the URL (e.g. "/contests/abc399/submissions/64188418" -> "64188418")
+        let id = href
+            .split('/')
+            .next_back()
+            .unwrap_or("")
+            .parse::<i64>()
+            .map_err(|e| {
+                CrawlerError::ParseError(format!("Failed to parse submission ID: {}", e))
+            })?;
+        // Extract contest ID from the URL (e.g. "/contests/abc399/submissions/64188418" -> "abc399")
+        let contest_id = href.split('/').nth(2).unwrap_or("").to_string();
+
+        // Submission date
+        let Some(date_elem) = tds[offset].select(&time_selector).next() else {
             continue; // Skip if no date is found
         };
+        let date_str = date_elem.text().collect::<String>();
+        // Parse the date string (e.g. "2024-04-05 12:34:56+0900")
+        let epoch_second = DateTime::parse_from_str(date_str.trim(), "%Y-%m-%d %H:%M:%S%z")
+            .map_err(|e| CrawlerError::ParseError(format!("Failed to parse date: {}", e)))?
+            .timestamp();
 
-        // Extract problem
-        let problem_selector = Selector::parse("td:nth-child(2) a")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let problem_element = row.select(&problem_selector).next();
-
-        let problem = if let Some(problem_elem) = problem_element {
-            // Extract problem ID from the URL (e.g., "/contests/abc399/tasks/abc399_a" -> "abc399_a")
-            if let Some(href) = problem_elem.value().attr("href") {
-                href.split('/').next_back().unwrap_or("").to_string()
-            } else {
-                continue; // Skip if no URL is found
-            }
-        } else {
-            continue; // Skip if no problem is found
+        // Problem ID from the task link (e.g. "/contests/abc399/tasks/abc399_a" -> "abc399_a")
+        let problem = match tds[offset + 1]
+            .select(&a_selector)
+            .next()
+            .and_then(|a| a.value().attr("href"))
+        {
+            Some(href) => href.split('/').next_back().unwrap_or("").to_string(),
+            None => continue, // Skip if no problem is found
         };
 
-        // Extract user
-        let user_selector = Selector::parse("td:nth-child(3) a:first-child")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let user_element = row.select(&user_selector).next();
-
-        let user = if let Some(user_elem) = user_element {
-            if let Some(href) = user_elem.value().attr("href") {
-                // Extract user_id from the URL path like "/users/{user_id}"
-                href.split('/')
-                    .nth(2) // Get the third component after splitting (index 2)
-                    .unwrap_or("")
-                    .to_string()
-            } else {
-                continue; // Skip if no href is found
-            }
-        } else {
-            continue; // Skip if no user is found
+        // User ID from the first link in the cell (e.g. "/users/{user_id}")
+        let user = match tds[offset + 2]
+            .select(&a_selector)
+            .next()
+            .and_then(|a| a.value().attr("href"))
+        {
+            Some(href) => href.split('/').nth(2).unwrap_or("").to_string(),
+            None => continue, // Skip if no user is found
         };
 
-        // Extract language
-        let language_selector = Selector::parse("td:nth-child(4) a")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let language_element = row.select(&language_selector).next();
-
-        let language = if let Some(language_elem) = language_element {
-            language_elem.text().collect::<String>()
-        } else {
+        // Language
+        let Some(language_elem) = tds[offset + 3].select(&a_selector).next() else {
             continue; // Skip if no language is found
         };
+        let language = language_elem.text().collect::<String>();
 
-        // Extract score
-        let score_selector = Selector::parse("td:nth-child(5)")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let score_element = row.select(&score_selector).next();
+        // Score
+        let score = tds[offset + 4]
+            .text()
+            .collect::<String>()
+            .trim()
+            .parse::<f64>()
+            .map_err(|e| CrawlerError::ParseError(format!("Failed to parse score: {}", e)))?;
 
-        let score = if let Some(score_elem) = score_element {
-            score_elem
-                .text()
-                .collect::<String>()
-                .parse::<f64>()
-                .map_err(|e| CrawlerError::ParseError(format!("Failed to parse score: {}", e)))?
-        } else {
-            continue; // Skip if no score is found
-        };
-
-        // Extract code length
-        let code_length_selector = Selector::parse("td:nth-child(6)")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let code_length_element = row.select(&code_length_selector).next();
-
-        let code_length = if let Some(code_length_elem) = code_length_element {
-            let text = code_length_elem.text().collect::<String>();
-            // Remove " Byte" from the end and parse as u32
-            text.trim_end_matches(" Byte").parse().map_err(|e| {
+        // Code length (e.g. "656 Byte")
+        let code_length = tds[offset + 5]
+            .text()
+            .collect::<String>()
+            .trim()
+            .trim_end_matches(" Byte")
+            .parse()
+            .map_err(|e| {
                 CrawlerError::ParseError(format!("Failed to parse code length: {}", e))
-            })?
-        } else {
-            continue; // Skip if no code length is found
-        };
+            })?;
 
-        // Extract result
-        let result_selector = Selector::parse("td:nth-child(7) span")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let result_element = row.select(&result_selector).next();
-
-        let result = if let Some(result_elem) = result_element {
-            result_elem.text().collect::<String>()
-        } else {
+        // Result (e.g. "AC")
+        let Some(result_elem) = tds[offset + 6].select(&span_selector).next() else {
             continue; // Skip if no result is found
         };
+        let result = result_elem.text().collect::<String>();
 
-        // Extract execution time
-        let execution_time_selector = Selector::parse("td:nth-child(8)")
-            .map_err(|e| CrawlerError::SelectorError(e.to_string()))?;
-        let execution_time_element = row.select(&execution_time_selector).next();
-
-        let execution_time = execution_time_element.and_then(|e| {
-            let text = e.text().collect::<String>();
-            text.trim_end_matches(" ms").parse::<i32>().ok()
-        });
-
-        // Get the URL from the details link
-        let url = if let Some(details_elem) = details_element {
-            if let Some(href) = details_elem.value().attr("href") {
-                href.to_string()
-            } else {
-                continue; // Skip if no URL is found
-            }
-        } else {
-            continue; // Skip if no details link is found
+        // Execution time (e.g. "479 ms"); absent for some results
+        let execution_time = {
+            let text = tds[offset + 7].text().collect::<String>();
+            text.trim().trim_end_matches(" ms").parse::<i32>().ok()
         };
-
-        // Extract contest ID from the URL (e.g., "/contests/abc399/submissions/64188418" -> "abc399")
-        let contest_id = url
-            .split('/')
-            .nth(2) // Get the third component after splitting
-            .unwrap_or("")
-            .to_string();
 
         submissions.push(Submission {
             id,

--- a/atcoder-problems-backend/crawler/tests/assets/submissions_rejudge.html
+++ b/atcoder-problems-backend/crawler/tests/assets/submissions_rejudge.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<!-- Snapshot of /contests/abc308/submissions as seen by an account with rejudge
+     privileges: the leading <input type="checkbox"> rejudge column shifts every
+     other column right by one. Captured 2026-06-14, table only (no csrf/session). -->
+<table class="table table-bordered table-striped small th-center">
+				<thead>
+				<tr>
+					<th width="1%"><input id="rejudge-checkall" type="checkbox"></th>
+					<th width="12%"><a href="/contests/abc308/submissions?desc=true&amp;orderBy=created">Submission Time</a></th>
+					<th>Task</th>
+					<th>User</th>
+					<th>Language</th>
+					<th width="5%"><a href="/contests/abc308/submissions?desc=true&amp;orderBy=score">Score</a></th>
+					<th width="9%"><a href="/contests/abc308/submissions?orderBy=source_length">Code Size</a></th>
+					<th width="5%">Status</th>
+					<th width="7%"><a href="/contests/abc308/submissions?orderBy=time_consumption">Exec Time</a></th>
+					<th width="8%"><a href="/contests/abc308/submissions?orderBy=memory_consumption">Memory</a></th>
+					<th width="5%"></th>
+				</tr>
+				</thead>
+				<tbody>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76670520"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-14 00:00:30+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_h">Ex - Make Q</a></td>
+						<td><a href="/users/osakanishi">osakanishi</a> <a href='/contests/abc308/submissions?f.User=osakanishi'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view osakanishi's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6083">Python (PyPy 3.11-v7.3.20)</a></td>
+						<td class="text-right submission-score" data-id="76670520">625</td>
+						<td class="text-right">2810 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>1587 ms</td><td class='text-right'>111904 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76670520" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76670513"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-14 00:00:03+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_h">Ex - Make Q</a></td>
+						<td><a href="/users/osakanishi">osakanishi</a> <a href='/contests/abc308/submissions?f.User=osakanishi'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view osakanishi's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6082">Python (CPython 3.13.7)</a></td>
+						<td class="text-right submission-score" data-id="76670513">0</td>
+						<td class="text-right">2810 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Time Limit Exceeded">TLE</span></td><td class='text-right'>> 4000 ms</td><td class='text-right'>11396 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76670513" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76668421"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 23:02:30+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/yuusya78">yuusya78</a> <a href='/contests/abc308/submissions?f.User=yuusya78'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view yuusya78's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6082">Python (CPython 3.13.7)</a></td>
+						<td class="text-right submission-score" data-id="76668421">0</td>
+						<td class="text-right">203 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Wrong Answer">WA</span></td><td class='text-right'>406 ms</td><td class='text-right'>64876 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76668421" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76613202"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 20:35:12+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_e">E - MEX</a></td>
+						<td><a href="/users/restofwaterimp">restofwaterimp</a> <a href='/contests/abc308/submissions?f.User=restofwaterimp'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view restofwaterimp's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6015">C# 13.0 (.NET 9.0.8)</a></td>
+						<td class="text-right submission-score" data-id="76613202">0</td>
+						<td class="text-right">2799 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Time Limit Exceeded">TLE</span></td><td class='text-right'>> 2000 ms</td><td class='text-right'>> 1048576 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76613202" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76612330"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 19:38:45+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/Ryotaro45123">Ryotaro45123</a> <a href='/contests/abc308/submissions?f.User=Ryotaro45123'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view Ryotaro45123's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6083">Python (PyPy 3.11-v7.3.20)</a></td>
+						<td class="text-right submission-score" data-id="76612330">200</td>
+						<td class="text-right">631 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>55 ms</td><td class='text-right'>80128 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76612330" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76609491"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 16:45:54+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/okku_n9">okku_n9</a> <a href='/contests/abc308/submissions?f.User=okku_n9'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view okku_n9's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76609491">300</td>
+						<td class="text-right">883 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>120 ms</td><td class='text-right'>9724 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76609491" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76609405"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 16:40:33+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/okku_n9">okku_n9</a> <a href='/contests/abc308/submissions?f.User=okku_n9'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view okku_n9's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76609405">0</td>
+						<td class="text-right">891 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Wrong Answer">WA</span></td><td class='text-right'>129 ms</td><td class='text-right'>9640 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76609405" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76609082"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 16:20:28+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_f">F - Vouchers</a></td>
+						<td><a href="/users/tatami_">tatami_</a> <a href='/contests/abc308/submissions?f.User=tatami_'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view tatami_'s submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6088">Rust (rustc 1.89.0)</a></td>
+						<td class="text-right submission-score" data-id="76609082">500</td>
+						<td class="text-right">1923 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>73 ms</td><td class='text-right'>40488 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76609082" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76608978"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 16:13:45+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_f">F - Vouchers</a></td>
+						<td><a href="/users/jim1424">jim1424</a> <a href='/contests/abc308/submissions?f.User=jim1424'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view jim1424's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76608978">500</td>
+						<td class="text-right">2557 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>292 ms</td><td class='text-right'>20260 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76608978" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607721"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:55:04+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/vjudge1">vjudge1</a> <a href='/contests/abc308/submissions?f.User=vjudge1'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view vjudge1's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6116">C&#43;&#43;23 (Clang 21.1.0)</a></td>
+						<td class="text-right submission-score" data-id="76607721">0</td>
+						<td class="text-right">498 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Runtime Error">RE</span></td><td class='text-right'>102 ms</td><td class='text-right'>2956 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607721" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607719"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:54:51+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_d">D - Snuke Maze</a></td>
+						<td><a href="/users/restofwaterimp">restofwaterimp</a> <a href='/contests/abc308/submissions?f.User=restofwaterimp'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view restofwaterimp's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6015">C# 13.0 (.NET 9.0.8)</a></td>
+						<td class="text-right submission-score" data-id="76607719">400</td>
+						<td class="text-right">3483 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>50 ms</td><td class='text-right'>30176 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607719" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607687"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:52:08+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/zhouhongyi">zhouhongyi</a> <a href='/contests/abc308/submissions?f.User=zhouhongyi'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view zhouhongyi's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6116">C&#43;&#43;23 (Clang 21.1.0)</a></td>
+						<td class="text-right submission-score" data-id="76607687">0</td>
+						<td class="text-right">498 Byte</td>
+						<td colspan='3' class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Compilation Error">CE</span></td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607687" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607663"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:49:57+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/vjudge1">vjudge1</a> <a href='/contests/abc308/submissions?f.User=vjudge1'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view vjudge1's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6054">C&#43;&#43; IOI-Style(GNU&#43;&#43;20) (GCC 14.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76607663">0</td>
+						<td class="text-right">627 Byte</td>
+						<td colspan='3' class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Compilation Error">CE</span></td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607663" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607573"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:44:05+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/vjudge1">vjudge1</a> <a href='/contests/abc308/submissions?f.User=vjudge1'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view vjudge1's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6054">C&#43;&#43; IOI-Style(GNU&#43;&#43;20) (GCC 14.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76607573">0</td>
+						<td class="text-right">483 Byte</td>
+						<td colspan='3' class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Compilation Error">CE</span></td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607573" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76607411"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 14:31:34+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_b">B - Default Price</a></td>
+						<td><a href="/users/mahuateng">mahuateng</a> <a href='/contests/abc308/submissions?f.User=mahuateng'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view mahuateng's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6054">C&#43;&#43; IOI-Style(GNU&#43;&#43;20) (GCC 14.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76607411">0</td>
+						<td class="text-right">257 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Wrong Answer">WA</span></td><td class='text-right'>0 ms</td><td class='text-right'>1704 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76607411" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76606644"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 13:22:10+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_e">E - MEX</a></td>
+						<td><a href="/users/jim1424">jim1424</a> <a href='/contests/abc308/submissions?f.User=jim1424'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view jim1424's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76606644">475</td>
+						<td class="text-right">2686 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>65 ms</td><td class='text-right'>79632 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76606644" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76606373"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 12:54:02+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_d">D - Snuke Maze</a></td>
+						<td><a href="/users/jim1424">jim1424</a> <a href='/contests/abc308/submissions?f.User=jim1424'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view jim1424's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76606373">400</td>
+						<td class="text-right">2773 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>16 ms</td><td class='text-right'>14304 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76606373" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76604864"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 10:52:04+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/jim1424">jim1424</a> <a href='/contests/abc308/submissions?f.User=jim1424'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view jim1424's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6017">C&#43;&#43;23 (GCC 15.2.0)</a></td>
+						<td class="text-right submission-score" data-id="76604864">300</td>
+						<td class="text-right">2334 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>133 ms</td><td class='text-right'>8236 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76604864" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76603426"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 06:41:41+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/restofwaterimp">restofwaterimp</a> <a href='/contests/abc308/submissions?f.User=restofwaterimp'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view restofwaterimp's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6015">C# 13.0 (.NET 9.0.8)</a></td>
+						<td class="text-right submission-score" data-id="76603426">300</td>
+						<td class="text-right">1429 Byte</td>
+						<td class='text-center'><span class='label label-success' data-toggle='tooltip' data-placement='top' title="Accepted">AC</span></td><td class='text-right'>246 ms</td><td class='text-right'>41656 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76603426" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+					<tr>
+						<td><input type="checkbox" form="rejudge-form" name="submission_ids[]" value="76603243"></td>
+						<td class="no-break"><time class='fixtime fixtime-second'>2026-06-13 05:41:57+0900</time></td>
+						<td><a href="/contests/abc308/tasks/abc308_c">C - Standings</a></td>
+						<td><a href="/users/restofwaterimp">restofwaterimp</a> <a href='/contests/abc308/submissions?f.User=restofwaterimp'><span class='glyphicon glyphicon-search black' aria-hidden='true' data-toggle='tooltip' title='view restofwaterimp's submissions'></span></a></td>
+						<td><a href="/contests/abc308/submissions?f.Language=6015">C# 13.0 (.NET 9.0.8)</a></td>
+						<td class="text-right submission-score" data-id="76603243">0</td>
+						<td class="text-right">1484 Byte</td>
+						<td class='text-center'><span class='label label-warning' data-toggle='tooltip' data-placement='top' title="Wrong Answer">WA</span></td><td class='text-right'>161 ms</td><td class='text-right'>45512 KiB</td>
+						<td class="text-center">
+							<a href="/contests/abc308/submissions/76603243" class="submission-details-link">Detail</a>
+						</td>
+					</tr>
+				
+				</tbody>
+			</table>
+</body></html>

--- a/atcoder-problems-backend/crawler/tests/test_parser.rs
+++ b/atcoder-problems-backend/crawler/tests/test_parser.rs
@@ -141,6 +141,50 @@ fn test_parse_submissions_html() {
 }
 
 #[test]
+fn test_parse_submissions_html_with_rejudge_column() {
+    // Contests the crawler account can rejudge (e.g. abc308, held jointly with a
+    // CodeQUEEN qualifier) render an extra leading checkbox column that shifts
+    // every other column. The parser must still extract every submission.
+    let html_content = include_str!("assets/submissions_rejudge.html");
+
+    let submissions =
+        parse_submissions_html(html_content).expect("Failed to parse submissions HTML");
+
+    assert_eq!(
+        submissions.len(),
+        20,
+        "Expected 20 submissions, found {}",
+        submissions.len()
+    );
+
+    let first = &submissions[0];
+    assert_eq!(first.id, 76670520);
+    assert_eq!(first.contest_id, "abc308");
+    assert_eq!(first.problem_id, "abc308_h");
+    assert_eq!(first.user, "osakanishi");
+    assert_eq!(first.language, "Python (PyPy 3.11-v7.3.20)");
+    assert_eq!(first.score, 625.);
+    assert_eq!(first.code_length, 2810);
+    assert_eq!(first.result, "AC");
+
+    let last = &submissions[19];
+    assert_eq!(last.id, 76603243);
+    assert_eq!(last.problem_id, "abc308_c");
+    assert_eq!(last.user, "restofwaterimp");
+    assert_eq!(last.result, "WA");
+
+    for submission in &submissions {
+        assert!(submission.id > 0);
+        assert!(submission.epoch_second > 0);
+        assert_eq!(submission.contest_id, "abc308");
+        assert!(!submission.problem_id.is_empty());
+        assert!(!submission.user.is_empty());
+        assert!(!submission.language.is_empty());
+        assert!(!submission.result.is_empty());
+    }
+}
+
+#[test]
 fn test_parse_tasks_html_abc308() {
     // Load the test HTML file
     let html_content = include_str!("assets/tasks_abc308.html");


### PR DESCRIPTION
## 原因

abc308 / abc358 / abc410（CodeQUEEN 予選と合同開催された回）への AC が AtCoder Problems に反映されない、という報告(#1518 / #1520)を調査した。本番(AWS ECS/CloudWatch)のログとクローラ視点での実ページ取得により、**パーサのバグ**であることが判明した。

これらのコンテストはクローラのアカウントが**リジャッジ権限**を持っているため、提出一覧の各行の**先頭にリジャッジ用チェックボックス列が1つ追加**され、以降の列がすべて右に1つずれる：

| | 通常コンテスト (abc307) | 該当コンテスト (abc308 等) |
|---|---|---|
| 列数 | 10 | **11** |
| 先頭列 | `<time>`(提出日時) | `<input type="checkbox" form="rejudge-form">` |

`parse_submissions_html` は `td:first-child time` や `td:nth-child(N)` と**位置依存**で各列を取得していたため、ずれた行で `<time>` 等が `None` となり**全行スキップ → 提出0件**としてパースしていた（`?` のパースエラーではなく `continue` のため、リトライもエラーログも出ず "No more submissions" になる）。

その結果、これらのコンテストの提出は一切 DB に取り込まれず（page1 を数分おきに巡回しているにもかかわらず常に0件判定）、AC が反映されなかった。「2026-01以降」なのは新クローラ移行時期と一致する。

## 変更

- `parse_submissions_html`:
  - 行先頭のチェックボックス列の有無を検出して**オフセットを吸収**
  - 提出詳細リンクは位置ではなく**クラス `a.submission-details-link`** で特定
  - 列は td のオフセット相対で取得（通常コンテストは offset=0 で従来どおり）
- 回帰テスト追加：abc308 の提出一覧（管理者ビュー＝チェックボックス列あり）のスナップショットを `tests/assets/submissions_rejudge.html` として追加し、20件正しくパースできることを検証。秘密情報が混ざらないよう提出テーブル部分のみ抽出。

## 確認

- `cargo test -p crawler --test test_parser` … 8 tests pass（通常レイアウトの既存テスト + 新規 rejudge レイアウトテスト）
- `cargo clippy -p crawler --all-targets -- -D warnings` … pass

※ 別PR #1531（404即スキップ）とは独立。あちらはクロール高速化、本PRが #1518/#1520 の実際の修正。

Closes #1518
Closes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)