### PR TITLE
Fix list points to display as integers instead of decimals

### DIFF
--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -356,7 +356,7 @@ export const ListTable: React.FC<Props> = (props) => {
         if (point >= INF_POINT) {
           return <p>-</p>;
         } else {
-          if (point % 100 === 0) {
+          if (point % 1 === 0) {
             return <p>{point}</p>;
           } else {
             return <p>{point.toFixed(2)}</p>;

--- a/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
+++ b/atcoder-problems-frontend/src/pages/ListPage/ListTable.tsx
@@ -356,11 +356,7 @@ export const ListTable: React.FC<Props> = (props) => {
         if (point >= INF_POINT) {
           return <p>-</p>;
         } else {
-          if (point % 1 === 0) {
-            return <p>{point}</p>;
-          } else {
-            return <p>{point.toFixed(2)}</p>;
-          }
+          return <p>{point}</p>;
         }
       },
     },


### PR DESCRIPTION
fix #1543
もともとlist欄はpointが100の倍数でないと.00が数字の後についてしまっていたため、1の倍数でないときのみ表示するようにした
<img width="1563" height="86" alt="スクリーンショット 2026-06-15 20 39 09" src="https://github.com/user-attachments/assets/6c1b9f2f-167a-42ab-82e3-a35c86260db8" />
<img width="1551" height="405" alt="スクリーンショット 2026-06-15 20 39 31" src="https://github.com/user-attachments/assets/358bbc95-b5bd-4a9e-8028-fec9150ab515" />
