### PR TITLE
ADT ページのテーブル化 + adt_top の非表示

### DIFF
--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -130,6 +130,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
         "ARC",
         "AGC",
         "AWC",
+        "ADT",
         "ABC-Like",
         "ARC-Like",
         "AGC-Like",
@@ -149,25 +150,12 @@ export const TablePage: React.FC<OuterProps> = (props) => {
               ? "AtCoder Grand Contest"
               : activeTab === "AWC"
               ? "AtCoder Weekday Contest"
+              : activeTab === "ADT"
+              ? "AtCoder Daily Training"
               : activeTab === "PAST"
               ? "PAST"
               : `${activeTab} Contest`
           }
-          contestToProblems={contestToProblems}
-          statusLabelMap={statusLabelMap}
-          showPenalties={showPenalties}
-          selectedLanguages={selectedLanguages}
-          userRatingInfo={userRatingInfo}
-        />
-      ) : activeTab === "ADT" ? (
-        <AtCoderRegularTable
-          showDifficulty={showDifficulty}
-          hideCompletedContest={hideCompletedContest}
-          colorMode={colorMode}
-          contests={filteredContests.filter((contest) => {
-            return /^adt_(?!top$)/g.test(contest.id);
-          })}
-          title="AtCoder Daily Training"
           contestToProblems={contestToProblems}
           statusLabelMap={statusLabelMap}
           showPenalties={showPenalties}

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -20,6 +20,7 @@ import { loggedInUserId } from "../../utils/UserState";
 import {
   classifyContest,
   ContestCategory,
+  isHiddenContest,
 } from "../../utils/ContestClassifier";
 import { getLikeContestCategory } from "../../utils/LikeContestUtils";
 import { TableTabButtons } from "./TableTab";
@@ -87,6 +88,9 @@ export const TablePage: React.FC<OuterProps> = (props) => {
       return [];
     }
     return contests.filter((contest) => {
+      if (isHiddenContest(contest)) {
+        return false;
+      }
       const contestType = classifyContest(contest);
       if (contestType === activeTab) {
         return true;

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -165,7 +165,7 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           hideCompletedContest={hideCompletedContest}
           colorMode={colorMode}
           contests={filteredContests.filter((contest) => {
-            return /^adt_all/g.test(contest.id);
+            return /^adt_(?!top$)/g.test(contest.id);
           })}
           title="AtCoder Daily Training"
           contestToProblems={contestToProblems}

--- a/atcoder-problems-frontend/src/pages/TablePage/index.tsx
+++ b/atcoder-problems-frontend/src/pages/TablePage/index.tsx
@@ -159,6 +159,21 @@ export const TablePage: React.FC<OuterProps> = (props) => {
           selectedLanguages={selectedLanguages}
           userRatingInfo={userRatingInfo}
         />
+      ) : activeTab === "ADT" ? (
+        <AtCoderRegularTable
+          showDifficulty={showDifficulty}
+          hideCompletedContest={hideCompletedContest}
+          colorMode={colorMode}
+          contests={filteredContests.filter((contest) => {
+            return /^adt_all/g.test(contest.id);
+          })}
+          title="AtCoder Daily Training"
+          contestToProblems={contestToProblems}
+          statusLabelMap={statusLabelMap}
+          showPenalties={showPenalties}
+          selectedLanguages={selectedLanguages}
+          userRatingInfo={userRatingInfo}
+        />
       ) : (
         <ContestTable
           showDifficulty={showDifficulty}

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.test.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.test.ts
@@ -2,6 +2,7 @@ import Contest from "../interfaces/Contest";
 import {
   isRatedContest,
   classifyContest,
+  isHiddenContest,
   ContestCategory,
 } from "./ContestClassifier";
 
@@ -63,6 +64,17 @@ describe("test function classifyContest", () => {
     expect(classifyContest(adtContest)).toBe("ADT" as ContestCategory);
   });
 
+  it("when adt_top is not classified as ADT", () => {
+    const adtTopContest: Contest = {
+      duration_second: 0,
+      id: "adt_top",
+      rate_change: "-",
+      start_epoch_second: 0,
+      title: "AtCoder Daily Training",
+    };
+    expect(classifyContest(adtTopContest)).not.toBe("ADT" as ContestCategory);
+  });
+
   it("when ABC-like", () => {
     const abcLikeContest: Contest = {
       duration_second: 6000,
@@ -98,5 +110,29 @@ describe("test function classifyContest", () => {
     expect(classifyContest(otherContest)).toBe(
       "Other Contests" as ContestCategory
     );
+  });
+});
+
+describe("test function isHiddenContest", () => {
+  it("when adt_top is hidden", () => {
+    const adtTopContest: Contest = {
+      duration_second: 0,
+      id: "adt_top",
+      rate_change: "-",
+      start_epoch_second: 0,
+      title: "AtCoder Daily Training",
+    };
+    expect(isHiddenContest(adtTopContest)).toBe(true);
+  });
+
+  it("when a normal ADT contest is not hidden", () => {
+    const adtContest: Contest = {
+      duration_second: 6000,
+      id: "adt_all_20260612_2",
+      rate_change: "-",
+      start_epoch_second: 1781260800,
+      title: "AtCoder Daily Training 2026/06/12 All",
+    };
+    expect(isHiddenContest(adtContest)).toBe(false);
   });
 });

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -61,9 +61,7 @@ export const classifyContest = (
   if (/^awc\d{4}$/.exec(contest.id)) {
     return "AWC";
   }
-  if (
-    /^adt_/.exec(contest.id) &&
-    !["adt_top"].includes(contest.id)) {
+  if (/^adt_/.exec(contest.id) && !["adt_top"].includes(contest.id)) {
     return "ADT";
   }
   if (

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -61,7 +61,9 @@ export const classifyContest = (
   if (/^awc\d{4}$/.exec(contest.id)) {
     return "AWC";
   }
-  if (/^adt_/.exec(contest.id)) {
+  if (
+    /^adt_/.exec(contest.id) &&
+    !["adt_top"].includes(contest.id)) {
     return "ADT";
   }
   if (

--- a/atcoder-problems-frontend/src/utils/ContestClassifier.ts
+++ b/atcoder-problems-frontend/src/utils/ContestClassifier.ts
@@ -22,6 +22,11 @@ export type ContestCategory = typeof ContestCategories[number];
 
 export const AGC_001_START = 1468670400;
 
+// `adt_top` is the ADT top page, not an actual daily training round, so it
+// should be hidden from contest listings.
+export const isHiddenContest = (contest: Contest): boolean =>
+  contest.id === "adt_top";
+
 export const isRatedContest = (
   contest: Contest,
   problemCount: number
@@ -61,7 +66,7 @@ export const classifyContest = (
   if (/^awc\d{4}$/.exec(contest.id)) {
     return "AWC";
   }
-  if (/^adt_/.exec(contest.id) && !["adt_top"].includes(contest.id)) {
+  if (/^adt_/.exec(contest.id) && !isHiddenContest(contest)) {
     return "ADT";
   }
   if (


### PR DESCRIPTION
## 概要

#1547 (ADT ページのテーブル化) をベースに、レビュー指摘を反映したものです。

## #1547 からの追加変更

#1547 では `adt_top` を ADT 分類から除外していましたが、フォールスルーして「Other Contests」に分類され、そちらのタブに表示されてしまう状態でした。`adt_top` は ADT のトップページであり実際のコンテストではないため、どのタブにも表示されないように完全に非表示化します。

- `ContestClassifier` に `isHiddenContest` を追加し、`adt_top` の判定を分類ロジックと一覧フィルタの両方で一元化
- `TablePage` の `filteredContests` で `isHiddenContest` のコンテストを除外
- `classifyContest` / `isHiddenContest` のユニットテストを追加

## 確認

- `pnpm test`（ContestClassifier）: 全 11 件 pass
- `pnpm run lint`: エラーなし
- `tsc --noEmit`: 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)