### PR TITLE
fix: max_streaksの二重タイムゾーン変換によるストリーク計算バグを修正

### DIFF
--- a/dbt/models/marts/max_streaks.sql
+++ b/dbt/models/marts/max_streaks.sql
@@ -15,7 +15,7 @@ daily_solves as (
     -- Convert to JST date (epoch + 9 hours, then truncate to day)
     select distinct
         user_id,
-        (to_timestamp(first_ac_epoch) at time zone 'UTC' at time zone 'Asia/Tokyo')::date as solve_date
+        (to_timestamp(first_ac_epoch) at time zone 'Asia/Tokyo')::date as solve_date
     from first_ac_per_problem
 ),
 


### PR DESCRIPTION
## Summary
- `dbt/models/marts/max_streaks.sql` で `AT TIME ZONE 'UTC'` → `AT TIME ZONE 'Asia/Tokyo'` と2回連鎖させていたため、意図した「UTC+9時間」ではなく実質「UTC-9時間」の変換になっていた
- 具体的には、UTC 9-15時台(JSTの18-24時、コンテスト開催時間帯)の提出だけ偶然正しい日付になり、それ以外の時間帯(日中の精進や早朝の提出)は `solve_date` が1日ずれ、本来連続しているストリークが `streak_groups` の判定(前日との差が1日超なら切る)で誤って途切れていた
- Fixes #1549 (Streak Ranking が更新されない)

## Root cause
`timestamptz AT TIME ZONE 'UTC'` で一度naiveな`timestamp`に変換した後、それを再度 `AT TIME ZONE 'Asia/Tokyo'` すると、Postgresはその値を「JSTの時刻表記」として再解釈し、そこから9時間引いてUTCに変換する。単純に `to_timestamp(epoch) AT TIME ZONE 'Asia/Tokyo'` と1回だけ変換すれば正しくJSTのwall-clock(naive timestamp)が得られ、`::date` も後続のセッションタイムゾーンに依存せず一意に決まる。

## Verification
- CloudWatch Logsで過去30日分の `atcoder-problems-2025-dbt` スケジュールタスクの実行ログを確認し、2時間おきに実行され毎回 `ERROR=0` で成功していることを確認済み(dbtが実行されていない/失敗しているわけではなく、ロジックの誤りが原因と特定)
- Postgresの `AT TIME ZONE` の変換規則(timestamptz→timestampとtimestamp→timestamptzで意味が逆になる)を手動でトレースし、UTC時刻帯ごとに正しい日付とバグの日付がずれることを確認
- `max_streaks` は `materialized='table'` で毎回全量再作成されるため、本番データへの追加のバックフィル作業は不要。次回のスケジュール実行(2時間おき)で自動的に正しい値に再計算される

## Test plan
- [ ] `docker compose run --rm dbt build` をローカルで実行し、`max_streaks` モデルが正常にビルドされ既存のテスト(`unique`/`not_null` on `user_id`)が通ることを確認
- [ ] マージ後、次回の本番dbtスケジュール実行後に `max_streaks` テーブルの値が更新され、Streak Rankingに正しい順位が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rK811gLsFrY6BiaZYYUW7