### PR TITLE
問題情報がADTに上書きされないようにする

### DIFF
--- a/atcoder-problems-backend/src/crawler_utils.rs
+++ b/atcoder-problems-backend/src/crawler_utils.rs
@@ -253,19 +253,25 @@ async fn upsert_problems(
             name: Set(problem.name.clone()),
             title: Set(title),
         };
-        sql_entities::problems::Entity::insert(model)
-            .on_conflict(
-                OnConflict::column(sql_entities::problems::Column::Id)
-                    .update_columns([
-                        sql_entities::problems::Column::ContestId,
-                        sql_entities::problems::Column::ProblemIndex,
-                        sql_entities::problems::Column::Name,
-                        sql_entities::problems::Column::Title,
-                    ])
-                    .to_owned(),
-            )
-            .exec(db)
-            .await?;
+
+        // ADTの問題は全てABCで既出であり、これらは同一視したい。
+        // そのまま通すと問題情報がABCからADTに上書きされてしまうので、ADTの問題はproblemsには入れないようにする。
+        // （ただしcontest_problemには入れる）
+        if !problem.contest_id.starts_with("adt") {
+            sql_entities::problems::Entity::insert(model)
+                .on_conflict(
+                    OnConflict::column(sql_entities::problems::Column::Id)
+                        .update_columns([
+                            sql_entities::problems::Column::ContestId,
+                            sql_entities::problems::Column::ProblemIndex,
+                            sql_entities::problems::Column::Name,
+                            sql_entities::problems::Column::Title,
+                        ])
+                        .to_owned(),
+                )
+                .exec(db)
+                .await?;
+        }
 
         // Insert into contest_problem table
         let contest_problem = sql_entities::contest_problem::ActiveModel {

--- a/atcoder-problems-backend/tests/test_crawler_utils.rs
+++ b/atcoder-problems-backend/tests/test_crawler_utils.rs
@@ -402,3 +402,93 @@ async fn test_crawl_contests_fetches_filtered_archive_categories() {
             .any(|contest| contest.id == "adt_all_20260612_2")
     );
 }
+
+#[tokio::test]
+async fn test_crawl_adt_problems() {
+    let db = setup_db().await.unwrap();
+
+    // 1. ABCのコンテスト、問題がクロールされる
+    sql_entities::contests::Entity::insert(sql_entities::contests::ActiveModel {
+        id: Set("abc001".to_string()),
+        start_epoch_second: Set(0),
+        duration_second: Set(0),
+        title: Set("AtCoder Beginner Contest 001".to_string()),
+        rate_change: Set("?".to_string()),
+    })
+    .exec(&db)
+    .await
+    .unwrap();
+
+    let mut abc_fetcher = MockProblemFetcher::new();
+    abc_fetcher
+        .expect_fetch_problems()
+        .withf(|contest_id| contest_id == "abc001")
+        .times(1)
+        .returning(|_| {
+            Ok(vec![Problem {
+                id: "abc001_a".to_string(),
+                contest_id: "abc001".to_string(),
+                problem_index: "A".to_string(),
+                name: "Problem A".to_string(),
+            }])
+        });
+
+    atcoder_problems_backend::crawler_utils::crawl_problems(&abc_fetcher, &db)
+        .await
+        .unwrap();
+
+    // 2. 次に、ADTのコンテスト、問題がクロールされる
+    sql_entities::contests::Entity::insert(sql_entities::contests::ActiveModel {
+        id: Set("adt_all_20260612".to_string()),
+        start_epoch_second: Set(0),
+        duration_second: Set(0),
+        title: Set("AtCoder Daily Training 2026/06/12 All".to_string()),
+        rate_change: Set("-".to_string()),
+    })
+    .exec(&db)
+    .await
+    .unwrap();
+
+    let mut adt_fetcher = MockProblemFetcher::new();
+    adt_fetcher
+        .expect_fetch_problems()
+        .withf(|contest_id| contest_id == "adt_all_20260612")
+        .times(1)
+        .returning(|_| {
+            Ok(vec![Problem {
+                id: "abc001_a".to_string(),
+                contest_id: "adt_all_20260612".to_string(),
+                problem_index: "C".to_string(),
+                name: "Problem C".to_string(),
+            }])
+        });
+
+    atcoder_problems_backend::crawler_utils::crawl_problems(&adt_fetcher, &db)
+        .await
+        .unwrap();
+
+    // 3. abc001_aがabc001とadt_all_20260612の両方に紐づいていることを確認する
+    let problems_after_adt = sql_entities::problems::Entity::find()
+        .all(&db)
+        .await
+        .unwrap();
+    assert_eq!(problems_after_adt.len(), 1);
+    assert_eq!(problems_after_adt[0].id, "abc001_a");
+    assert_eq!(problems_after_adt[0].contest_id, "abc001");
+
+    let contest_problems = sql_entities::contest_problem::Entity::find()
+        .all(&db)
+        .await
+        .unwrap();
+    assert_eq!(contest_problems.len(), 2);
+    assert!(contest_problems.iter().any(|cp| cp.contest_id == "abc001"
+        && cp.problem_id == "abc001_a"
+        && cp.problem_index == "A"));
+    assert!(
+        contest_problems
+            .iter()
+            .any(|cp| cp.contest_id == "adt_all_20260612"
+                && cp.problem_id == "abc001_a"
+                && cp.problem_index == "C")
+    );
+}


### PR DESCRIPTION
fix #1551 fix #1552

元々、クロールした問題情報をデータベースに入れる処理において、既に同じIDの問題が存在する場合は、新しい方の情報で上書きするという処理になっていました。ADTでは、URLのうち問題IDに使われる部分が出典のABCと全く同じ（例: https://atcoder.jp/contests/adt_all_20260617_2/tasks/abc396_a ）なので、上書き処理が発動したのだと考えます。

https://github.com/kenkoooo/AtCoderProblems/blob/b57d591d43de8d5408b60d45a5e0990c0114478f/atcoder-problems-backend/src/crawler_utils.rs#L247-L268

PRでは、`contest_id`が`adt`で始まる問題はproblemテーブルへの挿入処理をスキップするようにして対処しています。

この変更で上書きは止まるとは思うんですが、既に上書きされた問題はそのままになるので、それについては別途対処が必要です...。丁寧に書き換えるか、一回ABCの問題データを全部吹き飛ばして再クロールするか...
