### PR TITLE
Convert the ADT page into a table

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -130,6 +130,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
         "ARC",
         "AGC",
         "AWC",
+        "ADT",
         "ABC-Like",
         "ARC-Like",
         "AGC-Like",
@@ -149,25 +150,12 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "AtCoder Grand Contest"
               : activeTab === "AWC"
               ? "AtCoder Weekday Contest"
+              : activeTab === "ADT"
+              ? "AtCoder Daily Training"
               : activeTab === "PAST"
               ? "PAST"
               : `${activeTab} Contest`
           }
-          contestToProblems={contestToProblems}
-          statusLabelMap={statusLabelMap}
-          showPenalties={showPenalties}
-          selectedLanguages={selectedLanguages}
-          userRatingInfo={userRatingInfo}
-        />
-      ) : activeTab === "ADT" ? (
-        <AtCoderRegularTable
-          showDifficulty={showDifficulty}
-          hideCompletedContest={hideCompletedContest}
-          colorMode={colorMode}
-          contests={filteredContests.filter((contest) => {
-            return /^adt_(?!top$)/g.test(contest.id);
-          })}
-          title="AtCoder Daily Training"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
           showPenalties={showPenalties}

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -165,7 +165,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           hideCompletedContest={hideCompletedContest}
           colorMode={colorMode}
           contests={filteredContests.filter((contest) => {
-            return /^adt_all/g.test(contest.id);
+            return /^adt_(?!top$)/g.test(contest.id);
           })}
           title="AtCoder Daily Training"
           contestToProblems={contestToProblems}

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -159,6 +159,21 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           selectedLanguages={selectedLanguages}
           userRatingInfo={userRatingInfo}
         />
+      ) : activeTab === "ADT" ? (
+        <AtCoderRegularTable
+          showDifficulty={showDifficulty}
+          hideCompletedContest={hideCompletedContest}
+          colorMode={colorMode}
+          contests={filteredContests.filter((contest) => {
+            return /^adt_all/g.test(contest.id);
+          })}
+          title="AtCoder Daily Training"
+          contestToProblems={contestToProblems}
+          statusLabelMap={statusLabelMap}
+          showPenalties={showPenalties}
+          selectedLanguages={selectedLanguages}
+          userRatingInfo={userRatingInfo}
+        />
       ) : (
         <ContestTable
           showDifficulty={showDifficulty}

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -61,9 +61,7 @@ export const classifyContest = (
   if (/^awc\d{4}$/.exec(contest.id)) {
     return "AWC";
   }
-  if (
-    /^adt_/.exec(contest.id) &&
-    !["adt_top"].includes(contest.id)) {
+  if (/^adt_/.exec(contest.id) && !["adt_top"].includes(contest.id)) {
     return "ADT";
   }
   if (

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -61,7 +61,9 @@ export const classifyContest = (
   if (/^awc\d{4}$/.exec(contest.id)) {
     return "AWC";
   }
-  if (/^adt_/.exec(contest.id)) {
+  if (
+    /^adt_/.exec(contest.id) &&
+    !["adt_top"].includes(contest.id)) {
     return "ADT";
   }
   if (


### PR DESCRIPTION
fix #1537 
AtCoder Daily Trainingのページを、AtCoder Beginner Contestなどと同じテーブル形式に置き換えました。
<img width="1710" height="942" alt="スクリーンショット 2026-06-15 20 21 31" src="https://github.com/user-attachments/assets/a35b0776-9a05-42a3-a30a-ec22194f2638" />


