### PR TITLE
Fix pie chart vertical whitespace on narrow screens

### DIFF
--- a/atcoder-problems-frontend/src/components/SinglePieChart.tsx
+++ b/atcoder-problems-frontend/src/components/SinglePieChart.tsx
@@ -75,7 +75,7 @@ export const SinglePieChart: React.FC<Props> = ({ data, hideLegend }) => {
 
   return (
     <div>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" aspect={1} maxHeight={300}>
         <PieChart>
           <Pie
             activeIndex={activeIndex}


### PR DESCRIPTION
Make the pie chart height responsive on narrow screens.

Fixes #1554